### PR TITLE
feat: structured PII-safe logging for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,10 @@ jobs:
             type=ref,event=pr
             type=ref,event=branch
 
+      - name: Extract short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push ${{ matrix.service }} image
         uses: docker/build-push-action@v7
         with:
@@ -296,6 +300,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+          build-args: ${{ matrix.service == 'frontend' && format('GIT_HASH={0}', steps.sha.outputs.short) || '' }}
 
   # Fan-in job: succeeds only when both docker matrix variants pass.
   # Named 'build' to match the required status check configured in branch protection.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ docker compose up -d
 
 Migrations run automatically on backend startup (Docker stacks only). The first run seeds the `admin` account.
 
+> **Git revision in the UI:** The frontend displays the current git hash for build traceability. The dev stack mounts
+> `.git` read-only into the frontend container so Vite resolves the hash automatically via `git`. After each new commit,
+> restart the frontend container to pick up the updated hash:
+>
+> ```bash
+> docker-compose -f docker-compose.dev.yaml restart frontend
+> ```
+
 | Service      | URL                          |
 | ------------ | ---------------------------- |
 | Frontend     | http://localhost:3000        |
@@ -192,6 +200,7 @@ docker compose logs traefik    # Check TLS provisioning
 | `BACKUP_FREQ`          |    No    | `1440`              | Backup interval in minutes (default: every 24 h)        |
 | `BACKUP_BEGIN`         |    No    | `0300`              | First backup time, HHMM (default: 3:00 AM)              |
 | `BACKUP_CLEANUP_TIME`  |    No    | `10080`             | Delete backups older than N minutes (default: 7 days)   |
+| `LOG_LEVEL`            |    No    | _(unset)_           | Set to `silent` to suppress all backend log output      |
 
 ### Database backups
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Migrations run automatically on backend startup (Docker stacks only). The first 
 > restart the frontend container to pick up the updated hash:
 >
 > ```bash
-> docker-compose -f docker-compose.dev.yaml restart frontend
+> docker compose -f docker-compose.dev.yaml restart frontend
 > ```
 
 | Service      | URL                          |
@@ -182,25 +182,25 @@ docker compose logs traefik    # Check TLS provisioning
 
 ### Production environment variables
 
-| Variable               | Required | Default             | Description                                             |
-| ---------------------- | :------: | ------------------- | ------------------------------------------------------- |
-| `DOMAIN`               |   Yes    | —                   | FQDN (e.g. `gap.example.com`)                           |
-| `LETSENCRYPT_EMAIL`    |   Yes    | —                   | Email for Let's Encrypt registration                    |
-| `DB_PASSWORD`          |   Yes    | —                   | PostgreSQL password                                     |
-| `JWT_SECRET`           |   Yes    | —                   | JWT signing secret (min 32 chars)                       |
-| `ADMIN_PASSWORD`       |   Yes    | —                   | Initial admin password (seeded on first migration only) |
-| `JWT_EXPIRES_IN`       |    No    | `24h`               | Token expiry                                            |
-| `REGISTRATION_ENABLED` |    No    | `false`             | Allow public self-registration                          |
-| `SMTP_HOST`            |    No    | _(empty)_           | SMTP host; leave blank to log email links to console    |
-| `SMTP_PORT`            |    No    | `587`               | SMTP port                                               |
-| `SMTP_SECURE`          |    No    | `false`             | `true` for SMTPS; `false` for STARTTLS on port 587      |
-| `SMTP_USER`            |    No    | _(empty)_           | SMTP auth username                                      |
-| `SMTP_PASS`            |    No    | _(empty)_           | SMTP auth password                                      |
-| `SMTP_FROM`            |    No    | `no-reply@<DOMAIN>` | Sender address                                          |
-| `BACKUP_FREQ`          |    No    | `1440`              | Backup interval in minutes (default: every 24 h)        |
-| `BACKUP_BEGIN`         |    No    | `0300`              | First backup time, HHMM (default: 3:00 AM)              |
-| `BACKUP_CLEANUP_TIME`  |    No    | `10080`             | Delete backups older than N minutes (default: 7 days)   |
-| `LOG_LEVEL`            |    No    | _(unset)_           | Set to `silent` to suppress all backend log output      |
+| Variable               | Required | Default             | Description                                                                              |
+| ---------------------- | :------: | ------------------- | ---------------------------------------------------------------------------------------- |
+| `DOMAIN`               |   Yes    | —                   | FQDN (e.g. `gap.example.com`)                                                            |
+| `LETSENCRYPT_EMAIL`    |   Yes    | —                   | Email for Let's Encrypt registration                                                     |
+| `DB_PASSWORD`          |   Yes    | —                   | PostgreSQL password                                                                      |
+| `JWT_SECRET`           |   Yes    | —                   | JWT signing secret (min 32 chars)                                                        |
+| `ADMIN_PASSWORD`       |   Yes    | —                   | Initial admin password (seeded on first migration only)                                  |
+| `JWT_EXPIRES_IN`       |    No    | `24h`               | Token expiry                                                                             |
+| `REGISTRATION_ENABLED` |    No    | `false`             | Allow public self-registration                                                           |
+| `SMTP_HOST`            |    No    | _(empty)_           | SMTP host; leave blank to log email links to console                                     |
+| `SMTP_PORT`            |    No    | `587`               | SMTP port                                                                                |
+| `SMTP_SECURE`          |    No    | `false`             | `true` for SMTPS; `false` for STARTTLS on port 587                                       |
+| `SMTP_USER`            |    No    | _(empty)_           | SMTP auth username                                                                       |
+| `SMTP_PASS`            |    No    | _(empty)_           | SMTP auth password                                                                       |
+| `SMTP_FROM`            |    No    | `no-reply@<DOMAIN>` | Sender address                                                                           |
+| `BACKUP_FREQ`          |    No    | `1440`              | Backup interval in minutes (default: every 24 h)                                         |
+| `BACKUP_BEGIN`         |    No    | `0300`              | First backup time, HHMM (default: 3:00 AM)                                               |
+| `BACKUP_CLEANUP_TIME`  |    No    | `10080`             | Delete backups older than N minutes (default: 7 days)                                    |
+| `LOG_LEVEL`            |    No    | _(unset)_           | Set to `silent` to suppress non-fatal backend logs (fatal errors always write to stderr) |
 
 ### Database backups
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,6 +4,7 @@ const PasswordResetToken = require('../models/PasswordResetToken');
 const { sendPasswordResetEmail, sendPasswordSetupEmail } = require('../services/email');
 const config = require('../config/index');
 const { parseBody, registerSchema, loginSchema, forgotPasswordSchema, setPasswordSchema } = require('../utils/schemas');
+const { logger } = require('../utils/logger');
 
 async function authRoutes(fastify, _options) {
   const isDev = config.app.nodeEnv === 'development';
@@ -69,7 +70,7 @@ async function authRoutes(fastify, _options) {
           const tokenRecord = await PasswordResetToken.create(newUser.id, 'setup', 24);
           await sendPasswordSetupEmail(newUser, tokenRecord.token);
         } catch (emailError) {
-          console.error('Failed to send setup email:', emailError);
+          logger.error('Failed to send setup email', { err: emailError.message });
           // Don't fail the request - user was created successfully
         }
 
@@ -83,7 +84,7 @@ async function authRoutes(fastify, _options) {
           },
         });
       } catch (error) {
-        console.error('Registration error:', error);
+        logger.error('Registration error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Registration failed' });
       }
     }
@@ -163,7 +164,7 @@ async function authRoutes(fastify, _options) {
           },
         });
       } catch (error) {
-        console.error('Login error:', error);
+        logger.error('Login error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Login failed' });
       }
     }
@@ -205,7 +206,7 @@ async function authRoutes(fastify, _options) {
           },
         });
       } catch (error) {
-        console.error('Get current user error:', error);
+        logger.error('Get current user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve user info' });
       }
     }
@@ -251,7 +252,7 @@ async function authRoutes(fastify, _options) {
         }
         return reply.send(successMsg);
       } catch (error) {
-        console.error('Forgot password error:', error);
+        logger.error('Forgot password error', { err: error.message, code: error.code });
         // Still return 200 to avoid timing-based enumeration
         return reply.send(successMsg);
       }
@@ -299,7 +300,7 @@ async function authRoutes(fastify, _options) {
 
         return reply.send({ message: 'Password set successfully. You can now log in.' });
       } catch (error) {
-        console.error('Set password error:', error);
+        logger.error('Set password error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to set password' });
       }
     }

--- a/backend/src/routes/config.js
+++ b/backend/src/routes/config.js
@@ -2,6 +2,7 @@
 
 const Config = require('../models/Config');
 const { parseBody, updateConfigSchema } = require('../utils/schemas');
+const { logger } = require('../utils/logger');
 
 const ALLOWED_KEYS = ['group_join_locked'];
 
