### PR TITLE
fix(ci): restrict GITHUB_TOKEN to contents:read via explicit permissions block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -183,6 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     permissions:
+      contents: read
       pull-requests: write
       checks: write
     env:


### PR DESCRIPTION
## Summary

- Adds a workflow-level `permissions: contents: read` block, restricting the default `GITHUB_TOKEN` grant from broad write access to read-only
- Adds `contents: read` to the `test-e2e` job's existing permissions block (job-level permissions fully replace workflow-level for that job, so it must be listed explicitly)
- All other jobs inherit `contents: read` from the workflow-level block

## Fixes

Resolves code scanning alerts **#1, #2, #3, #4, #5, #6, #7** (`actions/missing-workflow-permissions`).

Without an explicit `permissions` block GitHub Actions defaults `GITHUB_TOKEN` to broad write access. A compromised third-party action could use this token to push code, create releases, or exfiltrate secrets.

## Test plan

- [ ] CI passes on this PR (all jobs can still checkout and run — `contents: read` is sufficient)
- [ ] Allure report publisher on `test-e2e` still works (`pull-requests: write` + `checks: write` retained)
- [ ] Code scanning alerts #1–#7 close automatically after merge