### PR TITLE
fix: replace global axios with dedicated instance

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -11,4 +11,3 @@ Dockerfile.dev
 .dockerignore
 eslint.config.js
 jest.config.cjs
-vite.config.js

--- a/frontend/src/components/UserMenu.jsx
+++ b/frontend/src/components/UserMenu.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, UserCircle } from 'lucide-react';
-import axios from 'axios';
+import api from '@/utils/api';
 import { useAuth } from '../context/AuthContext.jsx';
 import { formatRoleName } from '../utils/formatting.js';
 import { parseBody, updateUserSchema, newPasswordSchema } from '../utils/schemas.js';
@@ -90,7 +90,7 @@ function UserMenu() {
 
     setProfileSaving(true);
     try {
-      await axios.put(`${API_BASE}/users/${user.id}`, body);
+      await api.put(`${API_BASE}/users/${user.id}`, body);
       await refreshUser();
       setProfileSuccess('Profile updated successfully');
       clearTimeout(dismissTimerRef.current);
@@ -121,7 +121,7 @@ function UserMenu() {
 
     setPasswordSaving(true);
     try {
-      await axios.put(`${API_BASE}/users/${user.id}/password`, {
+      await api.put(`${API_BASE}/users/${user.id}/password`, {
         currentPassword: passwordForm.currentPassword,
         newPassword: passwordForm.newPassword,
       });

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '../utils/api';
 import { API_BASE } from '../config.js';
 
 const AuthContext = createContext(null);
@@ -12,20 +12,11 @@ export function AuthProvider({ children }) {
 
   // Fetch server config on mount
   useEffect(() => {
-    axios
+    api
       .get(`${API_BASE}/auth/config`)
       .then((res) => setRegistrationEnabled(res.data.registrationEnabled))
       .catch(() => setRegistrationEnabled(false));
   }, []);
-
-  // Configure axios defaults
-  useEffect(() => {
-    if (token) {
-      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-    } else {
-      delete axios.defaults.headers.common['Authorization'];
-    }
-  }, [token]);
 
   // Check if user is logged in on mount
   useEffect(() => {
@@ -36,7 +27,7 @@ export function AuthProvider({ children }) {
       }
 
       try {
-        const response = await axios.get(`${API_BASE}/auth/me`);
+        const response = await api.get(`${API_BASE}/auth/me`);
         setUser(response.data.user);
       } catch (_error) {
         // Token invalid, clear it
@@ -53,7 +44,7 @@ export function AuthProvider({ children }) {
 
   const login = async (username, password) => {
     try {
-      const response = await axios.post(`${API_BASE}/auth/login`, {
+      const response = await api.post(`${API_BASE}/auth/login`, {
         username,
         password,
       });
@@ -75,7 +66,7 @@ export function AuthProvider({ children }) {
 
   const register = async (username, email, password, { firstName, lastName, studentId } = {}) => {
     try {
-      const response = await axios.post(`${API_BASE}/auth/register`, {
+      const response = await api.post(`${API_BASE}/auth/register`, {
         username,
         email,
         password,
@@ -96,7 +87,7 @@ export function AuthProvider({ children }) {
 
   const logout = async () => {
     try {
-      await axios.post(`${API_BASE}/auth/logout`);
+      await api.post(`${API_BASE}/auth/logout`);
     } catch (_error) {
       // Ignore errors on logout
     } finally {
@@ -108,7 +99,7 @@ export function AuthProvider({ children }) {
 
   const refreshUser = async () => {
     try {
-      const response = await axios.get(`${API_BASE}/auth/me`);
+      const response = await api.get(`${API_BASE}/auth/me`);
       setUser(response.data.user);
     } catch (_error) {
       // If refresh fails, clear auth state

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import api from '../utils/api';
+import api from '@/utils/api';
 import { API_BASE } from '../config.js';
 
 const AuthContext = createContext(null);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '@/utils/api';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
 import { Link } from 'react-router-dom';
@@ -33,7 +33,7 @@ function Dashboard() {
     if (isNormalUser) {
       (async () => {
         try {
-          const res = await axios.get(`${API_BASE}/config/group-join-locked`);
+          const res = await api.get(`${API_BASE}/config/group-join-locked`);
           setGroupJoinLocked(res.data.locked === true);
         } catch (_err) {
           // silently ignore — lock defaults to off
@@ -46,7 +46,7 @@ function Dashboard() {
     setMembersLoading(true);
     setGroupMembers([]);
     try {
-      const response = await axios.get(`${API_BASE}/groups/${groupId}`);
+      const response = await api.get(`${API_BASE}/groups/${groupId}`);
       setGroupMembers(response.data.members || []);
     } catch (_err) {
       // silently ignore — members list is supplementary info
@@ -58,7 +58,7 @@ function Dashboard() {
   const fetchAvailableGroups = async () => {
     setGroupsLoading(true);
     try {
-      const response = await axios.get(`${API_BASE}/groups/enabled`);
+      const response = await api.get(`${API_BASE}/groups/enabled`);
       const groups = response.data.groups || [];
       setAvailableGroups(groups.filter((g) => g.max_members === null || g.member_count < g.max_members));
     } catch (_err) {
@@ -72,7 +72,7 @@ function Dashboard() {
   const handleJoinGroup = async (groupId) => {
     setJoiningGroup(true);
     try {
-      await axios.post(`${API_BASE}/groups/${groupId}/join`);
+      await api.post(`${API_BASE}/groups/${groupId}/join`);
       setGroupSuccess('Successfully joined group');
       await refreshUser();
       setTimeout(() => setGroupSuccess(''), 2000);
@@ -102,7 +102,7 @@ function Dashboard() {
     }
     setLeavingGroup(true);
     try {
-      await axios.post(`${API_BASE}/groups/${user.groupId}/leave`);
+      await api.post(`${API_BASE}/groups/${user.groupId}/leave`);
       setGroupSuccess('Successfully left group');
       await refreshUser();
       setTimeout(() => setGroupSuccess(''), 2000);

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { forgotPasswordSchema, parseBody } from '../utils/schemas.js';
 import { API_BASE } from '../config.js';
 
@@ -23,7 +23,7 @@ function ForgotPassword() {
 
     setLoading(true);
     try {
-      const response = await axios.post(`${API_BASE}/auth/forgot-password`, { email: body.email });
+      const response = await api.post(`${API_BASE}/auth/forgot-password`, { email: body.email });
       setSuccess(response.data.message || 'If that email is registered, a reset link has been sent.');
     } catch (_err) {
       // Show generic message even on error to avoid leaking information

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
 import { formatRoleName } from '../utils/formatting.js';
@@ -96,7 +96,7 @@ function Groups() {
 
   const fetchGroups = async () => {
     try {
-      const response = await axios.get(`${API_BASE}/groups`);
+      const response = await api.get(`${API_BASE}/groups`);
       setGroups(response.data.groups || []);
     } catch (_err) {
       setError('Failed to load groups');
@@ -108,7 +108,7 @@ function Groups() {
   const handleExportMappings = async () => {
     setExporting(true);
     try {
-      const response = await axios.get(`${API_BASE}/groups/export-mappings`);
+      const response = await api.get(`${API_BASE}/groups/export-mappings`);
       const { mappings } = response.data;
       const today = new Date().toISOString().slice(0, 10);
       downloadCsv(mappings, ['groupName', 'email'], `group-mappings-${today}.csv`);
@@ -178,7 +178,7 @@ function Groups() {
       if (newGroupMaxMembers !== '') {
         requestBody.maxMembers = parseInt(newGroupMaxMembers, 10);
       }
-      await axios.post(`${API_BASE}/groups`, requestBody);
+      await api.post(`${API_BASE}/groups`, requestBody);
       showSuccess('Group created successfully');
       setNewGroupName('');
       setNewGroupMaxMembers('');
@@ -222,7 +222,7 @@ function Groups() {
 
     setSaving(true);
     try {
-      await axios.put(`${API_BASE}/groups/${editingGroup.id}`, {
+      await api.put(`${API_BASE}/groups/${editingGroup.id}`, {
         name: body.name,
         maxMembers,
       });
@@ -239,7 +239,7 @@ function Groups() {
   const handleToggleEnabled = async (e, groupId, currentEnabled) => {
     e.stopPropagation();
     try {
-      await axios.put(`${API_BASE}/groups/${groupId}`, { enabled: !currentEnabled });
+      await api.put(`${API_BASE}/groups/${groupId}`, { enabled: !currentEnabled });
       showSuccess(`Group ${currentEnabled ? 'disabled' : 'enabled'} successfully`);
       fetchGroups();
     } catch (err) {
@@ -272,7 +272,7 @@ function Groups() {
       return;
     }
     try {
-      await Promise.all(groupIds.map((id) => axios.put(`${API_BASE}/groups/${id}`, { maxMembers })));
+      await Promise.all(groupIds.map((id) => api.put(`${API_BASE}/groups/${id}`, { maxMembers })));
       showSuccess(groupIds.length === 1 ? 'Group limit updated' : `Updated limit for ${groupIds.length} groups`);
       setLimitModal(null);
       fetchGroups();
@@ -317,7 +317,7 @@ function Groups() {
     for (let batchIndex = 0; batchIndex < allGroups.length; batchIndex += BULK_BATCH_SIZE) {
       const batch = allGroups.slice(batchIndex, batchIndex + BULK_BATCH_SIZE);
       try {
-        await axios.post(`${API_BASE}/groups/bulk`, batch);
+        await api.post(`${API_BASE}/groups/bulk`, batch);
         totalCreated += batch.length;
       } catch (err) {
         if (firstError === null) {
@@ -364,12 +364,12 @@ function Groups() {
     setDeleting(true);
     try {
       if (toDelete.length === 1) {
-        await axios.delete(`${API_BASE}/groups/${toDelete[0].id}`);
+        await api.delete(`${API_BASE}/groups/${toDelete[0].id}`);
       } else {
         const ids = toDelete.map((g) => g.id);
         for (let i = 0; i < ids.length; i += BULK_DELETE_BATCH_SIZE) {
           const batch = ids.slice(i, i + BULK_DELETE_BATCH_SIZE);
-          await axios.delete(`${API_BASE}/groups/bulk`, { data: { ids: batch } });
+          await api.delete(`${API_BASE}/groups/bulk`, { data: { ids: batch } });
         }
       }
       showSuccess(toDelete.length === 1 ? 'Group deleted successfully' : `Deleted ${toDelete.length} groups`);
@@ -397,8 +397,8 @@ function Groups() {
     setMembersLoading(true);
     try {
       const [groupRes, usersRes] = await Promise.all([
-        axios.get(`${API_BASE}/groups/${groupId}`),
-        isAssignmentManager ? axios.get(`${API_BASE}/users`) : Promise.resolve({ data: { users: [] } }),
+        api.get(`${API_BASE}/groups/${groupId}`),
+        isAssignmentManager ? api.get(`${API_BASE}/users`) : Promise.resolve({ data: { users: [] } }),
       ]);
       if (expandedGroupRef.current !== groupId) {
         return;
@@ -433,7 +433,7 @@ function Groups() {
   const handleRemoveMember = async (userId) => {
     const groupId = expandedGroup;
     try {
-      await axios.put(`${API_BASE}/users/${userId}/group`, { groupId: null });
+      await api.put(`${API_BASE}/users/${userId}/group`, { groupId: null });
       showSuccess('Member removed successfully');
       if (groupId) {
         fetchGroupMembers(groupId);
@@ -450,7 +450,7 @@ function Groups() {
     }
     const groupId = expandedGroup;
     try {
-      await axios.put(`${API_BASE}/users/${selectedUserId}/group`, { groupId });
+      await api.put(`${API_BASE}/users/${selectedUserId}/group`, { groupId });
       showSuccess('Member added successfully');
       setSelectedUserId('');
       if (groupId) {

--- a/frontend/src/pages/ImportGroupMappings.jsx
+++ b/frontend/src/pages/ImportGroupMappings.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { ArrowLeft, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import Header from '../components/Header.jsx';
 import CsvDropzone from '../components/CsvDropzone.jsx';
@@ -98,10 +98,7 @@ function ImportGroupMappings() {
   const buildPreview = async () => {
     setLoadingPreview(true);
     try {
-      const [usersRes, groupsRes] = await Promise.all([
-        axios.get(`${API_BASE}/users`),
-        axios.get(`${API_BASE}/groups`),
-      ]);
+      const [usersRes, groupsRes] = await Promise.all([api.get(`${API_BASE}/users`), api.get(`${API_BASE}/groups`)]);
       const userEmailSet = new Map((usersRes.data.users || []).map((u) => [u.email.toLowerCase(), u]));
       const groupNameSet = new Map((groupsRes.data.groups || []).map((g) => [g.name.toLowerCase(), g]));
 
@@ -198,7 +195,7 @@ function ImportGroupMappings() {
         action: r.action,
         skipReason: r.skipReason,
       }));
-      const res = await axios.post(`${API_BASE}/groups/import-mappings`, { rows });
+      const res = await api.post(`${API_BASE}/groups/import-mappings`, { rows });
       setImportResult(res.data);
 
       // Auto-download skipped rows CSV

--- a/frontend/src/pages/ImportUsers.jsx
+++ b/frontend/src/pages/ImportUsers.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { ArrowLeft, ArrowRight, Check, AlertTriangle, ChevronDown } from 'lucide-react';
 import Header from '../components/Header.jsx';
 import CsvDropzone from '../components/CsvDropzone.jsx';
@@ -352,7 +352,7 @@ export default function ImportUsers() {
     setPreviewLoading(true);
     setPreviewError('');
     try {
-      const res = await axios.get(`${API_BASE}/users`);
+      const res = await api.get(`${API_BASE}/users`);
       const existing = res.data.users || [];
       const byUname = new Map(existing.map((u) => [u.username?.toLowerCase(), u]));
       const byMail = new Map(existing.map((u) => [u.email?.toLowerCase(), u]));
@@ -449,7 +449,7 @@ export default function ImportUsers() {
           return clean;
         });
 
-      const res = await axios.post(`${API_BASE}/users/import`, {
+      const res = await api.post(`${API_BASE}/users/import`, {
         users: validUsers,
         conflictAction,
         sendSetupEmail,

--- a/frontend/src/pages/SetPassword.jsx
+++ b/frontend/src/pages/SetPassword.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { setPasswordSchema, parseBody } from '../utils/schemas.js';
 import { API_BASE } from '../config.js';
 
@@ -35,7 +35,7 @@ function SetPassword() {
 
     setLoading(true);
     try {
-      const response = await axios.post(`${API_BASE}/auth/set-password`, { token, password });
+      const response = await api.post(`${API_BASE}/auth/set-password`, { token, password });
       setSuccess(response.data.message || 'Password set successfully. You can now log in.');
       setTimeout(() => navigate('/login'), 2500);
     } catch (err) {

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '@/utils/api';
 import Header from '../components/Header.jsx';
 import { API_BASE } from '../config.js';
 
@@ -11,7 +11,7 @@ function Settings() {
   const [success, setSuccess] = useState('');
 
   useEffect(() => {
-    axios
+    api
       .get(`${API_BASE}/config`)
       .then((res) => {
         const rows = res.data.config || [];
@@ -28,7 +28,7 @@ function Settings() {
     setSuccess('');
     const newValue = !groupJoinLocked;
     try {
-      await axios.put(`${API_BASE}/config/group_join_locked`, { value: String(newValue) });
+      await api.put(`${API_BASE}/config/group_join_locked`, { value: String(newValue) });
       setGroupJoinLocked(newValue);
       setSuccess('Settings updated successfully');
       setTimeout(() => setSuccess(''), 2000);

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import { Pencil, UserPlus, Check, X, Download, Trash2, Upload, Mail } from 'lucide-react';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
@@ -76,8 +76,8 @@ function Users() {
   const fetchData = async () => {
     try {
       const [usersRes, groupsRes] = await Promise.all([
-        axios.get(`${API_BASE}/users`),
-        axios.get(`${API_BASE}/groups/enabled`),
+        api.get(`${API_BASE}/users`),
+        api.get(`${API_BASE}/groups/enabled`),
       ]);
       setUsers(usersRes.data.users || []);
       setGroups(groupsRes.data.groups || []);
@@ -90,7 +90,7 @@ function Users() {
 
   const handleGroupChange = async (userId, groupId) => {
     try {
-      await axios.put(`${API_BASE}/users/${userId}/group`, { groupId });
+      await api.put(`${API_BASE}/users/${userId}/group`, { groupId });
       showSuccess('User group updated successfully');
       fetchData();
     } catch (err) {
@@ -121,7 +121,7 @@ function Users() {
 
     setCreating(true);
     try {
-      await axios.post(`${API_BASE}/users`, {
+      await api.post(`${API_BASE}/users`, {
         username: body.username,
         email: body.email,
         firstName: body.firstName || undefined,
@@ -195,7 +195,7 @@ function Users() {
         payload.enabled = body.enabled;
       }
 
-      await axios.put(`${API_BASE}/users/${editingUser.id}`, payload);
+      await api.put(`${API_BASE}/users/${editingUser.id}`, payload);
       showSuccess('User updated successfully');
       setEditingUser(null);
       fetchData();
@@ -282,7 +282,7 @@ function Users() {
     setDeleting(true);
     try {
       if (toDelete.length === 1) {
-        await axios.delete(`${API_BASE}/users/${toDelete[0].id}`);
+        await api.delete(`${API_BASE}/users/${toDelete[0].id}`);
         showSuccess('User deleted successfully');
         setSelectedIds((prev) => {
           const next = new Set(prev);
@@ -294,7 +294,7 @@ function Users() {
         const BULK_DELETE_BATCH_SIZE = 2000;
         for (let i = 0; i < ids.length; i += BULK_DELETE_BATCH_SIZE) {
           const batch = ids.slice(i, i + BULK_DELETE_BATCH_SIZE);
-          await axios.delete(`${API_BASE}/users/bulk`, { data: { ids: batch } });
+          await api.delete(`${API_BASE}/users/bulk`, { data: { ids: batch } });
         }
         showSuccess(`Deleted ${toDelete.length} users`);
         setSelectedIds((prev) => {
@@ -325,7 +325,7 @@ function Users() {
     setSendingEmails(true);
     try {
       const body = selectedIds.size > 0 ? { userIds: targets.map((u) => u.id) } : {};
-      const res = await axios.post(`${API_BASE}/users/send-setup-emails`, body);
+      const res = await api.post(`${API_BASE}/users/send-setup-emails`, body);
       const { sent = 0, errors: emailErrors = [] } = res.data || {};
       const failedCount = emailErrors.length;
       if (sent > 0 && failedCount === 0) {

--- a/frontend/src/utils/__mocks__/api.js
+++ b/frontend/src/utils/__mocks__/api.js
@@ -1,0 +1,10 @@
+/* global jest */
+const api = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
+};
+
+export default api;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const api = axios.create();
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/frontend/tests/unit/components/UserMenu.test.jsx
+++ b/frontend/tests/unit/components/UserMenu.test.jsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import axios from 'axios';
+import api from '@/utils/api';
 import UserMenu from '../../../src/components/UserMenu.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
@@ -143,7 +143,7 @@ describe('UserMenu', () => {
       jest.useFakeTimers();
       setup({ user: { ...baseUser } });
       const ue = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      axios.put.mockResolvedValue({ data: { user: { ...baseUser, email: 'new@example.com' } } });
+      api.put.mockResolvedValue({ data: { user: { ...baseUser, email: 'new@example.com' } } });
       renderMenu();
       await ue.click(screen.getByRole('button', { name: /testuser/i }));
       await ue.click(screen.getByRole('button', { name: /edit profile/i }));
@@ -155,7 +155,7 @@ describe('UserMenu', () => {
       await ue.click(screen.getByRole('button', { name: /^save$/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001$/),
           expect.objectContaining({ email: 'new@example.com' })
         );
@@ -187,7 +187,7 @@ describe('UserMenu', () => {
 
     it('shows API error message on failed save', async () => {
       const user = setup();
-      axios.put.mockRejectedValue({ response: { data: { error: 'Email already in use' } } });
+      api.put.mockRejectedValue({ response: { data: { error: 'Email already in use' } } });
       renderMenu();
       await user.click(screen.getByRole('button', { name: /testuser/i }));
       await user.click(screen.getByRole('button', { name: /edit profile/i }));
@@ -246,7 +246,7 @@ describe('UserMenu', () => {
       jest.useFakeTimers();
       setup();
       const ue = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      axios.put.mockResolvedValue({});
+      api.put.mockResolvedValue({});
       renderMenu();
       await ue.click(screen.getByRole('button', { name: /testuser/i }));
       await ue.click(screen.getByRole('button', { name: /change password/i }));
@@ -256,7 +256,7 @@ describe('UserMenu', () => {
       await ue.click(screen.getByRole('button', { name: /^change password$/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/password$/),
           { currentPassword: 'oldpass', newPassword: 'newpass123' }
         );
@@ -272,7 +272,7 @@ describe('UserMenu', () => {
 
     it('shows API error on failed password change', async () => {
       const user = setup();
-      axios.put.mockRejectedValue({ response: { data: { error: 'Current password is incorrect' } } });
+      api.put.mockRejectedValue({ response: { data: { error: 'Current password is incorrect' } } });
       renderMenu();
       await user.click(screen.getByRole('button', { name: /testuser/i }));
       await user.click(screen.getByRole('button', { name: /change password/i }));

--- a/frontend/tests/unit/context/AuthContext.test.jsx
+++ b/frontend/tests/unit/context/AuthContext.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import axios from 'axios';
+import api from '@/utils/api';
 import { AuthProvider, useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 
 function TestHarness() {
   const { user, loading, token, isAuthenticated, isAdmin, isAssignmentManager, login, register, logout, refreshUser } =
@@ -38,10 +38,10 @@ function TestHarness() {
 describe('AuthContext', () => {
   beforeEach(() => {
     localStorage.clear();
-    delete axios.defaults.headers.common.Authorization;
     delete window.__authResult;
+    jest.clearAllMocks();
     // Provide a default mock for the /auth/config fetch that fires on mount
-    axios.get.mockResolvedValue({ data: { registrationEnabled: false } });
+    api.get.mockResolvedValue({ data: { registrationEnabled: false } });
   });
 
   it('starts unauthenticated with no token', async () => {
@@ -58,12 +58,12 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('auth')).toHaveTextContent('no');
     expect(screen.getByTestId('user')).toHaveTextContent('none');
     // /auth/config is always fetched on mount; /auth/me is only called when a token exists
-    expect(axios.get).not.toHaveBeenCalledWith(expect.stringContaining('/auth/me'));
+    expect(api.get).not.toHaveBeenCalledWith(expect.stringContaining('/auth/me'));
   });
 
   it('hydrates user from token via /auth/me', async () => {
     localStorage.setItem('token', 'existing-token');
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { user: { username: 'alice', role: 'assignment_manager' } },
     });
 
@@ -80,12 +80,11 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('user')).toHaveTextContent('alice');
     expect(screen.getByTestId('is-admin')).toHaveTextContent('no');
     expect(screen.getByTestId('is-assignment-manager')).toHaveTextContent('yes');
-    expect(axios.defaults.headers.common.Authorization).toBe('Bearer existing-token');
   });
 
   it('clears invalid token when /auth/me fails', async () => {
     localStorage.setItem('token', 'bad-token');
-    axios.get.mockRejectedValue(new Error('unauthorized'));
+    api.get.mockRejectedValue(new Error('unauthorized'));
 
     render(
       <AuthProvider>
@@ -102,11 +101,11 @@ describe('AuthContext', () => {
   });
 
   it('login stores token and authenticates user on success', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { user: { username: 'demo', role: 'normal_user' } },
     });
 
-    axios.post.mockResolvedValue({
+    api.post.mockResolvedValue({
       data: { token: 'jwt-token', user: { username: 'demo', role: 'normal_user' } },
     });
 
@@ -129,7 +128,7 @@ describe('AuthContext', () => {
   });
 
   it('login returns error on failure', async () => {
-    axios.post.mockRejectedValue({
+    api.post.mockRejectedValue({
       response: { data: { error: 'Invalid credentials' } },
     });
 
@@ -142,14 +141,14 @@ describe('AuthContext', () => {
     await userEvent.click(screen.getByText('Login'));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalled();
+      expect(api.post).toHaveBeenCalled();
     });
 
     expect(window.__authResult).toEqual({ success: false, error: 'Invalid credentials' });
   });
 
   it('register sends expected payload and returns success message', async () => {
-    axios.post.mockResolvedValue({ data: { message: 'Registered' } });
+    api.post.mockResolvedValue({ data: { message: 'Registered' } });
 
     render(
       <AuthProvider>
@@ -160,7 +159,7 @@ describe('AuthContext', () => {
     await userEvent.click(screen.getByText('Register'));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(api.post).toHaveBeenCalledWith(
         expect.stringMatching(/\/auth\/register$/),
         expect.objectContaining({
           username: 'demo',
@@ -175,7 +174,7 @@ describe('AuthContext', () => {
   });
 
   it('register returns default error message when response has no error', async () => {
-    axios.post.mockRejectedValue(new Error('network'));
+    api.post.mockRejectedValue(new Error('network'));
 
     render(
       <AuthProvider>
@@ -186,7 +185,7 @@ describe('AuthContext', () => {
     await userEvent.click(screen.getByText('Register'));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalled();
+      expect(api.post).toHaveBeenCalled();
     });
 
     expect(window.__authResult).toEqual({ success: false, error: 'Registration failed' });
@@ -194,7 +193,7 @@ describe('AuthContext', () => {
 
   it('refreshUser updates user data from /auth/me', async () => {
     localStorage.setItem('token', 'existing-token');
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
       .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'user', groupId: null } } })
       .mockResolvedValueOnce({
@@ -221,13 +220,13 @@ describe('AuthContext', () => {
     await userEvent.click(screen.getByText('Refresh'));
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledTimes(3); // config + /auth/me on mount + refreshUser
+      expect(api.get).toHaveBeenCalledTimes(3); // config + /auth/me on mount + refreshUser
     });
   });
 
   it('refreshUser clears auth on failure', async () => {
     localStorage.setItem('token', 'existing-token');
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
       .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'user' } } })
       .mockRejectedValueOnce(new Error('unauthorized'));
@@ -252,8 +251,8 @@ describe('AuthContext', () => {
 
   it('logout clears local state and storage', async () => {
     localStorage.setItem('token', 'existing-token');
-    axios.get.mockResolvedValue({ data: { user: { username: 'root', role: 'admin' } } });
-    axios.post.mockRejectedValue(new Error('network error'));
+    api.get.mockResolvedValue({ data: { user: { username: 'root', role: 'admin' } } });
+    api.post.mockRejectedValue(new Error('network error'));
 
     render(
       <AuthProvider>

--- a/frontend/tests/unit/context/AuthContext.test.jsx
+++ b/frontend/tests/unit/context/AuthContext.test.jsx
@@ -63,9 +63,9 @@ describe('AuthContext', () => {
 
   it('hydrates user from token via /auth/me', async () => {
     localStorage.setItem('token', 'existing-token');
-    api.get.mockResolvedValue({
-      data: { user: { username: 'alice', role: 'assignment_manager' } },
-    });
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'assignment_manager' } } }); // /auth/me on mount
 
     render(
       <AuthProvider>
@@ -101,9 +101,10 @@ describe('AuthContext', () => {
   });
 
   it('login stores token and authenticates user on success', async () => {
-    api.get.mockResolvedValue({
-      data: { user: { username: 'demo', role: 'normal_user' } },
-    });
+    // /auth/config on mount (no token yet), then /auth/me after token is set by login
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({ data: { user: { username: 'demo', role: 'normal_user' } } }); // /auth/me after login sets token
 
     api.post.mockResolvedValue({
       data: { token: 'jwt-token', user: { username: 'demo', role: 'normal_user' } },
@@ -251,7 +252,9 @@ describe('AuthContext', () => {
 
   it('logout clears local state and storage', async () => {
     localStorage.setItem('token', 'existing-token');
-    api.get.mockResolvedValue({ data: { user: { username: 'root', role: 'admin' } } });
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({ data: { user: { username: 'root', role: 'admin' } } }); // /auth/me on mount
     api.post.mockRejectedValue(new Error('network error'));
 
     render(

--- a/frontend/tests/unit/pages/Dashboard.test.jsx
+++ b/frontend/tests/unit/pages/Dashboard.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import Dashboard from '../../../src/pages/Dashboard.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
@@ -104,7 +104,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { members: [] } });
+      api.get.mockResolvedValue({ data: { members: [] } });
 
       render(
         <MemoryRouter>
@@ -133,7 +133,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           members: [
             {
@@ -186,7 +186,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           members: [
             { id: 'u1', username: 'jdoe', email: 'jdoe@example.com', first_name: 'John', last_name: 'Doe' },
@@ -226,7 +226,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           members: [
             { id: 'u1', username: 'legacyuser', email: 'legacy@example.com', first_name: null, last_name: null },
@@ -261,7 +261,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { members: [] } });
+      api.get.mockResolvedValue({ data: { members: [] } });
 
       render(
         <MemoryRouter>
@@ -290,7 +290,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           groups: [
             { id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 },
@@ -331,7 +331,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
         },
@@ -368,12 +368,12 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
         },
       });
-      axios.post.mockResolvedValue({});
+      api.post.mockResolvedValue({});
 
       render(
         <MemoryRouter>
@@ -388,7 +388,7 @@ describe('Dashboard page', () => {
       await user.click(screen.getByRole('button', { name: /join/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001\/join$/)
         );
         expect(screen.getByText('Successfully joined group')).toBeInTheDocument();
@@ -420,12 +420,12 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
         },
       });
-      axios.post.mockRejectedValue({ response: { data: { error: 'Group is full' } } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Group is full' } } });
 
       render(
         <MemoryRouter>
@@ -468,8 +468,8 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { members: [] } });
-      axios.post.mockResolvedValue({});
+      api.get.mockResolvedValue({ data: { members: [] } });
+      api.post.mockResolvedValue({});
 
       render(
         <MemoryRouter>
@@ -480,7 +480,7 @@ describe('Dashboard page', () => {
       await user.click(screen.getByRole('button', { name: /leave group/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001\/leave$/)
         );
         expect(screen.getByText('Successfully left group')).toBeInTheDocument();
@@ -512,8 +512,8 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { members: [] } });
-      axios.post.mockRejectedValue({ response: { data: { error: 'Not a member' } } });
+      api.get.mockResolvedValue({ data: { members: [] } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Not a member' } } });
 
       render(
         <MemoryRouter>
@@ -549,7 +549,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { groups: [] } });
+      api.get.mockResolvedValue({ data: { groups: [] } });
 
       render(
         <MemoryRouter>
@@ -580,7 +580,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockRejectedValue(new Error('network'));
+      api.get.mockRejectedValue(new Error('network'));
 
       render(
         <MemoryRouter>
@@ -614,7 +614,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockResolvedValue({ data: { groups: [] } });
+      api.get.mockResolvedValue({ data: { groups: [] } });
 
       render(
         <MemoryRouter>
@@ -678,7 +678,7 @@ describe('Dashboard page', () => {
     });
 
     it('shows "I\'m Feeling Lucky" button when user has no group and lock is off', async () => {
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: false } });
         }
@@ -701,7 +701,7 @@ describe('Dashboard page', () => {
     });
 
     it('assigns to a non-empty group when one exists', async () => {
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: false } });
         }
@@ -714,7 +714,7 @@ describe('Dashboard page', () => {
           },
         });
       });
-      axios.post.mockResolvedValue({});
+      api.post.mockResolvedValue({});
 
       render(
         <MemoryRouter>
@@ -728,12 +728,12 @@ describe('Dashboard page', () => {
 
       await waitFor(() => {
         // Should join g2 (non-empty), not g1 (empty)
-        expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g2\/join$/));
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g2\/join$/));
       });
     });
 
     it('falls back to any group when no non-empty groups exist', async () => {
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: false } });
         }
@@ -743,7 +743,7 @@ describe('Dashboard page', () => {
           },
         });
       });
-      axios.post.mockResolvedValue({});
+      api.post.mockResolvedValue({});
 
       render(
         <MemoryRouter>
@@ -756,12 +756,12 @@ describe('Dashboard page', () => {
       await userEvent.click(screen.getByRole('button', { name: /feeling lucky/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g1\/join$/));
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g1\/join$/));
       });
     });
 
     it('shows error when no groups are available', async () => {
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: false } });
         }
@@ -812,7 +812,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: true } });
         }
@@ -842,7 +842,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: true } });
         }
@@ -871,7 +871,7 @@ describe('Dashboard page', () => {
         isAssignmentManager: false,
       });
 
-      axios.get.mockImplementation((url) => {
+      api.get.mockImplementation((url) => {
         if (url.includes('group-join-locked')) {
           return Promise.resolve({ data: { locked: false } });
         }

--- a/frontend/tests/unit/pages/ForgotPassword.test.jsx
+++ b/frontend/tests/unit/pages/ForgotPassword.test.jsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import ForgotPassword from '../../../src/pages/ForgotPassword.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 
 describe('ForgotPassword page', () => {
   beforeEach(() => {
@@ -39,13 +39,13 @@ describe('ForgotPassword page', () => {
     await waitFor(() => {
       expect(screen.getByText('Email is required')).toBeInTheDocument();
     });
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(api.post).not.toHaveBeenCalled();
   });
 
   it('submits email and shows success message', async () => {
     const user = userEvent.setup();
 
-    axios.post.mockResolvedValue({
+    api.post.mockResolvedValue({
       data: { message: 'If that email is registered, a reset link has been sent.' },
     });
 
@@ -59,7 +59,7 @@ describe('ForgotPassword page', () => {
     await user.click(screen.getByRole('button', { name: /send reset link/i }));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/forgot-password$/), {
+      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/forgot-password$/), {
         email: 'test@example.com',
       });
       expect(screen.getByText('If that email is registered, a reset link has been sent.')).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('ForgotPassword page', () => {
   it('disables button after successful submission', async () => {
     const user = userEvent.setup();
 
-    axios.post.mockResolvedValue({
+    api.post.mockResolvedValue({
       data: { message: 'Reset link sent.' },
     });
 
@@ -92,7 +92,7 @@ describe('ForgotPassword page', () => {
   it('shows generic error message on API failure (does not leak backend error)', async () => {
     const user = userEvent.setup();
 
-    axios.post.mockRejectedValue({
+    api.post.mockRejectedValue({
       response: { data: { error: 'Too many requests. Please try again later.' } },
     });
 
@@ -115,7 +115,7 @@ describe('ForgotPassword page', () => {
   it('shows generic error when no response body on failure', async () => {
     const user = userEvent.setup();
 
-    axios.post.mockRejectedValue(new Error('Network Error'));
+    api.post.mockRejectedValue(new Error('Network Error'));
 
     render(
       <MemoryRouter>
@@ -134,7 +134,7 @@ describe('ForgotPassword page', () => {
   it('trims whitespace from email before submitting', async () => {
     const user = userEvent.setup();
 
-    axios.post.mockResolvedValue({ data: { message: 'Sent.' } });
+    api.post.mockResolvedValue({ data: { message: 'Sent.' } });
 
     render(
       <MemoryRouter>
@@ -146,7 +146,7 @@ describe('ForgotPassword page', () => {
     await user.click(screen.getByRole('button', { name: /send reset link/i }));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(expect.any(String), { email: 'user@example.com' });
+      expect(api.post).toHaveBeenCalledWith(expect.any(String), { email: 'user@example.com' });
     });
   });
 });

--- a/frontend/tests/unit/pages/Groups.test.jsx
+++ b/frontend/tests/unit/pages/Groups.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import Groups from '../../../src/pages/Groups.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
@@ -36,7 +36,7 @@ describe('Groups page', () => {
   });
 
   const setupPage = async (groups = [makeGroup()]) => {
-    axios.get.mockResolvedValueOnce({ data: { groups } });
+    api.get.mockResolvedValueOnce({ data: { groups } });
     render(
       <MemoryRouter>
         <Groups />
@@ -47,7 +47,7 @@ describe('Groups page', () => {
 
   // ── Loading / fetch ────────────────────────────────────────────────────
   it('shows loading spinner before data resolves', () => {
-    axios.get.mockImplementation(() => new Promise(() => {}));
+    api.get.mockImplementation(() => new Promise(() => {}));
     const { container } = render(
       <MemoryRouter>
         <Groups />
@@ -63,7 +63,7 @@ describe('Groups page', () => {
   });
 
   it('shows fetch error state', async () => {
-    axios.get.mockRejectedValue(new Error('boom'));
+    api.get.mockRejectedValue(new Error('boom'));
     render(
       <MemoryRouter>
         <Groups />
@@ -132,13 +132,13 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    axios.put.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ enabled: false })] } });
+    api.put.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ enabled: false })] } });
 
     await user.click(screen.getByRole('button', { name: 'Disable Group' }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
         enabled: false,
       });
       expect(screen.getByText('Group disabled successfully')).toBeInTheDocument();
@@ -151,13 +151,13 @@ describe('Groups page', () => {
   it('enables a disabled group', async () => {
     const user = userEvent.setup();
     await setupPage([makeGroup({ enabled: false })]);
-    axios.put.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
+    api.put.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: 'Enable Group' }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\//), { enabled: true });
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\//), { enabled: true });
     });
   });
 
@@ -165,7 +165,7 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    axios.put.mockRejectedValue({ response: { data: { error: 'Cannot update group' } } });
+    api.put.mockRejectedValue({ response: { data: { error: 'Cannot update group' } } });
 
     await user.click(screen.getByRole('button', { name: 'Disable Group' }));
 
@@ -209,16 +209,14 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    axios.delete.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+    api.delete.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
     await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
 
     await waitFor(() => {
-      expect(axios.delete).toHaveBeenCalledWith(
-        expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/)
-      );
+      expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/));
       expect(screen.getByText('Group deleted successfully')).toBeInTheDocument();
     });
 
@@ -233,7 +231,7 @@ describe('Groups page', () => {
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
     await user.click(screen.getByRole('button', { name: /cancel/i }));
 
-    expect(axios.delete).not.toHaveBeenCalled();
+    expect(api.delete).not.toHaveBeenCalled();
     expect(screen.queryByText(/delete 1 group\?/i)).not.toBeInTheDocument();
   });
 
@@ -241,7 +239,7 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    axios.delete.mockRejectedValue({ response: { data: { error: 'Cannot delete' } } });
+    api.delete.mockRejectedValue({ response: { data: { error: 'Cannot delete' } } });
 
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
     await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
@@ -263,8 +261,8 @@ describe('Groups page', () => {
   it('saves a numeric limit via modal', async () => {
     const user = userEvent.setup();
     await setupPage();
-    axios.put.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: 10 })] } });
+    api.put.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: 10 })] } });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
     const input = screen.getByPlaceholderText('Unlimited');
@@ -273,7 +271,7 @@ describe('Groups page', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
         maxMembers: 10,
       });
       expect(screen.getByText('Group limit updated')).toBeInTheDocument();
@@ -283,15 +281,15 @@ describe('Groups page', () => {
   it('saves unlimited (blank) limit via modal', async () => {
     const user = userEvent.setup();
     await setupPage();
-    axios.put.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: null })] } });
+    api.put.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: null })] } });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
     await user.clear(screen.getByPlaceholderText('Unlimited'));
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\//), { maxMembers: null });
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\//), { maxMembers: null });
     });
   });
 
@@ -307,7 +305,7 @@ describe('Groups page', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => expect(screen.getByText('Max members must be a positive number')).toBeInTheDocument());
-    expect(axios.put).not.toHaveBeenCalled();
+    expect(api.put).not.toHaveBeenCalled();
   });
 
   it('cancels the set limit modal', async () => {
@@ -325,7 +323,7 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    axios.put.mockRejectedValue({ response: { data: { error: 'Limit too low' } } });
+    api.put.mockRejectedValue({ response: { data: { error: 'Limit too low' } } });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
     await user.click(screen.getByRole('button', { name: /save/i }));
@@ -344,15 +342,15 @@ describe('Groups page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage([]);
-    axios.post.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
+    api.post.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), ' New Team ');
     await user.click(screen.getByRole('button', { name: /^create$/i }));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), { name: 'New Team' });
+      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), { name: 'New Team' });
       expect(screen.getByText('Group created successfully')).toBeInTheDocument();
     });
 
@@ -363,8 +361,8 @@ describe('Groups page', () => {
   it('creates a group with maxMembers', async () => {
     const user = userEvent.setup();
     await setupPage([]);
-    axios.post.mockResolvedValueOnce({});
-    axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
+    api.post.mockResolvedValueOnce({});
+    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), 'Limited Team');
@@ -372,7 +370,7 @@ describe('Groups page', () => {
     await user.click(screen.getByRole('button', { name: /^create$/i }));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), {
+      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), {
         name: 'Limited Team',
         maxMembers: 10,
       });
@@ -387,13 +385,13 @@ describe('Groups page', () => {
     await user.type(screen.getByPlaceholderText(/enter group name/i), '   ');
     await user.click(screen.getByRole('button', { name: /^create$/i }));
 
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(api.post).not.toHaveBeenCalled();
   });
 
   it('shows error inside modal when create group fails', async () => {
     const user = userEvent.setup();
     await setupPage([]);
-    axios.post.mockRejectedValue(new Error('network'));
+    api.post.mockRejectedValue(new Error('network'));
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), 'Team X');
@@ -459,7 +457,7 @@ describe('Groups page', () => {
     it('expands group row to show members', async () => {
       const user = userEvent.setup();
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -475,7 +473,7 @@ describe('Groups page', () => {
     it('shows full name and student ID for each member', async () => {
       const user = userEvent.setup();
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -493,7 +491,7 @@ describe('Groups page', () => {
     it('shows "No members in this group" when group is empty', async () => {
       const user = userEvent.setup();
       await setupPage();
-      axios.get.mockResolvedValueOnce({ data: { members: [] } }).mockResolvedValueOnce({ data: { users: [] } });
+      api.get.mockResolvedValueOnce({ data: { members: [] } }).mockResolvedValueOnce({ data: { users: [] } });
 
       await expandGroup(user);
 
@@ -503,7 +501,7 @@ describe('Groups page', () => {
     it('collapses row on second click', async () => {
       const user = userEvent.setup();
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -518,22 +516,22 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
 
-      axios.put.mockResolvedValueOnce({});
-      axios.get
+      api.put.mockResolvedValueOnce({});
+      api.get
         .mockResolvedValueOnce({ data: { members: [membersData[1]] } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
       await user.click(screen.getByRole('button', { name: /remove alice/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000010\/group$/),
           { groupId: null }
         );
@@ -548,7 +546,7 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -558,15 +556,15 @@ describe('Groups page', () => {
       // charlie is the only user not in the group
       await user.selectOptions(screen.getByRole('combobox'), 'u0000000-0000-0000-0000-000000000012');
 
-      axios.put.mockResolvedValueOnce({});
-      axios.get
+      api.put.mockResolvedValueOnce({});
+      api.get
         .mockResolvedValueOnce({ data: { members: [...membersData, allUsersData[2]] } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
       await user.click(screen.getByRole('button', { name: /^add$/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000012\/group$/),
           { groupId: 'g0000000-0000-0000-0000-000000000001' }
         );
@@ -580,7 +578,7 @@ describe('Groups page', () => {
     it('does not submit add when no user selected', async () => {
       const user = userEvent.setup();
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -588,14 +586,14 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument());
 
       await user.click(screen.getByRole('button', { name: /^add$/i }));
-      expect(axios.put).not.toHaveBeenCalled();
+      expect(api.put).not.toHaveBeenCalled();
     });
 
     it('hides add/remove controls for non-assignment-managers', async () => {
       useAuth.mockReturnValue({ isAssignmentManager: false });
       const user = userEvent.setup();
       await setupPage();
-      axios.get.mockResolvedValueOnce({ data: { members: membersData } });
+      api.get.mockResolvedValueOnce({ data: { members: membersData } });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
@@ -607,7 +605,7 @@ describe('Groups page', () => {
     it('hides add member dropdown when group is full', async () => {
       const user = userEvent.setup();
       await setupPage([makeGroup({ member_count: 2, max_members: 2 })]);
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -622,7 +620,7 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get.mockRejectedValueOnce(new Error('network'));
+      api.get.mockRejectedValueOnce(new Error('network'));
 
       await expandGroup(user);
 
@@ -636,14 +634,14 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
 
-      axios.put.mockRejectedValue({ response: { data: { error: 'Remove failed' } } });
+      api.put.mockRejectedValue({ response: { data: { error: 'Remove failed' } } });
       await user.click(screen.getByRole('button', { name: /remove alice/i }));
 
       await waitFor(() => expect(screen.getByText('Remove failed')).toBeInTheDocument());
@@ -653,7 +651,7 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: membersData } })
         .mockResolvedValueOnce({ data: { users: allUsersData } });
 
@@ -661,7 +659,7 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
 
       await user.selectOptions(screen.getByRole('combobox'), 'u0000000-0000-0000-0000-000000000012');
-      axios.put.mockRejectedValue({ response: { data: { error: 'Add failed' } } });
+      api.put.mockRejectedValue({ response: { data: { error: 'Add failed' } } });
       await user.click(screen.getByRole('button', { name: /^add$/i }));
 
       await waitFor(() => expect(screen.getByText('Add failed')).toBeInTheDocument());
@@ -690,7 +688,7 @@ describe('Groups page', () => {
       };
       // Group has no current members; all three users are "available" by membership,
       // but only regularUser has role_name === 'user'
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { members: [] } })
         .mockResolvedValueOnce({ data: { users: [adminUser, managerUser, regularUser] } });
 
@@ -819,14 +817,14 @@ describe('Groups page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValue({});
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.delete.mockResolvedValue({});
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledTimes(1);
-        expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
+        expect(api.delete).toHaveBeenCalledTimes(1);
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
           data: { ids: expect.arrayContaining(['g1', 'g2']) },
         });
         expect(screen.getByText('Deleted 2 groups')).toBeInTheDocument();
@@ -840,7 +838,7 @@ describe('Groups page', () => {
 
       await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
       await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-      axios.delete.mockRejectedValue({ response: { data: { error: 'Delete failed' } } });
+      api.delete.mockRejectedValue({ response: { data: { error: 'Delete failed' } } });
 
       await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
 
@@ -940,14 +938,14 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '3');
 
-      axios.post.mockResolvedValueOnce({ data: { created: 3 } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.post.mockResolvedValueOnce({ data: { created: 3 } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 3 groups/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledTimes(1);
-        expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
+        expect(api.post).toHaveBeenCalledTimes(1);
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
           { name: 'Team1' },
           { name: 'Team2' },
           { name: 'Team3' },
@@ -968,30 +966,30 @@ describe('Groups page', () => {
       await user.type(countInput, '1500');
 
       // First batch: 500 items; second batch: 500 items; third batch: 500 items
-      axios.post
+      api.post
         .mockResolvedValueOnce({ data: { created: 500 } })
         .mockResolvedValueOnce({ data: { created: 500 } })
         .mockResolvedValueOnce({ data: { created: 500 } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 1500 groups/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledTimes(3);
+        expect(api.post).toHaveBeenCalledTimes(3);
         // First call — 500 items (pad=2 for n=1500)
-        const firstCall = axios.post.mock.calls[0];
+        const firstCall = api.post.mock.calls[0];
         expect(firstCall[0]).toMatch(/\/groups\/bulk$/);
         expect(firstCall[1]).toHaveLength(500);
         expect(firstCall[1][0]).toEqual({ name: 'Group01' });
         expect(firstCall[1][499]).toEqual({ name: 'Group500' });
         // Second call — 500 items
-        const secondCall = axios.post.mock.calls[1];
+        const secondCall = api.post.mock.calls[1];
         expect(secondCall[0]).toMatch(/\/groups\/bulk$/);
         expect(secondCall[1]).toHaveLength(500);
         expect(secondCall[1][0]).toEqual({ name: 'Group501' });
         expect(secondCall[1][499]).toEqual({ name: 'Group1000' });
         // Third call — 500 items
-        const thirdCall = axios.post.mock.calls[2];
+        const thirdCall = api.post.mock.calls[2];
         expect(thirdCall[0]).toMatch(/\/groups\/bulk$/);
         expect(thirdCall[1]).toHaveLength(500);
         expect(thirdCall[1][0]).toEqual({ name: 'Group1001' });
@@ -1010,18 +1008,18 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '500');
 
-      axios.post.mockResolvedValueOnce({ data: { created: 500 } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.post.mockResolvedValueOnce({ data: { created: 500 } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 500 groups/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledTimes(1);
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledTimes(1);
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/groups\/bulk$/),
           expect.arrayContaining([expect.objectContaining({ name: 'Team01' })])
         );
-        const callArg = axios.post.mock.calls[0][1];
+        const callArg = api.post.mock.calls[0][1];
         expect(callArg).toHaveLength(500);
       });
     });
@@ -1038,13 +1036,13 @@ describe('Groups page', () => {
       await user.type(countInput, '2');
       await user.type(screen.getByPlaceholderText(/unlimited/i), '30');
 
-      axios.post.mockResolvedValueOnce({ data: { created: 2 } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.post.mockResolvedValueOnce({ data: { created: 2 } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
           { name: 'Team1', maxMembers: 30 },
           { name: 'Team2', maxMembers: 30 },
         ]);
@@ -1062,10 +1060,10 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '1500');
 
-      axios.post
+      api.post
         .mockResolvedValueOnce({ data: { created: 500 } })
         .mockRejectedValueOnce({ response: { data: { error: 'DB overloaded' } } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 1500 groups/i }));
 
@@ -1089,8 +1087,8 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '2');
 
-      axios.post.mockRejectedValueOnce({ response: { data: { error: 'Create failed' } } });
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.post.mockRejectedValueOnce({ response: { data: { error: 'Create failed' } } });
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
 
@@ -1112,7 +1110,7 @@ describe('Groups page', () => {
 
       // Submit button is disabled when prefix is empty, so we verify no API call
       expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
-      expect(axios.post).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
     });
 
     it('invalid count (0): does not make any API call', async () => {
@@ -1127,7 +1125,7 @@ describe('Groups page', () => {
 
       // Submit button disabled when count < 1
       expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
-      expect(axios.post).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
     });
   });
 
@@ -1165,15 +1163,15 @@ describe('Groups page', () => {
       await user.clear(input);
       await user.type(input, '8');
 
-      axios.put.mockResolvedValue({});
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.put.mockResolvedValue({});
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledTimes(2);
-        expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g1$/), { maxMembers: 8 });
-        expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g2$/), { maxMembers: 8 });
+        expect(api.put).toHaveBeenCalledTimes(2);
+        expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g1$/), { maxMembers: 8 });
+        expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g2$/), { maxMembers: 8 });
         expect(screen.getByText('Updated limit for 2 groups')).toBeInTheDocument();
       });
     });
@@ -1238,12 +1236,12 @@ describe('Groups page', () => {
         { groupName: 'Team Alpha', email: 'alice@test.com' },
         { groupName: 'Team Beta', email: 'bob@test.com' },
       ];
-      axios.get.mockResolvedValueOnce({ data: { mappings } });
+      api.get.mockResolvedValueOnce({ data: { mappings } });
 
       await user.click(screen.getByRole('button', { name: /export mappings/i }));
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/export-mappings$/));
+        expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/export-mappings$/));
         expect(downloadCsv).toHaveBeenCalledWith(
           mappings,
           ['groupName', 'email'],
@@ -1256,7 +1254,7 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.get.mockRejectedValueOnce(new Error('network'));
+      api.get.mockRejectedValueOnce(new Error('network'));
 
       await user.click(screen.getByRole('button', { name: /export mappings/i }));
 
@@ -1280,17 +1278,17 @@ describe('Groups page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupPage();
-      axios.delete.mockResolvedValueOnce({});
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: 'Delete Group' }));
       await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledWith(
+        expect(api.delete).toHaveBeenCalledWith(
           expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/)
         );
-        expect(axios.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk/));
+        expect(api.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk/));
       });
     });
 
@@ -1305,14 +1303,14 @@ describe('Groups page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValueOnce({});
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledTimes(1);
-        expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
+        expect(api.delete).toHaveBeenCalledTimes(1);
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
           data: { ids: expect.arrayContaining(['g1', 'g2']) },
         });
       });
@@ -1329,8 +1327,8 @@ describe('Groups page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValueOnce({});
-      axios.get.mockResolvedValueOnce({ data: { groups: [] } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
@@ -1348,7 +1346,7 @@ describe('Groups page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockRejectedValue({ response: { data: { error: 'Bulk delete failed' } } });
+      api.delete.mockRejectedValue({ response: { data: { error: 'Bulk delete failed' } } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
@@ -1359,7 +1357,7 @@ describe('Groups page', () => {
   describe('data freshness on navigation and tab visibility', () => {
     it('re-fetches groups when the browser tab becomes visible', async () => {
       // Initial load — one group
-      axios.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ name: 'Group A' })] } });
+      api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ name: 'Group A' })] } });
       render(
         <MemoryRouter>
           <Groups />
@@ -1368,7 +1366,7 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.getByText('Group A')).toBeInTheDocument());
 
       // Simulate another tab creating a group, then this tab regaining focus
-      axios.get.mockResolvedValueOnce({
+      api.get.mockResolvedValueOnce({
         data: {
           groups: [makeGroup({ name: 'Group A' }), makeGroup({ id: 'g2', name: 'Group B' })],
         },
@@ -1383,12 +1381,12 @@ describe('Groups page', () => {
     it('does not re-fetch when the tab becomes hidden', async () => {
       await setupPage();
 
-      const callsBefore = axios.get.mock.calls.length;
+      const callsBefore = api.get.mock.calls.length;
 
       Object.defineProperty(document, 'hidden', { value: true, configurable: true, writable: true });
       document.dispatchEvent(new Event('visibilitychange'));
 
-      expect(axios.get.mock.calls.length).toBe(callsBefore);
+      expect(api.get.mock.calls.length).toBe(callsBefore);
     });
   });
 });

--- a/frontend/tests/unit/pages/ImportGroupMappings.test.jsx
+++ b/frontend/tests/unit/pages/ImportGroupMappings.test.jsx
@@ -2,11 +2,11 @@
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import ImportGroupMappings from '../../../src/pages/ImportGroupMappings.jsx';
 import { downloadCsv } from '../../../src/utils/csv.js';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(() => ({
     user: { id: 'u1', username: 'admin', role: 'admin' },
@@ -142,7 +142,7 @@ describe('ImportGroupMappings page', () => {
     });
 
     it('accepts a valid CSV via drag and drop and auto-advances to preview', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
           groups: [{ id: 'g1', name: 'Team A' }],
@@ -168,7 +168,7 @@ describe('ImportGroupMappings page', () => {
     });
 
     it('auto-advances to step 2 when a valid CSV with detectable columns is uploaded', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
           groups: [{ id: 'g1', name: 'Team Alpha' }],
@@ -196,7 +196,7 @@ describe('ImportGroupMappings page', () => {
     ];
 
     async function goToPreview(csv = validCsv) {
-      axios.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
+      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
       renderPage();
       uploadCsv(csv);
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
@@ -215,7 +215,7 @@ describe('ImportGroupMappings page', () => {
 
     it('highlights rows with unknown user as Skip', async () => {
       const csvWithUnknown = 'group name,email\nTeam Alpha,alice@test.com\nTeam Alpha,nobody@ghost.com';
-      axios.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
+      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
       renderPage();
       uploadCsv(csvWithUnknown);
       await waitFor(() => expect(screen.getByText(/User not found/i)).toBeInTheDocument());
@@ -223,7 +223,7 @@ describe('ImportGroupMappings page', () => {
 
     it('highlights rows with unknown group as Skip', async () => {
       const csvWithBadGroup = 'group name,email\nGhost Group,alice@test.com';
-      axios.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
+      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
       renderPage();
       uploadCsv(csvWithBadGroup);
       await waitFor(() => expect(screen.getByText(/Group not found/i)).toBeInTheDocument());
@@ -231,7 +231,7 @@ describe('ImportGroupMappings page', () => {
 
     it('shows Conflict status for users already in a group', async () => {
       const conflictCsv = 'group name,email\nTeam Alpha,assigned@test.com';
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'u3', email: 'assigned@test.com', group_id: 'g1' }],
           groups: mockGroups,
@@ -244,7 +244,7 @@ describe('ImportGroupMappings page', () => {
 
     it('marks admin users as Skip with appropriate reason', async () => {
       const csvWithAdmin = 'group name,email\nTeam Alpha,admin@test.com';
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null }],
           groups: mockGroups,
@@ -259,7 +259,7 @@ describe('ImportGroupMappings page', () => {
 
     it('marks assignment_manager users as Skip with appropriate reason', async () => {
       const csvWithAM = 'group name,email\nTeam Alpha,am@test.com';
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'am1', email: 'am@test.com', role_name: 'assignment_manager', group_id: null }],
           groups: mockGroups,
@@ -274,7 +274,7 @@ describe('ImportGroupMappings page', () => {
 
     it('does not count privileged-user rows as importable', async () => {
       const csvMixed = 'group name,email\nTeam Alpha,admin@test.com\nTeam Alpha,alice@test.com';
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [
             { id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null },
@@ -292,7 +292,7 @@ describe('ImportGroupMappings page', () => {
 
     it('shows a skip/overwrite dropdown for conflict rows', async () => {
       const conflictCsv = 'group name,email\nTeam Alpha,assigned@test.com';
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'u3', email: 'assigned@test.com', group_id: 'g1' }],
           groups: mockGroups,
@@ -311,7 +311,7 @@ describe('ImportGroupMappings page', () => {
       ];
 
       async function goToConflictPreview() {
-        axios.get.mockResolvedValue({
+        api.get.mockResolvedValue({
           data: { users: conflictUsers, groups: mockGroups },
         });
         renderPage();
@@ -369,7 +369,7 @@ describe('ImportGroupMappings page', () => {
 
   describe('Step 3: Result', () => {
     async function runImport(importResponse = { imported: 2, skipped: [], errors: [] }) {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [
             { id: 'u1', email: 'alice@test.com', group_id: null },
@@ -381,7 +381,7 @@ describe('ImportGroupMappings page', () => {
           ],
         },
       });
-      axios.post.mockResolvedValue({ data: importResponse });
+      api.post.mockResolvedValue({ data: importResponse });
 
       renderPage();
       uploadCsv('group name,email\nTeam Alpha,alice@test.com\nTeam Beta,bob@test.com');
@@ -441,7 +441,7 @@ describe('ImportGroupMappings page', () => {
     ];
 
     async function goToImportReady() {
-      axios.get.mockResolvedValue({ data: { users: confirmUsers, groups: confirmGroups } });
+      api.get.mockResolvedValue({ data: { users: confirmUsers, groups: confirmGroups } });
       renderPage();
       uploadCsv(confirmCsv);
       await waitFor(() => expect(screen.getAllByText('Ready').length).toBeGreaterThan(0));
@@ -516,11 +516,11 @@ describe('ImportGroupMappings page', () => {
         fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
       });
       expect(screen.queryByRole('heading', { name: /before you continue/i })).not.toBeInTheDocument();
-      expect(axios.post).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
     });
 
     it('confirming after countdown proceeds with import', async () => {
-      axios.post.mockResolvedValue({ data: { imported: 2, skipped: [], errors: [] } });
+      api.post.mockResolvedValue({ data: { imported: 2, skipped: [], errors: [] } });
       await goToImportReady();
       jest.useFakeTimers();
       try {
@@ -544,13 +544,13 @@ describe('ImportGroupMappings page', () => {
 
   describe('Skipped CSV download', () => {
     it('does not include duplicate rows when a skipped row appears in both preview and API response', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
           groups: [{ id: 'g1', name: 'Team Alpha' }],
         },
       });
-      axios.post.mockResolvedValue({
+      api.post.mockResolvedValue({
         data: {
           imported: 1,
           skipped: [{ email: 'nobody@test.com', groupName: 'Team Alpha', reason: 'User not found' }],

--- a/frontend/tests/unit/pages/ImportUsers.test.jsx
+++ b/frontend/tests/unit/pages/ImportUsers.test.jsx
@@ -2,10 +2,10 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import ImportUsers from '../../../src/pages/ImportUsers.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(() => ({
     user: { id: 'u1', username: 'admin', role: 'admin' },
@@ -227,7 +227,7 @@ describe('ImportUsers page', () => {
     });
 
     it('loads preview and advances to step 3 on success', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       uploadCsv(validCsv);
       await waitForStep2();
@@ -237,7 +237,7 @@ describe('ImportUsers page', () => {
     });
 
     it('shows error when fetching existing users fails', async () => {
-      axios.get.mockRejectedValue({ response: { data: { error: 'Server error' } } });
+      api.get.mockRejectedValue({ response: { data: { error: 'Server error' } } });
       renderPage();
       uploadCsv(validCsv);
       await waitForStep2();
@@ -252,7 +252,7 @@ describe('ImportUsers page', () => {
     const twoCsv = 'username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe\njane,jane@test.com,Jane,Smith';
 
     async function goToPreview({ existingUsers = [], csv = twoCsv } = {}) {
-      axios.get.mockResolvedValue({ data: { users: existingUsers } });
+      api.get.mockResolvedValue({ data: { users: existingUsers } });
       renderPage();
       uploadCsv(csv);
       await waitForStep2();
@@ -305,18 +305,18 @@ describe('ImportUsers page', () => {
     });
 
     it('submits import and shows result step', async () => {
-      axios.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
+      api.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
       await goToPreview();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       expect(await screen.findByText('Import Complete')).toBeInTheDocument();
     });
 
     it('calls POST /users/import with correct payload', async () => {
-      axios.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
+      api.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
       await goToPreview();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       await screen.findByText('Import Complete');
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(api.post).toHaveBeenCalledWith(
         expect.stringContaining('/users/import'),
         expect.objectContaining({
           conflictAction: 'skip',
@@ -327,7 +327,7 @@ describe('ImportUsers page', () => {
     });
 
     it('shows submit error when import API fails', async () => {
-      axios.post.mockRejectedValue({ response: { data: { error: 'Import failed' } } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Import failed' } } });
       await goToPreview();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       expect(await screen.findByText('Import failed')).toBeInTheDocument();
@@ -352,8 +352,8 @@ describe('ImportUsers page', () => {
 
   describe('Step 4 — Result', () => {
     async function goToResult({ imported = 2, skipped = 0, errors = [] } = {}) {
-      axios.get.mockResolvedValue({ data: { users: [] } });
-      axios.post.mockResolvedValue({ data: { imported, skipped, errors } });
+      api.get.mockResolvedValue({ data: { users: [] } });
+      api.post.mockResolvedValue({ data: { imported, skipped, errors } });
       renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe\njane,jane@test.com,Jane,Smith');
       await waitForStep2();
@@ -396,7 +396,7 @@ describe('ImportUsers page', () => {
 
   describe('Full Name column mapping', () => {
     it('splits "First Last" format correctly in preview', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       // "name" header auto-detects to fullNameFL
       uploadCsv('username,email,name\njdoe,jdoe@test.com,John Doe');
@@ -408,7 +408,7 @@ describe('ImportUsers page', () => {
     });
 
     it('splits "First, Last" comma format correctly for fullNameFL', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       uploadCsv('username,email,name\njdoe,jdoe@test.com,"John, Doe"');
       await waitForStep2();
@@ -419,7 +419,7 @@ describe('ImportUsers page', () => {
     });
 
     it('splits "Last, First" format correctly when mapped to fullNameLF', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       // "fullname" auto-detects to fullNameFL; we'll change it to fullNameLF
       uploadCsv('username,email,fullname\njdoe,jdoe@test.com,"Doe, John"');
@@ -537,7 +537,7 @@ describe('ImportUsers page', () => {
 
   describe('Duplicate and conflict detection', () => {
     it('shows "Duplicate in file" badge for intra-CSV duplicate usernames', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,jdoe@a.com,John,Doe\njdoe,jdoe@b.com,Jane,Doe');
       await waitForStep2();
@@ -547,7 +547,7 @@ describe('ImportUsers page', () => {
     });
 
     it('shows "Duplicate in file" badge for intra-CSV duplicate emails', async () => {
-      axios.get.mockResolvedValue({ data: { users: [] } });
+      api.get.mockResolvedValue({ data: { users: [] } });
       renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,same@test.com,John,Doe\njane,same@test.com,Jane,Smith');
       await waitForStep2();
@@ -557,7 +557,7 @@ describe('ImportUsers page', () => {
     });
 
     it('shows "Conflict (email/ID taken)" for email conflict with existing user', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
         },
@@ -571,7 +571,7 @@ describe('ImportUsers page', () => {
     });
 
     it('shows "Conflict (email/ID taken)" for student ID conflict with existing user', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ username: 'other', email: 'other@test.com', role_name: 'user', student_id: 'S123' }],
         },
@@ -585,12 +585,12 @@ describe('ImportUsers page', () => {
     });
 
     it('does not send conflict rows to the import API', async () => {
-      axios.get.mockResolvedValue({
+      api.get.mockResolvedValue({
         data: {
           users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
         },
       });
-      axios.post.mockResolvedValue({ data: { imported: 0, skipped: 0, errors: [] } });
+      api.post.mockResolvedValue({ data: { imported: 0, skipped: 0, errors: [] } });
       renderPage();
       uploadCsv('username,email,firstName,lastName\nnewuser,taken@test.com,New,User');
       await waitForStep2();

--- a/frontend/tests/unit/pages/SetPassword.test.jsx
+++ b/frontend/tests/unit/pages/SetPassword.test.jsx
@@ -1,10 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import SetPassword from '../../../src/pages/SetPassword.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -57,7 +57,7 @@ describe('SetPassword page', () => {
     await waitFor(() => {
       expect(screen.getByText('Password must be at least 6 characters')).toBeInTheDocument();
     });
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(api.post).not.toHaveBeenCalled();
   });
 
   it('shows error when passwords do not match', async () => {
@@ -71,7 +71,7 @@ describe('SetPassword page', () => {
     await waitFor(() => {
       expect(screen.getByText('Passwords do not match.')).toBeInTheDocument();
     });
-    expect(axios.post).not.toHaveBeenCalled();
+    expect(api.post).not.toHaveBeenCalled();
   });
 
   it('submits token and password on success, then navigates to login', async () => {
@@ -79,14 +79,14 @@ describe('SetPassword page', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     renderWithToken('validtoken123');
 
-    axios.post.mockResolvedValue({ data: { message: 'Password set successfully. You can now log in.' } });
+    api.post.mockResolvedValue({ data: { message: 'Password set successfully. You can now log in.' } });
 
     await user.type(screen.getByPlaceholderText('At least 6 characters'), 'newpass1');
     await user.type(screen.getByPlaceholderText('Repeat your password'), 'newpass1');
     await user.click(screen.getByRole('button', { name: /set password/i }));
 
     await waitFor(() => {
-      expect(axios.post).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/set-password$/), {
+      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/set-password$/), {
         token: 'validtoken123',
         password: 'newpass1',
       });
@@ -105,7 +105,7 @@ describe('SetPassword page', () => {
     const user = userEvent.setup();
     renderWithToken('validtoken123');
 
-    axios.post.mockResolvedValue({ data: { message: 'Password updated.' } });
+    api.post.mockResolvedValue({ data: { message: 'Password updated.' } });
 
     await user.type(screen.getByPlaceholderText('At least 6 characters'), 'newpass1');
     await user.type(screen.getByPlaceholderText('Repeat your password'), 'newpass1');
@@ -122,7 +122,7 @@ describe('SetPassword page', () => {
     const user = userEvent.setup();
     renderWithToken('expiredtoken');
 
-    axios.post.mockRejectedValue({
+    api.post.mockRejectedValue({
       response: { data: { error: 'Token has expired or already been used.' } },
     });
 
@@ -139,7 +139,7 @@ describe('SetPassword page', () => {
     const user = userEvent.setup();
     renderWithToken('sometoken');
 
-    axios.post.mockRejectedValue(new Error('Network Error'));
+    api.post.mockRejectedValue(new Error('Network Error'));
 
     await user.type(screen.getByPlaceholderText('At least 6 characters'), 'newpass1');
     await user.type(screen.getByPlaceholderText('Repeat your password'), 'newpass1');

--- a/frontend/tests/unit/pages/Settings.test.jsx
+++ b/frontend/tests/unit/pages/Settings.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import Settings from '../../../src/pages/Settings.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
@@ -27,7 +27,7 @@ describe('Settings page', () => {
   });
 
   it('renders the Settings heading', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
 
@@ -41,7 +41,7 @@ describe('Settings page', () => {
   });
 
   it('shows the group join lock toggle', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
 
@@ -57,7 +57,7 @@ describe('Settings page', () => {
   });
 
   it('loads and reflects current locked=false state', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
 
@@ -74,7 +74,7 @@ describe('Settings page', () => {
   });
 
   it('loads and reflects current locked=true state', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'true' }] },
     });
 
@@ -91,10 +91,10 @@ describe('Settings page', () => {
   });
 
   it('enables the lock when toggle is clicked', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
-    axios.put.mockResolvedValue({});
+    api.put.mockResolvedValue({});
 
     render(
       <MemoryRouter>
@@ -107,15 +107,15 @@ describe('Settings page', () => {
     await userEvent.click(screen.getByRole('button', { name: /enable group join lock/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/config\/group_join_locked$/), { value: 'true' });
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/config\/group_join_locked$/), { value: 'true' });
     });
   });
 
   it('disables the lock when toggle is clicked while enabled', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'true' }] },
     });
-    axios.put.mockResolvedValue({});
+    api.put.mockResolvedValue({});
 
     render(
       <MemoryRouter>
@@ -128,7 +128,7 @@ describe('Settings page', () => {
     await userEvent.click(screen.getByRole('button', { name: /disable group join lock/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(expect.stringMatching(/\/config\/group_join_locked$/), { value: 'false' });
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/config\/group_join_locked$/), { value: 'false' });
     });
   });
 
@@ -136,10 +136,10 @@ describe('Settings page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
-    axios.put.mockResolvedValue({});
+    api.put.mockResolvedValue({});
 
     render(
       <MemoryRouter>
@@ -157,10 +157,10 @@ describe('Settings page', () => {
   });
 
   it('shows error message when update fails', async () => {
-    axios.get.mockResolvedValue({
+    api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },
     });
-    axios.put.mockRejectedValue(new Error('Network error'));
+    api.put.mockRejectedValue(new Error('Network error'));
 
     render(
       <MemoryRouter>
@@ -178,7 +178,7 @@ describe('Settings page', () => {
   });
 
   it('shows error message when initial load fails', async () => {
-    axios.get.mockRejectedValue(new Error('Network error'));
+    api.get.mockRejectedValue(new Error('Network error'));
 
     render(
       <MemoryRouter>

--- a/frontend/tests/unit/pages/Users.test.jsx
+++ b/frontend/tests/unit/pages/Users.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import axios from 'axios';
+import api from '@/utils/api';
 import Users from '../../../src/pages/Users.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
 
-jest.mock('axios');
+jest.mock('@/utils/api');
 jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
@@ -43,7 +43,7 @@ describe('Users page', () => {
   });
 
   it('shows loading spinner before data resolves', () => {
-    axios.get.mockImplementation(() => new Promise(() => {}));
+    api.get.mockImplementation(() => new Promise(() => {}));
 
     const { container } = render(
       <MemoryRouter>
@@ -56,7 +56,7 @@ describe('Users page', () => {
   });
 
   it('renders users after successful fetch', async () => {
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -75,7 +75,7 @@ describe('Users page', () => {
   });
 
   it('shows error when fetch fails', async () => {
-    axios.get.mockRejectedValue(new Error('nope'));
+    api.get.mockRejectedValue(new Error('nope'));
 
     render(
       <MemoryRouter>
@@ -89,7 +89,7 @@ describe('Users page', () => {
   });
 
   it('shows empty state when no users are returned', async () => {
-    axios.get.mockResolvedValue({ data: { users: [], groups: [] } });
+    api.get.mockResolvedValue({ data: { users: [], groups: [] } });
 
     render(
       <MemoryRouter>
@@ -106,14 +106,14 @@ describe('Users page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } })
       .mockResolvedValueOnce({
         data: { users: [{ ...initialUsers[0], group_name: 'Group A' }] },
       })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    axios.put.mockResolvedValue({});
+    api.put.mockResolvedValue({});
 
     render(
       <MemoryRouter>
@@ -133,7 +133,7 @@ describe('Users page', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(
+      expect(api.put).toHaveBeenCalledWith(
         expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
         { groupId: 'g0000000-0000-0000-0000-000000000002' }
       );
@@ -161,7 +161,7 @@ describe('Users page', () => {
       member_count: 2,
     };
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: [fullGroup, openGroup] } });
 
@@ -189,12 +189,12 @@ describe('Users page', () => {
       { ...initialUsers[0], group_name: 'Group A', group_id: 'g0000000-0000-0000-0000-000000000002' },
     ];
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: usersInGroup } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } })
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    axios.put.mockResolvedValue({});
+    api.put.mockResolvedValue({});
 
     render(
       <MemoryRouter>
@@ -211,7 +211,7 @@ describe('Users page', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(
+      expect(api.put).toHaveBeenCalledWith(
         expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
         {
           groupId: null,
@@ -230,10 +230,10 @@ describe('Users page', () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    axios.put.mockRejectedValue({ response: { data: { error: 'Update denied' } } });
+    api.put.mockRejectedValue({ response: { data: { error: 'Update denied' } } });
 
     render(
       <MemoryRouter>
@@ -264,7 +264,7 @@ describe('Users page', () => {
 
   describe('Create User', () => {
     const setupRenderedPage = async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -321,9 +321,9 @@ describe('Users page', () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupRenderedPage();
 
-      axios.post.mockResolvedValue({ data: { message: 'User created successfully' } });
+      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
       // Mock refetch after create
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -335,7 +335,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/users$/),
           expect.objectContaining({
             username: 'newuser',
@@ -359,7 +359,7 @@ describe('Users page', () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      axios.post.mockRejectedValue({ response: { data: { error: 'Username already exists' }, status: 409 } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Username already exists' }, status: 409 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
       await user.type(screen.getByPlaceholderText('Enter username'), 'existing');
@@ -377,7 +377,7 @@ describe('Users page', () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      axios.post.mockRejectedValue({ response: { data: { error: 'Invalid input' }, status: 400 } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Invalid input' }, status: 400 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
       await user.type(screen.getByPlaceholderText('Enter username'), 'baduser');
@@ -395,7 +395,7 @@ describe('Users page', () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      axios.post.mockRejectedValue({ response: { data: { error: 'Server error' }, status: 500 } });
+      api.post.mockRejectedValue({ response: { data: { error: 'Server error' }, status: 500 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
       await user.type(screen.getByPlaceholderText('Enter username'), 'baduser');
@@ -441,8 +441,8 @@ describe('Users page', () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupRenderedPage();
 
-      axios.post.mockResolvedValue({ data: { message: 'User created' } });
-      axios.get
+      api.post.mockResolvedValue({ data: { message: 'User created' } });
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -455,7 +455,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/users$/),
           expect.objectContaining({
             username: 'jdoe',
@@ -483,8 +483,8 @@ describe('Users page', () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupRenderedPage();
 
-      axios.post.mockResolvedValue({ data: { message: 'User created successfully' } });
-      axios.get
+      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -496,7 +496,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/users$/),
           expect.objectContaining({ sendSetupEmail: false })
         );
@@ -508,8 +508,8 @@ describe('Users page', () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupRenderedPage();
 
-      axios.post.mockResolvedValue({ data: { message: 'User created successfully' } });
-      axios.get
+      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -522,7 +522,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(
+        expect(api.post).toHaveBeenCalledWith(
           expect.stringMatching(/\/users$/),
           expect.objectContaining({ sendSetupEmail: true })
         );
@@ -564,7 +564,7 @@ describe('Users page', () => {
       },
     ];
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: usersWithRoles } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -594,7 +594,7 @@ describe('Users page', () => {
       ...initialUsers[0],
       role_name: 'admin',
     };
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: [adminUser] } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -613,7 +613,7 @@ describe('Users page', () => {
       ...initialUsers[0],
       role_name: 'assignment_manager',
     };
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: [managerUser] } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -630,7 +630,7 @@ describe('Users page', () => {
   it('cancels group assignment inline', async () => {
     const user = userEvent.setup();
 
-    axios.get
+    api.get
       .mockResolvedValueOnce({ data: { users: initialUsers } })
       .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -653,7 +653,7 @@ describe('Users page', () => {
 
   describe('Edit User', () => {
     const setupRenderedPage = async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -725,15 +725,15 @@ describe('Users page', () => {
       await user.clear(lastNameInput);
       await user.type(lastNameInput, 'NewLast');
 
-      axios.put.mockResolvedValue({});
-      axios.get
+      api.put.mockResolvedValue({});
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001$/),
           expect.objectContaining({ email: 'u1@test.com', firstName: 'NewFirst', lastName: 'NewLast' })
         );
@@ -770,15 +770,15 @@ describe('Users page', () => {
       const enabledCheckbox = screen.getByRole('checkbox', { name: /enabled/i });
       await user.click(enabledCheckbox);
 
-      axios.put.mockResolvedValue({});
-      axios.get
+      api.put.mockResolvedValue({});
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001$/),
           expect.objectContaining({
             email: 'new@test.com',
@@ -827,7 +827,7 @@ describe('Users page', () => {
 
       await user.click(screen.getByRole('button', { name: /edit user profile/i }));
 
-      axios.put.mockRejectedValue({ response: { data: { error: 'Username taken' } } });
+      api.put.mockRejectedValue({ response: { data: { error: 'Username taken' } } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -846,15 +846,15 @@ describe('Users page', () => {
       const roleSelect = within(modal).getByRole('combobox');
       await user.selectOptions(roleSelect, 'assignment_manager');
 
-      axios.put.mockResolvedValue({});
-      axios.get
+      api.put.mockResolvedValue({});
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\//),
           expect.objectContaining({ role: 'assignment_manager' })
         );
@@ -875,15 +875,15 @@ describe('Users page', () => {
       const enabledCheckbox = screen.getByRole('checkbox', { name: /enabled/i });
       await user.click(enabledCheckbox);
 
-      axios.put.mockResolvedValue({});
-      axios.get
+      api.put.mockResolvedValue({});
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
-        expect(axios.put).toHaveBeenCalledWith(
+        expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\//),
           expect.objectContaining({ enabled: false })
         );
@@ -938,7 +938,7 @@ describe('Users page', () => {
     let anchorClick;
 
     const setupRenderedPage = async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: multiUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1049,7 +1049,7 @@ describe('Users page', () => {
   // ── Delete user ────────────────────────────────────────────────────────
   describe('Delete user', () => {
     const setupDeletePage = async (users = initialUsers) => {
-      axios.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
       render(
         <MemoryRouter>
           <Users />
@@ -1146,16 +1146,14 @@ describe('Users page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupDeletePage();
-      axios.delete.mockResolvedValueOnce({});
-      axios.get
-        .mockResolvedValueOnce({ data: { users: [] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
       await user.click(screen.getByRole('button', { name: /delete 1 user$/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledWith(
+        expect(api.delete).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001$/)
         );
         expect(screen.getByText('User deleted successfully')).toBeInTheDocument();
@@ -1169,7 +1167,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /delete user/i }));
       await user.click(screen.getByRole('button', { name: /cancel/i }));
 
-      expect(axios.delete).not.toHaveBeenCalled();
+      expect(api.delete).not.toHaveBeenCalled();
       expect(screen.queryByText(/delete 1 user\?/i)).not.toBeInTheDocument();
     });
 
@@ -1177,7 +1175,7 @@ describe('Users page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupDeletePage();
-      axios.delete.mockRejectedValue({ response: { data: { error: 'Cannot delete user' } } });
+      api.delete.mockRejectedValue({ response: { data: { error: 'Cannot delete user' } } });
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
       await user.click(screen.getByRole('button', { name: /delete 1 user$/i }));
@@ -1245,16 +1243,14 @@ describe('Users page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValue({});
-      axios.get
-        .mockResolvedValueOnce({ data: { users: [] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.delete.mockResolvedValue({});
+      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledTimes(1);
-        expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk$/), {
+        expect(api.delete).toHaveBeenCalledTimes(1);
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk$/), {
           data: { ids: expect.arrayContaining(['u1', 'u2']) },
         });
         expect(screen.getByText('Deleted 2 users')).toBeInTheDocument();
@@ -1279,7 +1275,7 @@ describe('Users page', () => {
     };
 
     it('shows "Send Setup Email" button when pending users exist', async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [pendingUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1295,7 +1291,7 @@ describe('Users page', () => {
     });
 
     it('does not show "Send Setup Email" button when no pending users exist', async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [activeUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1313,7 +1309,7 @@ describe('Users page', () => {
 
     it('shows confirmation modal when clicking Send Setup Emails button', async () => {
       const user = userEvent.setup();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [pendingUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1331,12 +1327,12 @@ describe('Users page', () => {
 
       expect(screen.getByRole('heading', { name: /send setup email\??/i })).toBeInTheDocument();
       expect(screen.getByText(/1 pending user/i)).toBeInTheDocument();
-      expect(axios.post).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
     });
 
     it('cancels sending when Cancel is clicked in confirmation modal', async () => {
       const user = userEvent.setup();
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [pendingUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1354,16 +1350,16 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /cancel/i }));
 
       expect(screen.queryByText(/1 pending user/i)).not.toBeInTheDocument();
-      expect(axios.post).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
     });
 
     it('calls send-setup-emails API for all pending users after confirming', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [pendingUser, activeUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
-      axios.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
+      api.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
 
       render(
         <MemoryRouter>
@@ -1379,7 +1375,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^send$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(expect.stringContaining('/users/send-setup-emails'), {});
+        expect(api.post).toHaveBeenCalledWith(expect.stringContaining('/users/send-setup-emails'), {});
       });
     });
 
@@ -1392,10 +1388,10 @@ describe('Users page', () => {
         username: 'pending2',
         email: 'pending2@test.com',
       };
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [pendingUser, pendingUser2] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
-      axios.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
+      api.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
 
       render(
         <MemoryRouter>
@@ -1415,7 +1411,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('button', { name: /^send$/i }));
 
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith(expect.stringContaining('/users/send-setup-emails'), {
+        expect(api.post).toHaveBeenCalledWith(expect.stringContaining('/users/send-setup-emails'), {
           userIds: ['u0000000-0000-0000-0000-000000000010'],
         });
       });
@@ -1453,7 +1449,7 @@ describe('Users page', () => {
     ];
 
     const renderSearchPage = async () => {
-      axios.get.mockResolvedValueOnce({ data: { users: searchUsers } }).mockResolvedValueOnce({ data: { groups: [] } });
+      api.get.mockResolvedValueOnce({ data: { users: searchUsers } }).mockResolvedValueOnce({ data: { groups: [] } });
       render(
         <MemoryRouter>
           <Users />
@@ -1525,7 +1521,7 @@ describe('Users page', () => {
   // ── handleDeleteConfirmed routing (single vs bulk) ─────────────────────
   describe('handleDeleteConfirmed routing (single vs bulk)', () => {
     const setupDeletePage = async (users = initialUsers) => {
-      axios.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
       render(
         <MemoryRouter>
           <Users />
@@ -1538,19 +1534,17 @@ describe('Users page', () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       await setupDeletePage();
-      axios.delete.mockResolvedValueOnce({});
-      axios.get
-        .mockResolvedValueOnce({ data: { users: [] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
       await user.click(screen.getByRole('button', { name: /delete 1 user$/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledWith(
+        expect(api.delete).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001$/)
         );
-        expect(axios.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk/));
+        expect(api.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk/));
       });
     });
 
@@ -1566,16 +1560,14 @@ describe('Users page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValueOnce({});
-      axios.get
-        .mockResolvedValueOnce({ data: { users: [] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledTimes(1);
-        expect(axios.delete).toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk$/), {
+        expect(api.delete).toHaveBeenCalledTimes(1);
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/users\/bulk$/), {
           data: { ids: expect.arrayContaining(['u1', 'u2']) },
         });
       });
@@ -1593,10 +1585,8 @@ describe('Users page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockResolvedValueOnce({});
-      axios.get
-        .mockResolvedValueOnce({ data: { users: [] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.delete.mockResolvedValueOnce({});
+      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
@@ -1615,7 +1605,7 @@ describe('Users page', () => {
       await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      axios.delete.mockRejectedValue({ response: { data: { error: 'Bulk user delete failed' } } });
+      api.delete.mockRejectedValue({ response: { data: { error: 'Bulk user delete failed' } } });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
@@ -1633,7 +1623,7 @@ describe('Users page', () => {
       };
 
       // Initial load — user has no group
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [staleUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1646,7 +1636,7 @@ describe('Users page', () => {
       await waitFor(() => expect(screen.getByText('Not assigned')).toBeInTheDocument());
 
       // Simulate another tab assigning the user to a group, then this tab regaining focus
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: [freshUser] } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1657,7 +1647,7 @@ describe('Users page', () => {
     });
 
     it('does not re-fetch when the tab becomes hidden', async () => {
-      axios.get
+      api.get
         .mockResolvedValueOnce({ data: { users: initialUsers } })
         .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
@@ -1669,12 +1659,12 @@ describe('Users page', () => {
 
       await waitFor(() => expect(screen.getByText('u1')).toBeInTheDocument());
 
-      const callsBefore = axios.get.mock.calls.length;
+      const callsBefore = api.get.mock.calls.length;
 
       Object.defineProperty(document, 'hidden', { value: true, configurable: true, writable: true });
       document.dispatchEvent(new Event('visibilitychange'));
 
-      expect(axios.get.mock.calls.length).toBe(callsBefore);
+      expect(api.get.mock.calls.length).toBe(callsBefore);
     });
   });
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
 
 const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
 /* global process */
@@ -21,8 +23,15 @@ function resolveGitHash() {
 
 const gitHash = resolveGitHash();
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
     __GIT_HASH__: JSON.stringify(gitHash),


### PR DESCRIPTION
## Summary
- Creates `frontend/src/utils/api.js` — a dedicated axios instance with a request interceptor that reads the token from `localStorage` and attaches `Authorization: Bearer <token>` per-request
- Removes the `useEffect` in `AuthContext` that mutated `axios.defaults.headers.common`, eliminating the shared global state hazard
- Updates all 9 page/component files to import `api` from `@/utils/api` instead of the global `axios`
- Adds `frontend/src/utils/__mocks__/api.js` as a Jest manual mock, and updates all 10 test files accordingly

## Test plan
- [x] All 502 tests pass (`npm run test:quiet`)
- [x] Linter passes with zero warnings (`npm run lint`)

Closes #61