@@ -21,7 +22,7 @@ async function configRoutes(fastify, _options) {
         const value = await Config.get('group_join_locked');
         return reply.send({ locked: value === 'true' });
       } catch (error) {
-        console.error('Get config error:', error);
+        logger.error('Get config error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve config' });
       }
     }
@@ -46,7 +47,7 @@ async function configRoutes(fastify, _options) {
         const rows = await Config.getAll();
         return reply.send({ config: rows });
       } catch (error) {
-        console.error('Get all config error:', error);
+        logger.error('Get all config error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve config' });
       }
     }
@@ -82,7 +83,7 @@ async function configRoutes(fastify, _options) {
         const updated = await Config.set(key, body.value);
         return reply.send({ message: 'Config updated successfully', config: updated });
       } catch (error) {
-        console.error('Update config error:', error);
+        logger.error('Update config error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to update config' });
       }
     }

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -11,6 +11,7 @@ const {
   bulkCreateGroupItemSchema,
   BULK_CREATE_MAX,
 } = require('../utils/schemas');
+const { logger } = require('../utils/logger');
 
 const _parsedImportMax = parseInt(process.env.MAX_IMPORT_SIZE || '2000', 10);
 const MAX_IMPORT_MAPPINGS = Number.isNaN(_parsedImportMax) ? 2000 : _parsedImportMax;
@@ -31,7 +32,7 @@ async function groupsRoutes(fastify, _options) {
         const groups = await Group.findAll();
         return reply.send({ groups });
       } catch (error) {
-        console.error('Get groups error:', error);
+        logger.error('Get groups error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve groups' });
       }
     }
@@ -52,7 +53,7 @@ async function groupsRoutes(fastify, _options) {
         const groups = await Group.findEnabled();
         return reply.send({ groups });
       } catch (error) {
-        console.error('Get enabled groups error:', error);
+        logger.error('Get enabled groups error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve groups' });
       }
     }
@@ -96,7 +97,7 @@ async function groupsRoutes(fastify, _options) {
           members,
         });
       } catch (error) {
-        console.error('Get group error:', error);
+        logger.error('Get group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve group' });
       }
     }
@@ -143,7 +144,7 @@ async function groupsRoutes(fastify, _options) {
           },
         });
       } catch (error) {
-        console.error('Create group error:', error);
+        logger.error('Create group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to create group' });
       }
     }
@@ -209,7 +210,7 @@ async function groupsRoutes(fastify, _options) {
           groups,
         });
       } catch (error) {
-        console.error('Bulk create groups error:', error);
+        logger.error('Bulk create groups error', { err: error.message, code: error.code });
         if (error.code === '23505') {
           return reply.code(409).send({ error: 'One or more group names already exist' });
         }
@@ -273,7 +274,7 @@ async function groupsRoutes(fastify, _options) {
           group: updatedGroup,
         });
       } catch (error) {
-        console.error('Update group error:', error);
+        logger.error('Update group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to update group' });
       }
     }
@@ -310,7 +311,7 @@ async function groupsRoutes(fastify, _options) {
         const deleted = await Group.bulkDelete(uniqueIds);
         return reply.send({ message: 'Groups deleted successfully', deleted });
       } catch (error) {
-        console.error('Bulk delete groups error:', error);
+        logger.error('Bulk delete groups error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to delete groups' });
       }
     }
@@ -345,7 +346,7 @@ async function groupsRoutes(fastify, _options) {
 
         return reply.send({ message: 'Group deleted successfully' });
       } catch (error) {
-        console.error('Delete group error:', error);
+        logger.error('Delete group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to delete group' });
       }
     }
@@ -412,7 +413,7 @@ async function groupsRoutes(fastify, _options) {
 
         return reply.send({ message: 'Successfully joined group', groupId, groupName: group.name });
       } catch (error) {
-        console.error('Join group error:', error);
+        logger.error('Join group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to join group' });
       }
     }
@@ -468,7 +469,7 @@ async function groupsRoutes(fastify, _options) {
 
         return reply.send({ message: 'Successfully left group' });
       } catch (error) {
-        console.error('Leave group error:', error);
+        logger.error('Leave group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to leave group' });
       }
     }
@@ -551,14 +552,14 @@ async function groupsRoutes(fastify, _options) {
             imported++;
           } catch (rowErr) {
             const reason = rowErr.statusCode === 409 ? 'Group is full' : 'Failed to process row';
-            console.error('Import mapping row error:', rowErr);
+            logger.error('Import mapping row error', { err: rowErr.message, code: rowErr.code });
             errors.push({ email, groupName, error: reason });
           }
         }
 
         return reply.send({ imported, skipped, errors });
       } catch (error) {
-        console.error('Import group mappings error:', error);
+        logger.error('Import group mappings error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to import mappings' });
       }
     }
@@ -584,7 +585,7 @@ async function groupsRoutes(fastify, _options) {
         const mappings = rows.map((r) => ({ email: r.email, groupName: r.group_name }));
         return reply.send({ mappings });
       } catch (error) {
-        console.error('Export group mappings error:', error);
+        logger.error('Export group mappings error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to export mappings' });
       }
     }

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -13,6 +13,7 @@ const {
   validateUUID,
   ROLE_VALUES,
 } = require('../utils/schemas');
+const { logger } = require('../utils/logger');
 
 const _parsed = parseInt(process.env.MAX_IMPORT_SIZE || '2000', 10);
 const MAX_IMPORT_SIZE = Number.isNaN(_parsed) ? 2000 : _parsed;
@@ -50,7 +51,7 @@ async function usersRoutes(fastify, _options) {
         const users = await User.findAll({ role, status, groupId });
         return reply.send({ users });
       } catch (error) {
-        console.error('Get users error:', error);
+        logger.error('Get users error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve users' });
       }
     }
@@ -90,7 +91,7 @@ async function usersRoutes(fastify, _options) {
         const { password_hash: _password_hash, ...userWithoutPassword } = user;
         return reply.send({ user: userWithoutPassword });
       } catch (error) {
-        console.error('Get user error:', error);
+        logger.error('Get user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve user' });
       }
     }
@@ -189,7 +190,7 @@ async function usersRoutes(fastify, _options) {
             const tokenRecord = await PasswordResetToken.create(newUser.id, 'setup', 24);
             await sendPasswordSetupEmail(newUser, tokenRecord.token);
           } catch (emailError) {
-            console.error('Failed to send setup email:', emailError);
+            logger.error('Failed to send setup email', { err: emailError.message });
             // Don't fail the request — user was created successfully
           }
         }
@@ -217,7 +218,7 @@ async function usersRoutes(fastify, _options) {
           }
           return reply.code(409).send({ error: 'A user with these details already exists' });
         }
-        console.error('Create user error:', error);
+        logger.error('Create user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to create user' });
       }
     }
@@ -278,7 +279,7 @@ async function usersRoutes(fastify, _options) {
         if (error.statusCode && error.statusCode < 500) {
           return reply.code(error.statusCode).send({ error: error.message });
         }
-        console.error('Update user group error:', error);
+        logger.error('Update user group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to update user group' });
       }
     }
@@ -398,7 +399,7 @@ async function usersRoutes(fastify, _options) {
           user: safeUser,
         });
       } catch (error) {
-        console.error('Update user error:', error);
+        logger.error('Update user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to update user' });
       }
     }
@@ -447,7 +448,7 @@ async function usersRoutes(fastify, _options) {
 
         return reply.send({ message: 'Password updated successfully' });
       } catch (error) {
-        console.error('Change password error:', error);
+        logger.error('Change password error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to change password' });
       }
     }
@@ -487,7 +488,7 @@ async function usersRoutes(fastify, _options) {
 
         return reply.send({ message: 'User deleted successfully' });
       } catch (error) {
-        console.error('Delete user error:', error);
+        logger.error('Delete user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to delete user' });
       }
     }
@@ -528,7 +529,7 @@ async function usersRoutes(fastify, _options) {
         const deleted = await User.bulkDelete(uniqueIds);
         return reply.send({ message: 'Users deleted successfully', deleted });
       } catch (error) {
-        console.error('Bulk delete users error:', error);
+        logger.error('Bulk delete users error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to delete users' });
       }
     }
@@ -674,7 +675,7 @@ async function usersRoutes(fastify, _options) {
                 const tokenRecord = await PasswordResetToken.create(newUser.id, 'setup', 24);
                 await sendPasswordSetupEmail(newUser, tokenRecord.token);
               } catch (emailError) {
-                console.error('Failed to send setup email:', emailError);
+                logger.error('Failed to send setup email', { err: emailError.message });
               }
             }
 
@@ -687,7 +688,7 @@ async function usersRoutes(fastify, _options) {
 
         return reply.send({ imported, skipped, errors });
       } catch (error) {
-        console.error('Import error:', error);
+        logger.error('Import error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Import failed' });
       }
     }
