### PR TITLE
fix: remove unused @fastify/postgres dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,6 @@
         "@fastify/cors": "^11.2.0",
         "@fastify/helmet": "^13.0.2",
         "@fastify/jwt": "^10.0.0",
-        "@fastify/postgres": "^6.0.2",
         "@fastify/rate-limit": "^10.3.0",
         "bcryptjs": "^3.0.3",
         "dompurify": "^3.3.3",
@@ -1199,28 +1198,6 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@fastify/postgres": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@fastify/postgres/-/postgres-6.0.2.tgz",
-      "integrity": "sha512-b8JKy/aNcz/iKzFEe0Qwx7xkk2lmcQXxylg6jOctYCpNW/shSJZunIhMrTI3J5GQQubtMmRGXEiwfKdq5h4LNQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fastify-plugin": "^5.0.0"
-      },
-      "peerDependencies": {
-        "pg": ">=6.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,6 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/jwt": "^10.0.0",
-    "@fastify/postgres": "^6.0.2",
     "@fastify/rate-limit": "^10.3.0",
     "bcryptjs": "^3.0.3",
     "dompurify": "^3.3.3",


### PR DESCRIPTION
## Summary
- Removes `@fastify/postgres` from `backend/package.json` and regenerates `package-lock.json`
- The package was never imported or used anywhere in the codebase — the app connects to PostgreSQL directly via `pg.Pool`

## Test plan
- [x] All 502 tests pass (`npm run test:quiet`)
- [x] Linter passes with zero warnings (`npm run lint`)

Closes #57