### PR TITLE
fix: use env vars for admin credentials (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,22 @@ npm run dev
 
 ## Default Credentials
 
-After running migrations:
-- **Username:** `admin`
-- **Password:** `admin123`
+After running migrations, the admin username and password are set via environment variables:
+- **Username:** `admin` (or set `ADMIN_USERNAME` before migration)
+- **Password:** Set via `ADMIN_PASSWORD` environment variable before migration
 - **Role:** Admin
 
-⚠️ **Change this password immediately in production!**
+⚠️ **Set secure values for `ADMIN_USERNAME` and `ADMIN_PASSWORD` before running migrations in production!**
+
+To set admin credentials:
+```bash
+# In your .env file or environment
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=your-secure-password
+
+# Then run migrations
+npm run migrate
+```
 
 ## API Endpoints
 
@@ -207,6 +217,8 @@ npm test -- auth.spec.js
 | `DB_NAME` | Database name | `gap_db` |
 | `DB_USER` | Database user | `gap_user` |
 | `DB_PASSWORD` | Database password | (required) |
+| `ADMIN_USERNAME` | Initial admin username | `admin` |
+| `ADMIN_PASSWORD` | Initial admin password (required for migration) | (required) |
 | `REGISTRATION_ENABLED` | Enable user registration | `true` |
 | `PORT` | Server port | `3001` |
 | `CORS_ORIGIN` | Allowed CORS origin | `http://localhost:3000` |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,3 +13,7 @@ DB_PASSWORD=change_this_password_in_production
 REGISTRATION_ENABLED=true
 NODE_ENV=development
 PORT=3001
+
+# Admin Credentials (for initial migration)
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change_this_in_production

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "@fastify/cors": "^9.0.0",
     "@fastify/helmet": "^11.0.0",
     "@fastify/postgres": "^6.0.0",
+    "bcrypt": "^5.1.1",
     "fastify": "^4.25.0",
     "pg": "^8.11.0",
     "dotenv": "^16.3.0"

--- a/backend/src/db/migrate.js
+++ b/backend/src/db/migrate.js
@@ -1,9 +1,27 @@
 const { Pool } = require('pg');
+const bcrypt = require('bcrypt');
 const dbConfig = require('../config/database');
 
 const pool = new Pool(dbConfig);
 
-const migrationSQL = `
+async function generateMigrationSQL() {
+  // Read admin credentials from environment variables
+  const adminUsername = process.env.ADMIN_USERNAME || 'admin';
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  
+  // Fail migration if ADMIN_PASSWORD is not set
+  if (!adminPassword) {
+    console.error('ERROR: ADMIN_PASSWORD environment variable is not set.');
+    console.error('Please set ADMIN_PASSWORD in your environment or .env file.');
+    console.error('Example: ADMIN_PASSWORD=your-secure-password');
+    process.exit(1);
+  }
+  
+  // Generate bcrypt hash dynamically at migration time
+  const saltRounds = 10;
+  const passwordHash = await bcrypt.hash(adminPassword, saltRounds);
+  
+  return `
 -- Drop tables if they exist (for clean migration)
 DROP TABLE IF EXISTS users CASCADE;
 DROP TABLE IF EXISTS groups CASCADE;
@@ -50,13 +68,14 @@ CREATE INDEX idx_users_email ON users(email);
 CREATE INDEX idx_users_username ON users(username);
 CREATE INDEX idx_groups_enabled ON groups(enabled);
 
--- Insert default admin user (password: admin123)
--- Note: In production, change this immediately
+-- Insert default admin user with dynamically generated password hash
+-- Username: ${adminUsername}
+-- Password hash generated at migration time using bcrypt
 INSERT INTO users (username, email, password_hash, role_id, enabled) 
 VALUES (
-  'admin',
+  '${adminUsername}',
   'admin@gap.local',
-  '$2b$10$rQZ9vXJxL5K5J5K5J5K5JeQZ9vXJxL5K5J5K5J5K5J5K5J5K5J5K',
+  '${passwordHash}',
   1,
   true
 );
@@ -68,11 +87,16 @@ INSERT INTO groups (name, enabled) VALUES
   ('Team Gamma', true),
   ('Team Delta', false);
 `;
+}
 
 async function migrate() {
   const client = await pool.connect();
   try {
     console.log('Starting database migration...');
+    
+    // Generate SQL with dynamic admin credentials
+    const migrationSQL = await generateMigrationSQL();
+    
     await client.query('BEGIN');
     await client.query(migrationSQL);
     await client.query('COMMIT');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       JWT_EXPIRES_IN: 24h
       REGISTRATION_ENABLED: ${REGISTRATION_ENABLED:-true}
       CORS_ORIGIN: http://localhost:3000
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change_this_in_production}
     ports:
       - "3001:3001"
     depends_on:

--- a/k8s/gap-secrets.yaml.example
+++ b/k8s/gap-secrets.yaml.example
@@ -6,7 +6,9 @@
 # kubectl create secret generic gap-secrets \
 #   -n gap-portal \
 #   --from-literal=db-password='your-secure-password' \
-#   --from-literal=jwt-secret='your-jwt-secret'
+#   --from-literal=jwt-secret='your-jwt-secret' \
+#   --from-literal=admin-username='admin' \
+#   --from-literal=admin-password='your-secure-admin-password'
 #
 # Or use SealedSecrets / ExternalSecrets for production.
 
@@ -20,3 +22,5 @@ stringData:
   # Replace with secure values before applying
   db-password: "change-me-in-production"
   jwt-secret: "change-me-to-a-secure-random-string"
+  admin-username: "admin"
+  admin-password: "change-me-in-production"


### PR DESCRIPTION
## Summary

This PR addresses Issue #1 by removing the hardcoded admin password and using environment variables instead.

## Changes

1. **backend/src/db/migrate.js**:
   - Reads `ADMIN_USERNAME` and `ADMIN_PASSWORD` from environment variables
   - Generates bcrypt hash dynamically at migration time
   - Fails migration with clear error message if `ADMIN_PASSWORD` is not set
   - Defaults `ADMIN_USERNAME` to 'admin' if not set

2. **backend/.env.example**:
   - Added `ADMIN_USERNAME=admin`
   - Added `ADMIN_PASSWORD=change_this_in_production`

3. **k8s/gap-secrets.yaml.example**:
   - Added admin credentials to the secrets template

4. **docker-compose.yml**:
   - Added `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables

5. **README.md**:
   - Documented the new environment variables
   - Updated default credentials section with instructions

## Testing

- Migration fails gracefully if `ADMIN_PASSWORD` is not set
- Migration succeeds with valid `ADMIN_PASSWORD`
- Generated hash is valid bcrypt format

## Security Benefits

- No hardcoded credentials in version control
- Admin password can be set securely per environment
- Follows security best practices for credential management

Closes #1