@@ -739,14 +740,14 @@ async function usersRoutes(fastify, _options) {
             await sendPasswordSetupEmail(u, tokenRecord.token);
             sent++;
           } catch (emailError) {
-            console.error(`Failed to send setup email to ${u.username}:`, emailError);
+            logger.error('Failed to send setup email', { username: u.username, err: emailError.message });
             errors.push({ userId: u.id, username: u.username, reason: 'Failed to send email' });
           }
         }
 
         return reply.send({ sent, errors });
       } catch (error) {
-        console.error('Send setup emails error:', error);
+        logger.error('Send setup emails error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to send setup emails' });
       }
     }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,8 +16,9 @@ const authPlugin = require('./middleware/auth');
 const rbacPlugin = require('./middleware/rbac');
 
 async function buildServer({ logger: disableLogger } = {}) {
-  // We manage logging ourselves via hooks; disable Fastify's built-in Pino logger.
-  // Pass logger:false in tests (via buildTestServer) to suppress all log output.
+  // We manage request/access logging ourselves via hooks; disable Fastify's built-in Pino logger.
+  // Pass logger:false in tests (via buildTestServer) to suppress access-log hook output only;
+  // route/service logs are controlled separately via NODE_ENV=test or LOG_LEVEL=silent.
   const enableLogging = disableLogger !== false && config.app.nodeEnv !== 'test';
 
   const fastify = Fastify({ logger: false });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,7 @@ const cors = require('@fastify/cors');
 const helmet = require('@fastify/helmet');
 const rateLimit = require('@fastify/rate-limit');
 const config = require('./config/index');
+const { logger } = require('./utils/logger');
 
 // Import routes
 const authRoutes = require('./routes/auth');
@@ -14,10 +15,12 @@ const configRoutes = require('./routes/config');
 const authPlugin = require('./middleware/auth');
 const rbacPlugin = require('./middleware/rbac');
 
-async function buildServer({ logger } = {}) {
-  const fastify = Fastify({
-    logger: logger !== undefined ? logger : config.app.nodeEnv !== 'production',
-  });
+async function buildServer({ logger: disableLogger } = {}) {
+  // We manage logging ourselves via hooks; disable Fastify's built-in Pino logger.
+  // Pass logger:false in tests (via buildTestServer) to suppress all log output.
+  const enableLogging = disableLogger !== false && config.app.nodeEnv !== 'test';
+
+  const fastify = Fastify({ logger: false });
 
   // Register security plugins
   await fastify.register(helmet, {
@@ -49,6 +52,37 @@ async function buildServer({ logger } = {}) {
     } catch (err) {
       reply.code(401).send({ error: 'Unauthorized', message: err.message });
       throw err;
+    }
+  });
+
+  // Access logging — record start time on every request
+  fastify.addHook('onRequest', async (request) => {
+    request._startTime = Date.now();
+  });
+
+  // Access logging — emit a structured line after each response is sent
+  fastify.addHook('onResponse', async (request, reply) => {
+    if (!enableLogging) {
+      return;
+    }
+    const duration = Date.now() - (request._startTime || Date.now());
+    const ip = (request.headers['x-forwarded-for'] || '').split(',')[0].trim() || request.ip || 'unknown';
+    const status = reply.statusCode;
+    const meta = { ip, duration: `${duration}ms` };
+    if (request.user?.id) {
+      meta.userId = request.user.id;
+    }
+    if (request.user?.role) {
+      meta.role = request.user.role;
+    }
+    const safeUrl = request.url.replace(/[\r\n\x1b]/g, ''); // eslint-disable-line no-control-regex
+    const line = `${request.method} ${safeUrl} ${status}`;
+    if (status >= 500) {
+      logger.error(line, meta);
+    } else if (status >= 400) {
+      logger.warn(line, meta);
+    } else {
+      logger.info(line, meta);
     }
   });
 
@@ -126,14 +160,14 @@ async function buildServer({ logger } = {}) {
 let _serverInstance = null;
 
 async function shutdown(signal) {
-  console.log(`${signal} received, shutting down gracefully...`);
+  logger.info(`${signal} received, shutting down gracefully...`);
   try {
     if (_serverInstance) {
       await _serverInstance.close();
     }
     process.exit(0);
   } catch (err) {
-    console.error('Error during shutdown:', err);
+    logger.error('Error during shutdown', { err: err.message });
     process.exit(1);
   }
 }
@@ -149,11 +183,11 @@ async function start() {
       host: config.app.host,
     });
 
-    console.log(`🚀 G.A.P. Backend server running at http://${config.app.host}:${config.app.port}`);
-    console.log(`📝 Environment: ${config.app.nodeEnv}`);
-    console.log(`🔐 Registration: ${config.app.registrationEnabled ? 'enabled' : 'disabled'}`);
+    logger.info(`G.A.P. Backend server running at http://${config.app.host}:${config.app.port}`);
+    logger.info(`Environment: ${config.app.nodeEnv}`);
+    logger.info(`Registration: ${config.app.registrationEnabled ? 'enabled' : 'disabled'}`);
   } catch (err) {
-    console.error('Failed to start server:', err);
+    logger.error('Failed to start server', { err: err.message });
     process.exit(1);
   }
 }
@@ -162,13 +196,13 @@ async function start() {
 if (require.main === module) {
   process.on('SIGTERM', () => {
     shutdown('SIGTERM').catch((err) => {
-      console.error('Error during graceful shutdown on SIGTERM:', err);
+      logger.error('Error during graceful shutdown on SIGTERM', { err: err.message });
       process.exit(1);
     });
   });
   process.on('SIGINT', () => {
     shutdown('SIGINT').catch((err) => {
-      console.error('Error during graceful shutdown on SIGINT:', err);
+      logger.error('Error during graceful shutdown on SIGINT', { err: err.message });
       process.exit(1);
     });
   });

--- a/backend/src/services/email.js
+++ b/backend/src/services/email.js
@@ -1,5 +1,6 @@
 const nodemailer = require('nodemailer');
 const config = require('../config/index');
+const { logger, maskEmail } = require('../utils/logger');
 
 let _transporter = null;
 
@@ -32,16 +33,17 @@ function getTransporter() {
 async function sendEmail(to, subject, html) {
   const transporter = getTransporter();
   if (!transporter) {
-    // SMTP not configured — log to console so dev flows (password setup/reset) remain usable
+    // SMTP not configured — log so dev flows (password setup/reset) remain usable
     if (process.env.NODE_ENV !== 'production') {
-      console.log(`[EMAIL DEV] To: ${to} | Subject: ${subject}`); // eslint-disable-line no-console
-      console.log('[EMAIL DEV] Body:', html); // eslint-disable-line no-console
+      logger.info(`[EMAIL DEV] To: ${maskEmail(to)}`);
+      logger.info('[EMAIL DEV] Body omitted — set SMTP_HOST to send real emails');
     } else {
-      console.warn('[EMAIL] SMTP not configured; email not sent.'); // eslint-disable-line no-console
+      logger.warn('[EMAIL] SMTP not configured; email not sent.');
     }
     return;
   }
   await transporter.sendMail({ from: config.smtp.from, to, subject, html });
+  logger.info(`Email sent to: ${maskEmail(to)}`);
 }
 
 function emailLayout(content) {

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Human-readable, PII-aware logger for the G.A.P. backend.
+ *
+ * Output format (single line per event):
+ *   [ISO-8601] LEVEL  message  {"context":"..."}
+ *
+ * Examples:
+ *   [2024-01-15T10:30:01.123Z] INFO   Server started on port 3001
+ *   [2024-01-15T10:30:02.456Z] INFO   GET /api/users 200 172.17.0.1 15ms  {"userId":"abc-123","role":"admin"}
+ *   [2024-01-15T10:30:03.789Z] ERROR  Login error  {"err":"Database connection timeout","code":"ETIMEDOUT"}
+ */
+
+const LEVEL_LABELS = {
+  trace: 'TRACE',
+  debug: 'DEBUG',
+  info: 'INFO ',
+  warn: 'WARN ',
+  error: 'ERROR',
+  fatal: 'FATAL',
+};
+
+const isSilent = () => process.env.NODE_ENV === 'test' || process.env.LOG_LEVEL === 'silent';
+
+// ---------------------------------------------------------------------------
+// PII masking utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Masks an email address, keeping the first two chars of the local part and
+ * the full domain — enough context to correlate log entries without exposing
+ * the full address.
+ *
+ * Examples:
+ *   john.doe@example.com  →  jo***e@example.com
+ *   ab@test.com           →  ab@test.com       (short local part: show as-is)
+ *   a@test.com            →  a@test.com        (single char: show as-is)
+ */
+function maskEmail(email) {
+  if (!email || typeof email !== 'string') {
+    return email;
+  }
+  const atIdx = email.indexOf('@');
+  if (atIdx < 0) {
+    return '***@***';
+  }
+  const local = email.slice(0, atIdx);
+  const domain = email.slice(atIdx + 1);
+  if (local.length <= 2) {
+    return `${local}@${domain}`;
+  }
+  return `${local.slice(0, 2)}***${local.slice(-1)}@${domain}`;
+}
+
+/**
+ * Masks a full name, keeping only the first letter of each word.
+ *
+ * Example: "John Doe" → "J*** D***"
+ */
+function maskName(name) {
+  if (!name || typeof name !== 'string') {
+    return name;
+  }
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((part) => (part.length > 0 ? `${part[0]}***` : ''))
+    .join(' ');
+}
+
+/**
+ * Masks an access or JWT token, keeping only the first 8 characters.
+ *
+ * Example: "eyJhbGciOiJIUzI1NiJ9.xxx" → "eyJhbGci..."
+ */
+function maskToken(token) {
+  if (!token || typeof token !== 'string') {
+    return '[REDACTED]';
+  }
+  return token.length > 8 ? `${token.slice(0, 8)}...` : '[REDACTED]';
+}
+
+/**
+ * Masks a student ID, keeping the first two and last two characters.
+ *
+ * Example: "S1234567" → "S1***67"
+ */
+function maskStudentId(id) {
+  if (!id || typeof id !== 'string') {
+    return id;
+  }
+  if (id.length <= 4) {
+    return '***';
+  }
+  return `${id.slice(0, 2)}***${id.slice(-2)}`;
+}
+
+// Fields that are always fully redacted
+const REDACT_FIELDS = new Set(['password', 'currentPassword', 'newPassword', 'passwordHash', 'password_hash']);
+
+// Fields whose values are access/auth tokens and should be masked
+const TOKEN_FIELDS = new Set(['token', 'resetToken', 'authorization', 'accessToken', 'refreshToken']);
+
+/**
+ * Returns a shallow-cloned copy of `meta` with known PII fields redacted or
+ * masked. Intended for log context objects — not a deep sanitiser.
+ */
+function redactMeta(meta) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return meta;
+  }
+  const safe = { ...meta };
+  for (const key of Object.keys(safe)) {
+    if (REDACT_FIELDS.has(key)) {
+      safe[key] = '[REDACTED]'; // eslint-disable-line security/detect-object-injection
+    } else if (TOKEN_FIELDS.has(key)) {
+      safe[key] = maskToken(String(safe[key])); // eslint-disable-line security/detect-object-injection
+    } else if (key === 'email') {
+      safe[key] = maskEmail(safe[key]); // eslint-disable-line security/detect-object-injection
+    } else if (key === 'firstName' || key === 'lastName' || key === 'fullName') {
+      safe[key] = maskName(safe[key]); // eslint-disable-line security/detect-object-injection
+    } else if (key === 'studentId' || key === 'student_id') {
+      safe[key] = maskStudentId(String(safe[key])); // eslint-disable-line security/detect-object-injection
+    }
+  }
+  return safe;
+}
+
+// ---------------------------------------------------------------------------
+// Formatter
+// ---------------------------------------------------------------------------
+
+function formatLine(level, msg, meta) {
+  const ts = new Date().toISOString();
+  const label = LEVEL_LABELS[level] || 'INFO '; // eslint-disable-line security/detect-object-injection
+  let line = `[${ts}] ${label}  ${msg}`;
+  if (meta !== undefined && meta !== null) {
+    const safeMeta = typeof meta === 'object' ? redactMeta(meta) : meta;
+    line += `  ${JSON.stringify(safeMeta)}`;
+  }
+  return line;
+}
+
+// ---------------------------------------------------------------------------
+// Logger instance
+// ---------------------------------------------------------------------------
+
+const logger = {
+  trace: (msg, meta) => {
+    if (!isSilent()) {
+      process.stdout.write(formatLine('trace', msg, meta) + '\n');
+    }
+  },
+  debug: (msg, meta) => {
+    if (!isSilent()) {
+      process.stdout.write(formatLine('debug', msg, meta) + '\n');
+    }
+  },
+  info: (msg, meta) => {
+    if (!isSilent()) {
+      process.stdout.write(formatLine('info', msg, meta) + '\n');
+    }
+  },
+  warn: (msg, meta) => {
+    if (!isSilent()) {
+      process.stderr.write(formatLine('warn', msg, meta) + '\n');
+    }
+  },
+  error: (msg, meta) => {
+    if (!isSilent()) {
+      process.stderr.write(formatLine('error', msg, meta) + '\n');
+    }
+  },
+  fatal: (msg, meta) => {
+    // Always log fatal errors, even in test mode
+    process.stderr.write(formatLine('fatal', msg, meta) + '\n');
+  },
+};
+
+module.exports = { logger, maskEmail, maskName, maskToken, maskStudentId, redactMeta };

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -115,13 +115,15 @@ function redactMeta(meta) {
     if (REDACT_FIELDS.has(key)) {
       safe[key] = '[REDACTED]'; // eslint-disable-line security/detect-object-injection
     } else if (TOKEN_FIELDS.has(key)) {
-      safe[key] = maskToken(String(safe[key])); // eslint-disable-line security/detect-object-injection
+      const tv = safe[key]; // eslint-disable-line security/detect-object-injection
+      safe[key] = tv === null || tv === undefined ? tv : maskToken(String(tv)); // eslint-disable-line security/detect-object-injection
     } else if (key === 'email') {
       safe[key] = maskEmail(safe[key]); // eslint-disable-line security/detect-object-injection
-    } else if (key === 'firstName' || key === 'lastName' || key === 'fullName') {
+    } else if (key === 'firstName' || key === 'lastName' || key === 'fullName' || key === 'name') {
       safe[key] = maskName(safe[key]); // eslint-disable-line security/detect-object-injection
     } else if (key === 'studentId' || key === 'student_id') {
-      safe[key] = maskStudentId(String(safe[key])); // eslint-disable-line security/detect-object-injection
+      const sv = safe[key]; // eslint-disable-line security/detect-object-injection
+      safe[key] = sv === null || sv === undefined ? sv : maskStudentId(String(sv)); // eslint-disable-line security/detect-object-injection
     }
   }
   return safe;

--- a/backend/tests/unit/auth.test.js
+++ b/backend/tests/unit/auth.test.js
@@ -40,6 +40,15 @@ jest.mock('../../src/config/index', () => ({
   },
 }));
 
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
 const User = require('../../src/models/User');
 const Role = require('../../src/models/Role');
 const PasswordResetToken = require('../../src/models/PasswordResetToken');
@@ -371,18 +380,16 @@ describe('Auth Routes', () => {
       Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000003', name: 'user' });
       User.create.mockRejectedValue(new Error('Database error'));
 
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const authRoutes = require('../../src/routes/auth');
       authRoutes(mockFastify, {});
 
       await capturedHandlers['/auth/register']({ body: validRegisterBody }, mockReply);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'Registration failed' });
-
-      consoleSpy.mockRestore();
     });
   });
 
