### PR TITLE
feat: add top-level error boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -20,8 +20,8 @@ class ErrorBoundary extends Component {
   }
 
   handleReload() {
-    if (this.props.onReset) {
-      this.props.onReset();
+    if (typeof this.props.onReset === 'function') {
+      this.setState({ hasError: false }, () => this.props.onReset());
     } else {
       window.location.reload();
     }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,52 @@
+import { Component } from 'react';
+import { logger } from '../utils/logger.js';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+    this.handleReload = this.handleReload.bind(this);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    logger.error('Unhandled error caught by ErrorBoundary', {
+      message: error.message,
+      componentStack: info.componentStack,
+    });
+  }
+
+  handleReload() {
+    if (this.props.onReset) {
+      this.props.onReset();
+    } else {
+      window.location.reload();
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <div className="text-center max-w-md px-4">
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">Something went wrong</h1>
+            <p className="text-gray-600 mb-6">An unexpected error occurred. Please try refreshing the page.</p>
+            <button
+              onClick={this.handleReload}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              Refresh page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -13,9 +13,10 @@ class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, info) {
+    const message = error instanceof Error ? error.message : String(error);
     logger.error('Unhandled error caught by ErrorBoundary', {
-      message: error.message,
-      componentStack: info.componentStack,
+      message,
+      componentStack: info?.componentStack,
     });
   }
 

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -13,9 +13,12 @@ class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, info) {
-    const message = error instanceof Error ? error.message : String(error);
+    const isError = error instanceof Error;
+    const message = isError ? error.message : String(error);
     logger.error('Unhandled error caught by ErrorBoundary', {
+      name: isError ? error.name : undefined,
       message,
+      stack: isError ? error.stack : undefined,
       componentStack: info?.componentStack,
     });
   }
@@ -37,7 +40,7 @@ class ErrorBoundary extends Component {
             <p className="text-gray-600 mb-6">An unexpected error occurred. Please try refreshing the page.</p>
             <button
               onClick={this.handleReload}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
             >
               Refresh page
             </button>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import ErrorBoundary from './components/ErrorBoundary.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/tests/unit/components/ErrorBoundary.test.jsx
+++ b/frontend/tests/unit/components/ErrorBoundary.test.jsx
@@ -98,4 +98,23 @@ describe('ErrorBoundary', () => {
       expect.objectContaining({ message: 'Test error' })
     );
   });
+
+  it('logs a normalized message when a non-Error value is thrown', () => {
+    jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    function ThrowingString() {
+      throw 'raw string error';
+    }
+
+    render(
+      <ErrorBoundary>
+        <ThrowingString />
+      </ErrorBoundary>
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unhandled error caught by ErrorBoundary',
+      expect.objectContaining({ message: 'raw string error' })
+    );
+  });
 });

--- a/frontend/tests/unit/components/ErrorBoundary.test.jsx
+++ b/frontend/tests/unit/components/ErrorBoundary.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '../../../src/components/ErrorBoundary.jsx';
+import { logger } from '../../../src/utils/logger.js';
+
+function ThrowingComponent({ shouldThrow }) {
+  if (shouldThrow) {
+    throw new Error('Test error');
+  }
+  return <div>Safe content</div>;
+}
+
+// Suppress the expected React error output during these tests.
+// jest.restoreAllMocks() in setup.js afterEach handles restoration.
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Safe content')).toBeInTheDocument();
+  });
+
+  it('renders fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.queryByText('Safe content')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+    expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+  });
+
+  it('shows a refresh button in the fallback UI', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('button', { name: /refresh page/i })).toBeInTheDocument();
+  });
+
+  it('calls the onReset prop when the refresh button is clicked', () => {
+    const onReset = jest.fn();
+
+    render(
+      <ErrorBoundary onReset={onReset}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh page/i }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the error via componentDidCatch', () => {
+    jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unhandled error caught by ErrorBoundary',
+      expect.objectContaining({ message: 'Test error' })
+    );
+  });
+});

--- a/frontend/tests/unit/components/ErrorBoundary.test.jsx
+++ b/frontend/tests/unit/components/ErrorBoundary.test.jsx
@@ -58,6 +58,32 @@ describe('ErrorBoundary', () => {
     expect(onReset).toHaveBeenCalledTimes(1);
   });
 
+  it('resets error state after onReset so children render again on next render', () => {
+    const onReset = jest.fn();
+
+    // 1. Render with a throwing child — boundary enters error state
+    const { rerender } = render(
+      <ErrorBoundary onReset={onReset}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+
+    // 2. Swap to a safe child while boundary is still in error state
+    rerender(
+      <ErrorBoundary onReset={onReset}>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    // Still showing fallback — hasError hasn't been cleared yet
+    expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+
+    // 3. Click reset — clears hasError, safe child renders normally
+    fireEvent.click(screen.getByRole('button', { name: /refresh page/i }));
+    expect(screen.queryByRole('heading', { name: /something went wrong/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Safe content')).toBeInTheDocument();
+  });
+
   it('logs the error via componentDidCatch', () => {
     jest.spyOn(logger, 'error').mockImplementation(() => {});
 

--- a/frontend/tests/unit/components/ErrorBoundary.test.jsx
+++ b/frontend/tests/unit/components/ErrorBoundary.test.jsx
@@ -84,7 +84,7 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Safe content')).toBeInTheDocument();
   });
 
-  it('logs the error via componentDidCatch', () => {
+  it('logs the error via componentDidCatch with name, message, and stack', () => {
     jest.spyOn(logger, 'error').mockImplementation(() => {});
 
     render(
@@ -95,7 +95,11 @@ describe('ErrorBoundary', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled error caught by ErrorBoundary',
-      expect.objectContaining({ message: 'Test error' })
+      expect.objectContaining({
+        name: 'Error',
+        message: 'Test error',
+        stack: expect.stringContaining('Test error'),
+      })
     );
   });
 
@@ -114,7 +118,7 @@ describe('ErrorBoundary', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled error caught by ErrorBoundary',
-      expect.objectContaining({ message: 'raw string error' })
+      expect.objectContaining({ name: undefined, message: 'raw string error', stack: undefined })
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `ErrorBoundary` class component (`frontend/src/components/ErrorBoundary.jsx`) using `getDerivedStateFromError` and `componentDidCatch`
- Wraps `<App />` in `frontend/src/main.jsx` with `<ErrorBoundary>` so any unhandled JS error in the tree renders a user-friendly fallback UI instead of a white screen
- Accepts optional `onReset` prop for custom reset behaviour (defaults to `window.location.reload()`)
- Logs caught errors via the existing PII-safe `logger.error`

## Test plan

- [ ] `ErrorBoundary` renders children when no error is thrown
- [ ] `ErrorBoundary` renders fallback UI (heading + message + button) when a child throws
- [ ] Refresh button is rendered in the fallback UI
- [ ] Clicking the button calls the `onReset` prop
- [ ] `componentDidCatch` logs the error via `logger.error`
- [ ] All 507 existing frontend tests still pass
- [ ] Linter passes with zero warnings

Closes #69