### PR TITLE
fix: remove unused authenticate decorator

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -46,16 +46,6 @@ async function buildServer({ logger: disableLogger } = {}) {
   await fastify.register(authPlugin);
   await fastify.register(rbacPlugin);
 
-  // JWT decorator for token verification
-  fastify.decorate('authenticate', async (request, reply) => {
-    try {
-      await request.jwtVerify();
-    } catch (err) {
-      reply.code(401).send({ error: 'Unauthorized', message: err.message });
-      throw err;
-    }
-  });
-
   // Access logging — record start time on every request
   fastify.addHook('onRequest', async (request) => {
     request._startTime = Date.now();


### PR DESCRIPTION
## Summary
- Removes the dead `authenticate` decorator from `backend/src/server.js`
- The decorator wrapped `jwtVerify()` but was never referenced in any route — all routes use `verifyToken` (from the auth plugin) via inline `preHandler` logic

## Test plan
- [x] All 502 existing tests pass (`npm run test:quiet`)
- [x] Linter passes with zero warnings (`npm run lint`)

Closes #60