### PR TITLE
fix: fall back to github.repository_owner for Docker image name when DOCKERHUB_USERNAME is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/gap-${{ matrix.service }}
+          images: ${{ secrets.DOCKERHUB_USERNAME || github.repository_owner }}/gap-${{ matrix.service }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Summary

- Dependabot PRs run in a restricted context without access to repository secrets, causing `DOCKERHUB_USERNAME` to resolve to an empty string
- This produced the invalid Docker image tag `/gap-backend:pr-N` (leading slash), failing the `Build and push` step for every Dependabot PR
- Fix: use `${{ secrets.DOCKERHUB_USERNAME || github.repository_owner }}` so a valid image name is always generated for PR builds

## Behaviour

| Context | Before | After |
|---|---|---|
| Dependabot / forks (no secret) | `/gap-backend:pr-N` ❌ invalid | `alwynpan/gap-backend:pr-N` ✅ valid |
| Main / tag push (secret present) | `myuser/gap-backend:latest` ✅ | `myuser/gap-backend:latest` ✅ unchanged |

The `push:` step remains gated on `github.event_name == 'push' && refs/heads/main`, so no images are accidentally pushed using the fallback name.

## Test plan

- [ ] Verify CI passes on this PR (no secrets needed — Docker build only, no push)
- [ ] Merge PR #104 after this lands and confirm its Docker build passes

## Related

Fixes the backend Docker build failure observed on alwynpan/gap-app#104 (Dependabot picomatch bump).