### PR TITLE
fix(security): add per-route rate limit to PUT /users/:id/password

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -14,11 +14,14 @@ const {
   ROLE_VALUES,
 } = require('../utils/schemas');
 const { logger } = require('../utils/logger');
+const config = require('../config/index');
 
 const _parsed = parseInt(process.env.MAX_IMPORT_SIZE || '2000', 10);
 const MAX_IMPORT_SIZE = Number.isNaN(_parsed) ? 2000 : _parsed;
 
 async function usersRoutes(fastify, _options) {
+  const isDev = config.app.nodeEnv === 'development';
+
   // Get all users (admin/assignment_manager only) — supports ?role=, ?status=, ?groupId= filters
   fastify.get(
     '/users',
@@ -406,9 +409,16 @@ async function usersRoutes(fastify, _options) {
   );
 
   // Change password (only the current logged-in user can change their own password)
+  // Rate-limited to prevent brute-force of the current-password check (fixes code scanning alert #10)
   fastify.put(
     '/users/:id/password',
     {
+      config: {
+        rateLimit: {
+          max: isDev ? 500 : 10,
+          timeWindow: '15 minutes',
+        },
+      },
       preHandler: async (request, reply) => {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2118,6 +2118,18 @@ describe('Users Routes', () => {
       );
       expect(mockReply.code).toHaveBeenCalledWith(500);
     });
+
+    it('registers with a per-route rate limit to prevent brute-force (code scanning alert #10)', () => {
+      const mockFastify = createMockFastify();
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const putCall = mockFastify.put.mock.calls.find(([path]) => path === '/users/:id/password');
+      expect(putCall).toBeDefined();
+      const routeConfig = putCall[1];
+      expect(routeConfig.config.rateLimit).toBeDefined();
+      expect(routeConfig.config.rateLimit.max).toBeGreaterThan(0);
+      expect(routeConfig.config.rateLimit.timeWindow).toBeDefined();
+    });
   });
 
   describe('DELETE /users/:id - error handling', () => {

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2126,6 +2126,7 @@ describe('Users Routes', () => {
       const putCall = mockFastify.put.mock.calls.find(([path]) => path === '/users/:id/password');
       expect(putCall).toBeDefined();
       const routeConfig = putCall[1];
+      expect(routeConfig.config).toBeDefined();
       expect(routeConfig.config.rateLimit).toBeDefined();
       expect(routeConfig.config.rateLimit.max).toBeGreaterThan(0);
       expect(routeConfig.config.rateLimit.timeWindow).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds a `config.rateLimit` block (10 req / 15 min in prod, 500 in dev) to `PUT /users/:id/password` in `backend/src/routes/users.js`
- Imports `config` and computes `isDev` at the top of `usersRoutes` — matching the pattern used in `auth.js`
- Adds a unit test asserting the route is registered with a rate-limit config

## Fixes

Resolves code scanning alert **#10** (`js/missing-rate-limiting`).

The change-password route requires the caller to supply their current password, which is verified via `bcrypt.compare`. Without a rate limit an attacker can brute-force the current-password check at full speed. The new limit mirrors the approach already applied to `/auth/login` and `/auth/forgot-password`.

## False positives dismissed separately

- **Alert #8** (`/auth/login`) — rate limiting was already present via `config.rateLimit` (5 req/min). CodeQL does not recognise the Fastify per-route config pattern.
- **Alert #9** (`server.js preHandler`) — the hook decodes a JWT for convenience but performs no credential check; requests without a valid token are handled by route-level `preHandler` guards.

## Test plan

- [ ] `npm test` passes (578 tests, all green)
- [ ] `npm run lint` passes with zero warnings
- [ ] Code scanning alert #10 closes automatically after merge