@@ -524,18 +531,16 @@ describe('Auth Routes', () => {
     it('handles login error', async () => {
       User.findByUsername.mockRejectedValue(new Error('Database error'));
 
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const authRoutes = require('../../src/routes/auth');
       authRoutes(mockFastify, {});
 
       await capturedHandlers['/auth/login']({ body: { username: 'test', password: 'password' } }, mockReply);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'Login failed' });
-
-      consoleSpy.mockRestore();
     });
   });
 
@@ -742,14 +747,12 @@ describe('Auth Routes', () => {
       authRoutes(mockFastify, {});
 
       User.findByEmail.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await capturedHandlers['/auth/forgot-password']({ body: { email: 'user@test.com' } }, mockReply);
 
       expect(mockReply.send).toHaveBeenCalledWith({
         message: 'If that email is registered, a reset link has been sent.',
       });
-      consoleSpy.mockRestore();
     });
   });
 
@@ -885,13 +888,11 @@ describe('Auth Routes', () => {
       authRoutes(mockFastify, {});
 
       PasswordResetToken.findByToken.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
       await capturedHandlers['/auth/set-password']({ body: { token: 'sometoken', password: 'newpass1' } }, mockReply);
 
       expect(mockReply.code).toHaveBeenCalledWith(500);
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'Failed to set password' });
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/backend/tests/unit/config.test.js
+++ b/backend/tests/unit/config.test.js
@@ -2,6 +2,15 @@
 
 jest.mock('../../src/models/Config');
 
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
 const Config = require('../../src/models/Config');
 
 describe('Config Routes', () => {
@@ -80,11 +89,9 @@ describe('Config Routes', () => {
     it('returns 500 on database error', async () => {
       const { handlers } = setupRoute();
       Config.get.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/config/group-join-locked_get']({ user: { id: 'u1', role: 'user' } }, reply);
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -118,11 +125,9 @@ describe('Config Routes', () => {
     it('returns 500 on database error', async () => {
       const { handlers } = setupRoute();
       Config.getAll.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/config_get']({}, reply);
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -195,7 +200,7 @@ describe('Config Routes', () => {
     it('returns 500 on database error', async () => {
       const { handlers } = setupRoute();
       Config.set.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/config/:key_put'](
         {
@@ -205,9 +210,8 @@ describe('Config Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -3,6 +3,15 @@ jest.mock('../../src/models/Group');
 jest.mock('../../src/models/User');
 jest.mock('../../src/models/Config');
 
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
 const Group = require('../../src/models/Group');
 const User = require('../../src/models/User');
 const Config = require('../../src/models/Config');
@@ -82,12 +91,11 @@ describe('Groups Routes', () => {
     it('handles error when fetching groups', async () => {
       const { handlers } = setupRoute();
       Group.findAll.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups_get']({}, reply);
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -112,12 +120,11 @@ describe('Groups Routes', () => {
     it('handles error when fetching enabled groups', async () => {
       const { handlers } = setupRoute();
       Group.findEnabled.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/enabled_get']({}, reply);
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -164,12 +171,11 @@ describe('Groups Routes', () => {
     it('handles error when fetching group', async () => {
       const { handlers } = setupRoute();
       Group.findById.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id_get']({ params: { id: '10000000-0000-4000-8000-000000000001' } }, reply);
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -315,7 +321,7 @@ describe('Groups Routes', () => {
       const { handlers } = setupRoute();
       Group.findByName.mockResolvedValue(null);
       Group.create.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups_post'](
         {
@@ -324,9 +330,8 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -548,7 +553,7 @@ describe('Groups Routes', () => {
         enabled: true,
       });
       Group.update.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id_put'](
         {
@@ -558,9 +563,8 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -621,7 +625,7 @@ describe('Groups Routes', () => {
     it('handles error when deleting group', async () => {
       const { handlers } = setupRoute();
       Group.delete.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id_delete'](
         {
@@ -630,9 +634,8 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -853,7 +856,7 @@ describe('Groups Routes', () => {
     it('handles error when joining group', async () => {
       const { handlers } = setupRoute();
       Group.findById.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id/join_post'](
         {
@@ -862,9 +865,8 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('rejects normal user when join lock is enabled', async () => {
@@ -1090,7 +1092,7 @@ describe('Groups Routes', () => {
     it('handles error when leaving group', async () => {
       const { handlers } = setupRoute();
       Group.findById.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id/leave_post'](
         {
@@ -1099,9 +1101,8 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('rejects normal user when join lock is enabled', async () => {
@@ -1263,7 +1264,6 @@ describe('Groups Routes', () => {
       const fullErr = new Error('Group is full');
       fullErr.statusCode = 409;
       Group.assignUserToGroup.mockRejectedValue(fullErr);
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1274,13 +1274,11 @@ describe('Groups Routes', () => {
       );
       const result = reply.send.mock.calls[0][0];
       expect(result.errors[0].error).toBe('Group is full');
-      consoleSpy.mockRestore();
     });
 
     it('records per-row DB error in errors array', async () => {
       const { handlers } = setupRoute();
       User.findByEmail.mockRejectedValue(new Error('DB down'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1291,7 +1289,6 @@ describe('Groups Routes', () => {
       );
       const result = reply.send.mock.calls[0][0];
       expect(result.errors[0].error).toBe('Failed to process row');
-      consoleSpy.mockRestore();
     });
 
     it('skips row when target user is an admin', async () => {
@@ -1390,11 +1387,9 @@ describe('Groups Routes', () => {
     it('handles DB error (500)', async () => {
       const { handlers } = setupRoute();
       Group.getExportMappings.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/groups/export-mappings_get']({ user: { id: 'u1', role: 'admin' } }, reply);
       expect(reply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -1601,7 +1596,6 @@ describe('Groups Routes', () => {
       const err = new Error('duplicate key value violates unique constraint');
       err.code = '23505';
       Group.bulkCreate.mockRejectedValue(err);
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const reply = mockReply();
       await handlers['/groups/bulk_post'](
         {
@@ -1612,7 +1606,6 @@ describe('Groups Routes', () => {
       );
       expect(reply.code).toHaveBeenCalledWith(409);
       expect(reply.send).toHaveBeenCalledWith({ error: 'One or more group names already exist' });
-      consoleSpy.mockRestore();
     });
 
     it('rejects duplicate names within the batch itself (400)', async () => {
@@ -1634,7 +1627,7 @@ describe('Groups Routes', () => {
     it('returns 500 on unexpected database error and rolls back', async () => {
       const { handlers } = setupRoute();
       Group.bulkCreate.mockRejectedValue(new Error('Connection lost'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/bulk_post'](
         {
@@ -1643,10 +1636,9 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
       expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to create groups' });
-      consoleSpy.mockRestore();
     });
   });
 
@@ -1748,7 +1740,7 @@ describe('Groups Routes', () => {
     it('returns 500 on DB error', async () => {
       const { handlers } = setupRoute();
       Group.bulkDelete.mockRejectedValue(new Error('DB exploded'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/bulk_delete'](
         {
@@ -1757,10 +1749,9 @@ describe('Groups Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
       expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to delete groups' });
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/backend/tests/unit/services/email.test.js
+++ b/backend/tests/unit/services/email.test.js
@@ -2,6 +2,29 @@ jest.mock('nodemailer', () => ({
   createTransport: jest.fn(),
 }));
 
+jest.mock('../../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => {
+    if (!e || typeof e !== 'string') {
+      return e;
+    }
+    const atIdx = e.indexOf('@');
+    if (atIdx < 0) {
+      return '***@***';
+    }
+    const local = e.slice(0, atIdx);
+    const domain = e.slice(atIdx + 1);
+    if (local.length <= 2) {
+      return `${local}@${domain}`;
+    }
+    return `${local.slice(0, 2)}***${local.slice(-1)}@${domain}`;
+  },
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
 describe('Email Service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -10,8 +33,6 @@ describe('Email Service', () => {
 
   describe('sendEmail', () => {
     it('logs to console when SMTP host is not configured', async () => {
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-
       jest.mock('../../../src/config/index', () => ({
         smtp: { host: '', port: 587, secure: false, user: '', pass: '', from: 'no-reply@gap-app.local' },
         appUrl: 'http://localhost:3000',
@@ -19,11 +40,10 @@ describe('Email Service', () => {
       jest.mock('nodemailer', () => ({ createTransport: jest.fn() }));
 
       const { sendEmail } = require('../../../src/services/email');
+      const { logger: mockLogger } = require('../../../src/utils/logger');
       await sendEmail('to@test.com', 'Subject', '<p>Body</p>');
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('To: to@test.com'));
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Subject: Subject'));
-      consoleSpy.mockRestore();
+      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('To: to@test.com'));
     });
 
     it('sends email via transporter when SMTP is configured', async () => {

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -15,6 +15,15 @@ jest.mock('../../src/services/email', () => ({
   sendEmail: jest.fn(),
 }));
 
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
 const User = require('../../src/models/User');
 const Group = require('../../src/models/Group');
 const Role = require('../../src/models/Role');
@@ -136,14 +145,13 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findAll.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users_get']({}, mockReply);
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -197,14 +205,13 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findById.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id_get']({ params: { id: '00000000-0000-4000-8000-000000000001' } }, mockReply);
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('returns 400 for invalid UUID in :id param (M5)', async () => {
@@ -693,7 +700,7 @@ describe('Users Routes', () => {
       User.findByEmail.mockResolvedValue(null);
       Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000003', name: 'user' });
       User.create.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -701,9 +708,8 @@ describe('Users Routes', () => {
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users_post']({ body: validCreateBody }, mockReply);
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('returns 409 when User.create throws Postgres 23505 unique violation on student_id', async () => {
@@ -979,7 +985,7 @@ describe('Users Routes', () => {
         username: 'test',
       });
       Group.assignUserToGroup.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -993,9 +999,8 @@ describe('Users Routes', () => {
         mockReply
       );
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -1274,7 +1279,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.update.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -1290,9 +1295,8 @@ describe('Users Routes', () => {
         mockReply
       );
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('prevents disabling the built-in admin user', async () => {
@@ -1828,7 +1832,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.delete.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -1842,9 +1846,8 @@ describe('Users Routes', () => {
         mockReply
       );
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -1857,7 +1860,7 @@ describe('Users Routes', () => {
         username: 'test',
       });
       Group.assignUserToGroup.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -1871,9 +1874,8 @@ describe('Users Routes', () => {
         mockReply
       );
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -2103,7 +2105,6 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findById.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2116,7 +2117,6 @@ describe('Users Routes', () => {
         mockReply
       );
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -2125,7 +2125,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.delete.mockRejectedValue(new Error('Database error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2139,9 +2139,8 @@ describe('Users Routes', () => {
         mockReply
       );
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -2587,7 +2586,6 @@ describe('Users Routes', () => {
       User.findByEmail.mockResolvedValue(null);
       User.findByStudentId.mockResolvedValue(null);
       User.create.mockRejectedValue(new Error('DB constraint violation'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2604,7 +2602,6 @@ describe('Users Routes', () => {
         skipped: 0,
         errors: [{ row: 1, identifier: 'baduser', reason: 'Processing failed' }],
       });
-      consoleSpy.mockRestore();
     });
 
     it('handles mix of new, skipped, and errored rows', async () => {
@@ -2645,7 +2642,6 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockRejectedValue(new Error('DB down'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2656,7 +2652,6 @@ describe('Users Routes', () => {
       );
 
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
 
     it('errors when new user email conflicts with existing user', async () => {
@@ -2891,7 +2886,6 @@ describe('Users Routes', () => {
       PasswordResetToken.deleteStaleForUser.mockResolvedValue();
       PasswordResetToken.create.mockResolvedValue({ token: 'tok123' });
       sendPasswordSetupEmail.mockRejectedValue(new Error('SMTP down'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2902,14 +2896,12 @@ describe('Users Routes', () => {
         sent: 0,
         errors: [{ userId: 'u1', username: 'pending1', reason: 'Failed to send email' }],
       });
-      consoleSpy.mockRestore();
     });
 
     it('handles top-level errors with 500', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findAll.mockRejectedValue(new Error('DB down'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2917,7 +2909,6 @@ describe('Users Routes', () => {
       await handlers['/users/send-setup-emails_post']({ user: { id: 'admin1', role: 'admin' }, body: {} }, mockReply);
 
       expect(mockReply.code).toHaveBeenCalledWith(500);
-      consoleSpy.mockRestore();
     });
   });
 
@@ -3049,7 +3040,7 @@ describe('Users Routes', () => {
     it('returns 500 on DB error', async () => {
       const { handlers, reply } = setupUsersRoute();
       User.bulkDelete.mockRejectedValue(new Error('DB exploded'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { logger: mockLogger } = require('../../src/utils/logger');
       await handlers['/users/bulk_delete'](
         {
           user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' },
@@ -3057,10 +3048,9 @@ describe('Users Routes', () => {
         },
         reply
       );
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
       expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to delete users' });
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/backend/tests/unit/utils/logger.test.js
+++ b/backend/tests/unit/utils/logger.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const { maskEmail, maskName, maskToken, maskStudentId, redactMeta } = require('../../../src/utils/logger');
+
+// ---------------------------------------------------------------------------
+// logger output (uses module reload so isSilent=false paths are exercised)
+// ---------------------------------------------------------------------------
+
+describe('logger output methods', () => {
+  let activeLogger;
+  let stdoutSpy;
+  let stderrSpy;
+  const origNodeEnv = process.env.NODE_ENV;
+  const origLogLevel = process.env.LOG_LEVEL;
+
+  beforeAll(() => {
+    // Load a fresh module instance with NODE_ENV != test so isSilent is false
+    process.env.NODE_ENV = 'development';
+    delete process.env.LOG_LEVEL;
+    jest.resetModules();
+    activeLogger = require('../../../src/utils/logger').logger;
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = origNodeEnv;
+    if (origLogLevel !== undefined) {
+      process.env.LOG_LEVEL = origLogLevel;
+    }
+    jest.resetModules();
+  });
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('info writes a formatted line to stdout', () => {
+    activeLogger.info('hello world');
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const output = stdoutSpy.mock.calls[0][0];
+    expect(output).toMatch(/\[.*\] INFO {3}hello world\n/);
+  });
+
+  it('warn writes a formatted line to stderr', () => {
+    activeLogger.warn('something odd');
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy.mock.calls[0][0]).toMatch(/WARN /);
+  });
+
+  it('error writes a formatted line to stderr', () => {
+    activeLogger.error('boom', { err: 'oops' });
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const output = stderrSpy.mock.calls[0][0];
+    expect(output).toMatch(/ERROR/);
+    expect(output).toContain('boom');
+  });
+
+  it('debug writes to stdout', () => {
+    activeLogger.debug('debug msg');
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy.mock.calls[0][0]).toMatch(/DEBUG/);
+  });
+
+  it('trace writes to stdout', () => {
+    activeLogger.trace('trace msg');
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy.mock.calls[0][0]).toMatch(/TRACE/);
+  });
+
+  it('fatal always writes to stderr even in test mode', () => {
+    // fatal bypasses isSilent
+    activeLogger.fatal('fatal error');
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy.mock.calls[0][0]).toMatch(/FATAL/);
+  });
+
+  it('redacts PII from meta before writing', () => {
+    activeLogger.info('user logged in', { email: 'secret@example.com', password: 'pass123' });
+    const output = stdoutSpy.mock.calls[0][0];
+    expect(output).not.toContain('secret@example.com');
+    expect(output).not.toContain('pass123');
+    expect(output).toContain('[REDACTED]');
+  });
+
+  it('includes meta as JSON when provided', () => {
+    activeLogger.info('test', { role: 'admin', userId: 'u-1' });
+    const output = stdoutSpy.mock.calls[0][0];
+    expect(output).toContain('"role":"admin"');
+    expect(output).toContain('"userId":"u-1"');
+  });
+
+  it('silent when LOG_LEVEL=silent', () => {
+    process.env.LOG_LEVEL = 'silent';
+    jest.resetModules();
+    const silentLogger = require('../../../src/utils/logger').logger;
+    silentLogger.info('should be suppressed');
+    silentLogger.error('also suppressed');
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+    delete process.env.LOG_LEVEL;
+    jest.resetModules();
+  });
+});
+
+describe('maskEmail', () => {
+  it('masks middle chars, keeps first two and last char of local part plus domain', () => {
+    expect(maskEmail('john.doe@example.com')).toBe('jo***e@example.com');
+  });
+
+  it('keeps short local parts unchanged (2 chars or fewer)', () => {
+    expect(maskEmail('ab@test.com')).toBe('ab@test.com');
+    expect(maskEmail('a@test.com')).toBe('a@test.com');
+  });
+
+  it('masks a 3-char local part', () => {
+    expect(maskEmail('joe@test.com')).toBe('jo***e@test.com');
+  });
+
+  it('returns *** for missing or invalid email', () => {
+    expect(maskEmail(null)).toBeNull();
+    expect(maskEmail(undefined)).toBeUndefined();
+    expect(maskEmail('noatsign')).toBe('***@***');
+  });
+
+  it('returns non-string values as-is', () => {
+    expect(maskEmail(42)).toBe(42);
+  });
+});
+
+describe('maskName', () => {
+  it('keeps only the first letter of each word', () => {
+    expect(maskName('John Doe')).toBe('J*** D***');
+  });
+
+  it('handles single-word names', () => {
+    expect(maskName('Alice')).toBe('A***');
+  });
+
+  it('handles extra whitespace between words', () => {
+    expect(maskName('  Jane   Smith  ')).toBe('J*** S***');
+  });
+
+  it('returns null/undefined as-is', () => {
+    expect(maskName(null)).toBeNull();
+    expect(maskName(undefined)).toBeUndefined();
+  });
+
+  it('returns non-string values as-is', () => {
+    expect(maskName(42)).toBe(42);
+  });
+});
+
+describe('maskToken', () => {
+  it('shows only the first 8 characters followed by ellipsis', () => {
+    expect(maskToken('eyJhbGciOiJIUzI1NiJ9.rest')).toBe('eyJhbGci...');
+  });
+
+  it('returns [REDACTED] for short tokens', () => {
+    expect(maskToken('short')).toBe('[REDACTED]');
+    expect(maskToken('12345678')).toBe('[REDACTED]');
+  });
+
+  it('returns [REDACTED] for falsy values', () => {
+    expect(maskToken(null)).toBe('[REDACTED]');
+    expect(maskToken('')).toBe('[REDACTED]');
+    expect(maskToken(undefined)).toBe('[REDACTED]');
+  });
+});
+
+describe('maskStudentId', () => {
+  it('shows first two and last two characters', () => {
+    expect(maskStudentId('S1234567')).toBe('S1***67');
+  });
+
+  it('returns *** for short IDs (4 chars or fewer)', () => {
+    expect(maskStudentId('S123')).toBe('***');
+    expect(maskStudentId('AB')).toBe('***');
+  });
+
+  it('returns null/undefined as-is', () => {
+    expect(maskStudentId(null)).toBeNull();
+    expect(maskStudentId(undefined)).toBeUndefined();
+  });
+});
+
+describe('redactMeta', () => {
+  it('fully redacts password fields', () => {
+    const meta = { password: 'secret123', currentPassword: 'old', newPassword: 'new' };
+    const result = redactMeta(meta);
+    expect(result.password).toBe('[REDACTED]');
+    expect(result.currentPassword).toBe('[REDACTED]');
+    expect(result.newPassword).toBe('[REDACTED]');
+  });
+
+  it('masks token fields', () => {
+    const token = 'eyJhbGciOiJIUzI1NiJ9.rest';
+    const result = redactMeta({ token, accessToken: token });
+    expect(result.token).toBe('eyJhbGci...');
+    expect(result.accessToken).toBe('eyJhbGci...');
+  });
+
+  it('masks email field', () => {
+    const result = redactMeta({ email: 'alice@example.com', action: 'login' });
+    expect(result.email).toBe('al***e@example.com');
+    expect(result.action).toBe('login');
+  });
+
+  it('masks firstName and lastName fields', () => {
+    const result = redactMeta({ firstName: 'Alice', lastName: 'Smith' });
+    expect(result.firstName).toBe('A***');
+    expect(result.lastName).toBe('S***');
+  });
+
+  it('masks studentId field', () => {
+    const result = redactMeta({ studentId: 'S9876543' });
+    expect(result.studentId).toBe('S9***43');
+  });
+
+  it('leaves unrecognised fields unchanged', () => {
+    const result = redactMeta({ role: 'admin', userId: 'abc-123', status: 200 });
+    expect(result).toEqual({ role: 'admin', userId: 'abc-123', status: 200 });
+  });
+
+  it('does not mutate the original object', () => {
+    const original = { password: 'secret', email: 'test@test.com' };
+    redactMeta(original);
+    expect(original.password).toBe('secret');
+    expect(original.email).toBe('test@test.com');
+  });
+
+  it('returns non-objects as-is', () => {
+    expect(redactMeta(null)).toBeNull();
+    expect(redactMeta('string')).toBe('string');
+    expect(redactMeta([1, 2])).toEqual([1, 2]);
+  });
+});

--- a/deployment/docker/docker-compose.yaml
+++ b/deployment/docker/docker-compose.yaml
@@ -80,6 +80,8 @@ services:
     build:
       context: ../../frontend
       dockerfile: Dockerfile
+      args:
+        GIT_HASH: ${GIT_HASH:-unknown}
     container_name: gap-frontend
     depends_on:
       - backend

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -68,6 +68,7 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+      - ./.git:/app/.git:ro
 
 volumes:
   postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,10 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# GIT_HASH injected by CI/CD via --build-arg; defaults to 'unknown'
+ARG GIT_HASH=unknown
+ENV GIT_HASH=${GIT_HASH}
+
 # Build application
 RUN npm run build
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,6 +2,8 @@ FROM node:24-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 # Install all dependencies
 COPY package*.json ./
 RUN npm ci

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -1,0 +1,143 @@
+/**
+ * PII-safe frontend logger.
+ *
+ * Wraps the browser console and sanitises known PII fields before they are
+ * written to developer tools or any log forwarding service. Use this instead
+ * of raw `console.*` calls throughout the application.
+ *
+ * Only logs in development; all output is suppressed in production builds.
+ */
+
+// ---------------------------------------------------------------------------
+// PII masking utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Masks an email address, keeping the first two chars of the local part and
+ * the full domain.
+ *
+ * Example: john.doe@example.com → jo***e@example.com
+ */
+export function maskEmail(email) {
+  if (!email || typeof email !== 'string') {
+    return email;
+  }
+  const atIdx = email.indexOf('@');
+  if (atIdx < 0) {
+    return '***@***';
+  }
+  const local = email.slice(0, atIdx);
+  const domain = email.slice(atIdx + 1);
+  if (local.length <= 2) {
+    return `${local}@${domain}`;
+  }
+  return `${local.slice(0, 2)}***${local.slice(-1)}@${domain}`;
+}
+
+/**
+ * Masks a full name, keeping only the first letter of each word.
+ *
+ * Example: "John Doe" → "J*** D***"
+ */
+export function maskName(name) {
+  if (!name || typeof name !== 'string') {
+    return name;
+  }
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((part) => (part.length > 0 ? `${part[0]}***` : ''))
+    .join(' ');
+}
+
+/**
+ * Masks an access or JWT token, keeping only the first 8 characters.
+ *
+ * Example: "eyJhbGci..." → "eyJhbGci..."
+ */
+export function maskToken(token) {
+  if (!token || typeof token !== 'string') {
+    return '[REDACTED]';
+  }
+  return token.length > 8 ? `${token.slice(0, 8)}...` : '[REDACTED]';
+}
+
+/**
+ * Masks a student ID, keeping the first two and last two characters.
+ *
+ * Example: "S1234567" → "S1***67"
+ */
+export function maskStudentId(id) {
+  if (!id || typeof id !== 'string') {
+    return id;
+  }
+  return id.length > 4 ? `${id.slice(0, 2)}***${id.slice(-2)}` : '***';
+}
+
+// Fields that are always fully redacted
+const REDACT_FIELDS = new Set([
+  'password',
+  'currentPassword',
+  'newPassword',
+  'token',
+  'accessToken',
+  'refreshToken',
+  'authorization',
+]);
+
+/**
+ * Returns a shallow-cloned copy of `meta` with known PII fields redacted or
+ * masked. Safe to pass to any console method.
+ */
+export function sanitizeMeta(meta) {
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return meta;
+  }
+  const safe = { ...meta };
+  /* eslint-disable security/detect-object-injection */
+  for (const key of Object.keys(safe)) {
+    if (REDACT_FIELDS.has(key)) {
+      safe[key] = '[REDACTED]';
+    } else if (key === 'email') {
+      safe[key] = maskEmail(safe[key]);
+    } else if (key === 'firstName' || key === 'lastName' || key === 'fullName' || key === 'name') {
+      safe[key] = maskName(safe[key]);
+    } else if (key === 'studentId') {
+      safe[key] = maskStudentId(String(safe[key]));
+    }
+  }
+  /* eslint-enable security/detect-object-injection */
+  return safe;
+}
+
+// ---------------------------------------------------------------------------
+// Logger — only active in development builds
+//
+// Note: import.meta.env.DEV is evaluated at call time (not module load time)
+// so that test helpers can toggle process.env.DEV to control logger output.
+// ---------------------------------------------------------------------------
+
+/* eslint-disable no-console */
+export const logger = {
+  info: (msg, meta) => {
+    if (import.meta.env.DEV) {
+      console.info(msg, meta !== undefined ? sanitizeMeta(meta) : '');
+    }
+  },
+  warn: (msg, meta) => {
+    if (import.meta.env.DEV) {
+      console.warn(msg, meta !== undefined ? sanitizeMeta(meta) : '');
+    }
+  },
+  error: (msg, meta) => {
+    if (import.meta.env.DEV) {
+      console.error(msg, meta !== undefined ? sanitizeMeta(meta) : '');
+    }
+  },
+  debug: (msg, meta) => {
+    if (import.meta.env.DEV) {
+      console.debug(msg, meta !== undefined ? sanitizeMeta(meta) : '');
+    }
+  },
+};
+/* eslint-enable no-console */

--- a/frontend/src/utils/logger.js
+++ b/frontend/src/utils/logger.js
@@ -103,7 +103,7 @@ export function sanitizeMeta(meta) {
     } else if (key === 'firstName' || key === 'lastName' || key === 'fullName' || key === 'name') {
       safe[key] = maskName(safe[key]);
     } else if (key === 'studentId') {
-      safe[key] = maskStudentId(String(safe[key]));
+      safe[key] = maskStudentId(safe[key]);
     }
   }
   /* eslint-enable security/detect-object-injection */
@@ -113,8 +113,9 @@ export function sanitizeMeta(meta) {
 // ---------------------------------------------------------------------------
 // Logger — only active in development builds
 //
-// Note: import.meta.env.DEV is evaluated at call time (not module load time)
-// so that test helpers can toggle process.env.DEV to control logger output.
+// Note: in Vite builds, import.meta.env.DEV is inlined at compile time, not
+// read dynamically at runtime. In Jest, the Babel transform rewrites
+// import.meta.env to process.env, so tests can toggle it via process.env.DEV.
 // ---------------------------------------------------------------------------
 
 /* eslint-disable no-console */

--- a/frontend/tests/unit/utils/logger.test.js
+++ b/frontend/tests/unit/utils/logger.test.js
@@ -1,0 +1,209 @@
+import { maskEmail, maskName, maskToken, sanitizeMeta, logger } from '@/utils/logger';
+
+describe('maskEmail', () => {
+  it('masks middle chars, keeps first two and last char of local part plus domain', () => {
+    expect(maskEmail('john.doe@example.com')).toBe('jo***e@example.com');
+  });
+
+  it('keeps short local parts (2 chars or fewer) unchanged', () => {
+    expect(maskEmail('ab@test.com')).toBe('ab@test.com');
+    expect(maskEmail('a@test.com')).toBe('a@test.com');
+  });
+
+  it('masks a 3-char local part', () => {
+    expect(maskEmail('joe@test.com')).toBe('jo***e@test.com');
+  });
+
+  it('returns *** for strings without @', () => {
+    expect(maskEmail('noatsign')).toBe('***@***');
+  });
+
+  it('returns null/undefined as-is', () => {
+    expect(maskEmail(null)).toBeNull();
+    expect(maskEmail(undefined)).toBeUndefined();
+  });
+});
+
+describe('maskName', () => {
+  it('keeps only the first letter of each word', () => {
+    expect(maskName('John Doe')).toBe('J*** D***');
+  });
+
+  it('handles single-word names', () => {
+    expect(maskName('Alice')).toBe('A***');
+  });
+
+  it('handles names with extra whitespace', () => {
+    expect(maskName('  Jane   Smith  ')).toBe('J*** S***');
+  });
+
+  it('returns null/undefined as-is', () => {
+    expect(maskName(null)).toBeNull();
+    expect(maskName(undefined)).toBeUndefined();
+  });
+});
+
+describe('maskToken', () => {
+  it('shows only the first 8 characters followed by ellipsis', () => {
+    expect(maskToken('eyJhbGciOiJIUzI1NiJ9.rest')).toBe('eyJhbGci...');
+  });
+
+  it('returns [REDACTED] for tokens shorter than 9 chars', () => {
+    expect(maskToken('12345678')).toBe('[REDACTED]');
+    expect(maskToken('short')).toBe('[REDACTED]');
+  });
+
+  it('returns [REDACTED] for falsy values', () => {
+    expect(maskToken(null)).toBe('[REDACTED]');
+    expect(maskToken('')).toBe('[REDACTED]');
+    expect(maskToken(undefined)).toBe('[REDACTED]');
+  });
+});
+
+describe('sanitizeMeta', () => {
+  it('fully redacts password fields', () => {
+    const meta = { password: 'secret', currentPassword: 'old', newPassword: 'new' };
+    expect(sanitizeMeta(meta)).toEqual({
+      password: '[REDACTED]',
+      currentPassword: '[REDACTED]',
+      newPassword: '[REDACTED]',
+    });
+  });
+
+  it('fully redacts token fields', () => {
+    const token = 'eyJhbGciOiJIUzI1NiJ9.rest';
+    const result = sanitizeMeta({ token, accessToken: token });
+    expect(result.token).toBe('[REDACTED]');
+    expect(result.accessToken).toBe('[REDACTED]');
+  });
+
+  it('masks email', () => {
+    const result = sanitizeMeta({ email: 'alice@example.com', action: 'login' });
+    expect(result.email).toBe('al***e@example.com');
+    expect(result.action).toBe('login');
+  });
+
+  it('masks firstName, lastName, fullName, and name fields', () => {
+    const result = sanitizeMeta({
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      name: 'Bob Jones',
+    });
+    expect(result.firstName).toBe('A***');
+    expect(result.lastName).toBe('S***');
+    expect(result.fullName).toBe('A*** S***');
+    expect(result.name).toBe('B*** J***');
+  });
+
+  it('masks studentId', () => {
+    const result = sanitizeMeta({ studentId: 'S9876543' });
+    expect(result.studentId).toBe('S9***43');
+  });
+
+  it('masks short studentId with ***', () => {
+    const result = sanitizeMeta({ studentId: 'S123' });
+    expect(result.studentId).toBe('***');
+  });
+
+  it('leaves unrecognised fields unchanged', () => {
+    const result = sanitizeMeta({ role: 'admin', userId: 'abc-123', status: 200 });
+    expect(result).toEqual({ role: 'admin', userId: 'abc-123', status: 200 });
+  });
+
+  it('does not mutate the original object', () => {
+    const original = { password: 'secret', email: 'test@test.com' };
+    sanitizeMeta(original);
+    expect(original.password).toBe('secret');
+    expect(original.email).toBe('test@test.com');
+  });
+
+  it('returns non-objects as-is', () => {
+    expect(sanitizeMeta(null)).toBeNull();
+    expect(sanitizeMeta('string')).toBe('string');
+    expect(sanitizeMeta([1, 2])).toEqual([1, 2]);
+  });
+});
+
+describe('logger (dev mode)', () => {
+  const origDev = process.env.DEV;
+
+  beforeAll(() => {
+    process.env.DEV = 'true';
+  });
+
+  afterAll(() => {
+    process.env.DEV = origDev;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls console.info for info level', () => {
+    logger.info('test message');
+    expect(console.info).toHaveBeenCalledWith('test message', '');
+  });
+
+  it('calls console.warn for warn level', () => {
+    logger.warn('warn message');
+    expect(console.warn).toHaveBeenCalledWith('warn message', '');
+  });
+
+  it('calls console.error for error level', () => {
+    logger.error('error message');
+    expect(console.error).toHaveBeenCalledWith('error message', '');
+  });
+
+  it('sanitizes PII in meta before logging', () => {
+    logger.info('login attempt', { email: 'user@example.com', password: 'secret' });
+    expect(console.info).toHaveBeenCalledWith('login attempt', {
+      email: 'us***r@example.com',
+      password: '[REDACTED]',
+    });
+  });
+});
+
+describe('logger (production mode)', () => {
+  const origDev = process.env.DEV;
+
+  beforeAll(() => {
+    delete process.env.DEV;
+  });
+
+  afterAll(() => {
+    process.env.DEV = origDev;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('suppresses info in production', () => {
+    logger.info('should not appear');
+    expect(console.info).not.toHaveBeenCalled();
+  });
+
+  it('suppresses warn in production', () => {
+    logger.warn('should not appear');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('suppresses error in production', () => {
+    logger.error('should not appear');
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/utils/logger.test.js
+++ b/frontend/tests/unit/utils/logger.test.js
@@ -133,7 +133,11 @@ describe('logger (dev mode)', () => {
   });
 
   afterAll(() => {
-    process.env.DEV = origDev;
+    if (origDev === undefined) {
+      delete process.env.DEV;
+    } else {
+      process.env.DEV = origDev;
+    }
   });
 
   beforeEach(() => {
@@ -179,7 +183,11 @@ describe('logger (production mode)', () => {
   });
 
   afterAll(() => {
-    process.env.DEV = origDev;
+    if (origDev === undefined) {
+      delete process.env.DEV;
+    } else {
+      process.env.DEV = origDev;
+    }
   });
 
   beforeEach(() => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
-/* eslint-disable no-undef */
+/* global process */
 function resolveGitHash() {
   if (process.env.GIT_HASH) {
     return process.env.GIT_HASH;
@@ -18,7 +18,6 @@ function resolveGitHash() {
     return 'unknown';
   }
 }
-/* eslint-enable no-undef */
 
 const gitHash = resolveGitHash();
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,13 +4,23 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
-const gitHash = (() => {
+/* eslint-disable no-undef */
+function resolveGitHash() {
+  if (process.env.GIT_HASH) {
+    return process.env.GIT_HASH;
+  }
+  if (process.env.NODE_ENV === 'production') {
+    return 'unknown';
+  }
   try {
     return execSync('git rev-parse --short HEAD').toString().trim();
   } catch {
     return 'unknown';
   }
-})();
+}
+/* eslint-enable no-undef */
+
+const gitHash = resolveGitHash();
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary

- **Backend logger** (`backend/src/utils/logger.js`): New PII-aware structured logger with masking for email, name, token, and student ID. Replaces all `console.*` calls across routes. Suppressed in test env via `isSilent()` evaluated at call time so `NODE_ENV` changes in tests take effect.
- **Frontend logger** (`frontend/src/utils/logger.js`): ESM equivalent — dev-only output, same PII masking helpers, `import.meta.env.DEV` checked at call time for testability.
- **Access logging** (`backend/src/server.js`): `onRequest`/`onResponse` hooks emit structured lines (method, URL, status, IP, duration, userId, role). Log injection fixed — `request.url` stripped of `\r`, `\n`, `\x1b` before embedding in log line.
- **Email logging** (`backend/src/services/email.js`): Dev path logs masked recipient only (subject removed to avoid PII leakage). Prod path logs masked recipient after successful send.
- **Git hash in Docker**: Dev container installs git + mounts `.git` read-only so Vite's `resolveGitHash()` works via `execSync`. Prod build receives `GIT_HASH` build arg from CI (short SHA extracted in workflow). `vite.config.js` handles all cases: env var → production guard → `execSync` fallback.
- **Security fixes**: Log injection via `request.url` and `u.username` (username moved to structured JSON metadata). Email subject removed from dev log.
- **ESLint**: Replaced `/* eslint-disable no-undef */` block in `vite.config.js` with `/* global process */` — the correct flat-config approach.

## Test plan

- [ ] Backend unit tests pass: `cd backend && npx jest --coverage`
- [ ] Frontend unit tests pass: `cd frontend && npx jest --coverage`
- [ ] Logger unit tests cover all masking functions and output paths (backend: 33 tests, frontend: 28 tests)
- [ ] Lint passes with zero warnings: `npm run lint`
- [ ] Dev container: start with `docker compose -f docker-compose.dev.yaml up` and confirm git hash appears in UI footer
- [ ] Prod build: pass `GIT_HASH=$(git rev-parse --short HEAD)` as build arg and confirm hash in built assets
- [ ] Integration tests: `cd backend && npx jest --config jest.integration.config.js` — confirm no open handle warnings