### PR TITLE
perf: batch-lookup import endpoints to eliminate N+1 queries

### DIFF
--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -173,6 +173,15 @@ class Group {
     return result.rows[0] || null;
   }
 
+  static async findByNames(names) {
+    if (!names || names.length === 0) {
+      return [];
+    }
+    const lower = names.map((n) => n.toLowerCase());
+    const result = await pool.query('SELECT * FROM groups WHERE LOWER(name) = ANY($1)', [lower]);
+    return result.rows;
+  }
+
   static async getExportMappings() {
     const result = await pool.query(
       `SELECT u.email, g.name AS group_name

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -119,6 +119,53 @@ class User {
     return result.rows[0] || null;
   }
 
+  static async findByEmails(emails) {
+    if (!emails || emails.length === 0) {
+      return [];
+    }
+    const result = await pool.query(
+      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
+              u.group_id, u.enabled, u.status, u.created_at, u.updated_at,
+              u.role_id, r.name as role_name
+       FROM users u
+       LEFT JOIN roles r ON u.role_id = r.id
+       WHERE u.email = ANY($1)`,
+      [emails]
+    );
+    return result.rows;
+  }
+
+  static async findByUsernames(usernames) {
+    if (!usernames || usernames.length === 0) {
+      return [];
+    }
+    const lower = usernames.map((u) => u.toLowerCase());
+    const result = await pool.query(
+      `SELECT u.id, u.username, u.email, u.password_hash, u.first_name, u.last_name,
+              u.student_id, u.enabled, u.status,
+              u.group_id, g.name as group_name,
+              u.role_id, r.name as role_name
+       FROM users u
+       LEFT JOIN groups g ON u.group_id = g.id
+       LEFT JOIN roles r ON u.role_id = r.id
+       WHERE LOWER(u.username) = ANY($1)`,
+      [lower]
+    );
+    return result.rows;
+  }
+
+  static async findByStudentIds(studentIds) {
+    if (!studentIds || studentIds.length === 0) {
+      return [];
+    }
+    const result = await pool.query(
+      `SELECT id, username, email, first_name, last_name, student_id, group_id, enabled, status, created_at, updated_at, role_id
+       FROM users WHERE student_id = ANY($1)`,
+      [studentIds]
+    );
+    return result.rows;
+  }
+
   static async create(userData) {
     const { username, email, password, firstName, lastName, studentId, groupId, roleId } = userData;
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -504,24 +504,22 @@ async function groupsRoutes(fastify, _options) {
         const skipped = [];
         const errors = [];
 
-        // First pass: categorise rows without touching the DB
-        const skipRows = [];
-        const validationErrorRows = [];
-        const validRows = [];
-
+        // First pass: parse all rows while preserving input order for deterministic output
+        const parsedRows = [];
         for (const rawRow of rows) {
           if (rawRow.action === 'skip') {
             const email = typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?';
             const groupName = typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?';
             const rawReason = typeof rawRow.skipReason === 'string' ? rawRow.skipReason : '';
             const reason = sanitize(rawReason).slice(0, 500) || 'Skipped';
-            skipRows.push({ email, groupName, reason });
+            parsedRows.push({ type: 'skip', email, groupName, reason });
             continue;
           }
 
           const parseResult = importGroupMappingRowSchema.safeParse(rawRow);
           if (!parseResult.success) {
-            validationErrorRows.push({
+            parsedRows.push({
+              type: 'invalid',
               email: typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?',
               groupName: typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?',
               error: parseResult.error.issues[0]?.message || 'Validation failed',
@@ -529,10 +527,11 @@ async function groupsRoutes(fastify, _options) {
             continue;
           }
 
-          validRows.push(parseResult.data);
+          parsedRows.push({ type: 'valid', ...parseResult.data });
         }
 
         // Batch lookups — 2 queries regardless of import size
+        const validRows = parsedRows.filter((r) => r.type === 'valid');
         const uniqueEmails = [...new Set(validRows.map((r) => r.email))];
         const uniqueGroupNames = [...new Set(validRows.map((r) => r.groupName))];
 
@@ -554,12 +553,18 @@ async function groupsRoutes(fastify, _options) {
           groupsByName.set(normalizedName, group);
         }
 
-        // Accumulate pre-categorised results
-        skipped.push(...skipRows);
-        errors.push(...validationErrorRows);
+        // Second pass: emit results in original row order
+        for (const parsed of parsedRows) {
+          if (parsed.type === 'skip') {
+            skipped.push({ email: parsed.email, groupName: parsed.groupName, reason: parsed.reason });
+            continue;
+          }
+          if (parsed.type === 'invalid') {
+            errors.push({ email: parsed.email, groupName: parsed.groupName, error: parsed.error });
+            continue;
+          }
 
-        // Second pass: process valid rows using in-memory maps
-        for (const { email, groupName } of validRows) {
+          const { email, groupName } = parsed;
           try {
             const user = usersByEmail.get(email);
             if (!user) {

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -542,7 +542,17 @@ async function groupsRoutes(fastify, _options) {
         ]);
 
         const usersByEmail = new Map(usersArr.map((u) => [u.email, u]));
-        const groupsByName = new Map(groupsArr.map((g) => [g.name.toLowerCase(), g]));
+        const groupsByName = new Map();
+        for (const group of groupsArr) {
+          const normalizedName = group.name.toLowerCase();
+          const existing = groupsByName.get(normalizedName);
+          if (existing && existing.id !== group.id) {
+            return reply.code(409).send({
+              error: `Ambiguous group name: "${group.name}" matches multiple groups that differ only by case`,
+            });
+          }
+          groupsByName.set(normalizedName, group);
+        }
 
         // Accumulate pre-categorised results
         skipped.push(...skipRows);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -504,19 +504,24 @@ async function groupsRoutes(fastify, _options) {
         const skipped = [];
         const errors = [];
 
+        // First pass: categorise rows without touching the DB
+        const skipRows = [];
+        const validationErrorRows = [];
+        const validRows = [];
+
         for (const rawRow of rows) {
           if (rawRow.action === 'skip') {
             const email = typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?';
             const groupName = typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?';
             const rawReason = typeof rawRow.skipReason === 'string' ? rawRow.skipReason : '';
             const reason = sanitize(rawReason).slice(0, 500) || 'Skipped';
-            skipped.push({ email, groupName, reason });
+            skipRows.push({ email, groupName, reason });
             continue;
           }
 
           const parseResult = importGroupMappingRowSchema.safeParse(rawRow);
           if (!parseResult.success) {
-            errors.push({
+            validationErrorRows.push({
               email: typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?',
               groupName: typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?',
               error: parseResult.error.issues[0]?.message || 'Validation failed',
@@ -524,10 +529,29 @@ async function groupsRoutes(fastify, _options) {
             continue;
           }
 
-          const { email, groupName } = parseResult.data;
+          validRows.push(parseResult.data);
+        }
 
+        // Batch lookups — 2 queries regardless of import size
+        const uniqueEmails = [...new Set(validRows.map((r) => r.email))];
+        const uniqueGroupNames = [...new Set(validRows.map((r) => r.groupName))];
+
+        const [usersArr, groupsArr] = await Promise.all([
+          User.findByEmails(uniqueEmails),
+          Group.findByNames(uniqueGroupNames),
+        ]);
+
+        const usersByEmail = new Map(usersArr.map((u) => [u.email, u]));
+        const groupsByName = new Map(groupsArr.map((g) => [g.name.toLowerCase(), g]));
+
+        // Accumulate pre-categorised results
+        skipped.push(...skipRows);
+        errors.push(...validationErrorRows);
+
+        // Second pass: process valid rows using in-memory maps
+        for (const { email, groupName } of validRows) {
           try {
-            const user = await User.findByEmail(email);
+            const user = usersByEmail.get(email);
             if (!user) {
               skipped.push({ email, groupName, reason: 'User not found' });
               continue;
@@ -542,7 +566,7 @@ async function groupsRoutes(fastify, _options) {
               continue;
             }
 
-            const group = await Group.findByName(groupName);
+            const group = groupsByName.get(groupName.toLowerCase());
             if (!group) {
               skipped.push({ email, groupName, reason: 'Group not found' });
               continue;

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -727,7 +727,7 @@ async function usersRoutes(fastify, _options) {
             });
 
             // Keep maps in sync for within-batch duplicate detection
-            const newEntry = { ...newUser, role_name: 'user' };
+            const newEntry = { ...newUser, role_name: roleRecord.name };
             usernameMap.set(username.toLowerCase(), newEntry);
             emailMap.set(email, newEntry);
             if (studentId) {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -751,6 +751,7 @@ async function usersRoutes(fastify, _options) {
           }
         }
 
+        errors.sort((a, b) => a.row - b.row);
         return reply.send({ imported, skipped, errors });
       } catch (error) {
         logger.error('Import error', { err: error.message, code: error.code });

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -586,25 +586,51 @@ async function usersRoutes(fastify, _options) {
         let imported = 0;
         let skipped = 0;
         const errors = [];
-        let rowNum = 0;
 
-        for (const rawRow of usersToImport) {
-          rowNum++;
-
+        // First pass: parse all rows and collect unique keys for batch lookup
+        const parsedRows = [];
+        for (let rowNum = 1; rowNum <= usersToImport.length; rowNum++) {
+          const rawRow = usersToImport[rowNum - 1];
           const parseResult = importUserRowSchema.safeParse(rawRow);
           if (!parseResult.success) {
             const rawUsername = typeof rawRow.username === 'string' ? rawRow.username.slice(0, 100) : '';
             const rawEmail = typeof rawRow.email === 'string' ? rawRow.email.slice(0, 255) : '';
             const rowLabel = sanitize(rawUsername || rawEmail) || `row ${rowNum}`;
             errors.push({ row: rowNum, identifier: rowLabel, reason: 'Missing or invalid required fields' });
+            parsedRows.push(null);
             continue;
           }
+          parsedRows.push({ rowNum, ...parseResult.data });
+        }
 
-          const { username, email, firstName, lastName, studentId } = parseResult.data;
+        // Batch lookups — 3 queries regardless of import size
+        const validParsedRows = parsedRows.filter(Boolean);
+        const allUsernames = [...new Set(validParsedRows.map((r) => r.username.toLowerCase()))];
+        const allEmails = [...new Set(validParsedRows.map((r) => r.email))];
+        const allStudentIds = [...new Set(validParsedRows.filter((r) => r.studentId).map((r) => r.studentId))];
+
+        const [usernameRows, emailRows, studentIdRows] = await Promise.all([
+          User.findByUsernames(allUsernames),
+          User.findByEmails(allEmails),
+          User.findByStudentIds(allStudentIds),
+        ]);
+
+        const usernameMap = new Map(usernameRows.map((u) => [u.username.toLowerCase(), u]));
+        const emailMap = new Map(emailRows.map((u) => [u.email, u]));
+        const studentIdMap = new Map(studentIdRows.map((u) => [u.student_id, u]));
+
+        // Second pass: process rows using in-memory maps; update maps after each write
+        // for within-batch duplicate detection
+        for (const parsed of parsedRows) {
+          if (!parsed) {
+            continue; // validation error already recorded in first pass
+          }
+
+          const { rowNum, username, email, firstName, lastName, studentId } = parsed;
           const rowLabel = username || email || `row ${rowNum}`;
 
           try {
-            const existing = await User.findByUsername(username);
+            const existing = usernameMap.get(username.toLowerCase());
 
             if (existing) {
               if (conflictAction === 'skip') {
@@ -621,7 +647,7 @@ async function usersRoutes(fastify, _options) {
                 continue;
               }
               // Check if email would conflict with a different user
-              const emailOwner = await User.findByEmail(email);
+              const emailOwner = emailMap.get(email);
               if (emailOwner && emailOwner.id !== existing.id) {
                 errors.push({
                   row: rowNum,
@@ -632,7 +658,7 @@ async function usersRoutes(fastify, _options) {
               }
               // Check if student ID would conflict with a different user
               if (studentId) {
-                const sidOwner = await User.findByStudentId(studentId);
+                const sidOwner = studentIdMap.get(studentId);
                 if (sidOwner && sidOwner.id !== existing.id) {
                   errors.push({
                     row: rowNum,
@@ -643,12 +669,33 @@ async function usersRoutes(fastify, _options) {
                 }
               }
               await User.update(existing.id, { email, firstName, lastName, studentId: studentId || null });
+              // Keep maps in sync so subsequent rows in the same batch see current state
+              const updatedEntry = {
+                ...existing,
+                email,
+                first_name: firstName,
+                last_name: lastName,
+                student_id: studentId || null,
+              };
+              usernameMap.set(username.toLowerCase(), updatedEntry);
+              if (existing.email !== email) {
+                emailMap.delete(existing.email);
+                emailMap.set(email, updatedEntry);
+              }
+              if (existing.student_id !== (studentId || null)) {
+                if (existing.student_id) {
+                  studentIdMap.delete(existing.student_id);
+                }
+                if (studentId) {
+                  studentIdMap.set(studentId, updatedEntry);
+                }
+              }
               imported++;
               continue;
             }
 
-            // New user — check email and student ID uniqueness
-            const emailOwner = await User.findByEmail(email);
+            // New user — check email and student ID uniqueness using maps
+            const emailOwner = emailMap.get(email);
             if (emailOwner) {
               errors.push({
                 row: rowNum,
@@ -658,7 +705,7 @@ async function usersRoutes(fastify, _options) {
               continue;
             }
             if (studentId) {
-              const sidOwner = await User.findByStudentId(studentId);
+              const sidOwner = studentIdMap.get(studentId);
               if (sidOwner) {
                 errors.push({
                   row: rowNum,
@@ -678,6 +725,14 @@ async function usersRoutes(fastify, _options) {
               studentId: studentId || null,
               roleId: roleRecord.id,
             });
+
+            // Keep maps in sync for within-batch duplicate detection
+            const newEntry = { ...newUser, role_name: 'user' };
+            usernameMap.set(username.toLowerCase(), newEntry);
+            emailMap.set(email, newEntry);
+            if (studentId) {
+              studentIdMap.set(studentId, newEntry);
+            }
 
             if (sendSetupEmail) {
               try {

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -1436,6 +1436,34 @@ describe('Groups Routes', () => {
       expect(reply.code).not.toHaveBeenCalledWith(409);
       expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 1 }));
     });
+
+    it('preserves input row order across skip, validation error, and import rows', async () => {
+      const { handlers } = setupRoute();
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
+      Group.assignUserToGroup.mockResolvedValue();
+      const reply = mockReply();
+      await handlers['/groups/import-mappings_post'](
+        {
+          user: { id: 'u1', role: 'admin' },
+          body: {
+            rows: [
+              { email: 'alice@test.com', groupName: 'Team A', action: 'import' },
+              { email: 'bad@test.com', groupName: 'Team A', action: 'skip', skipReason: 'Manual skip' },
+              { email: '', groupName: '', action: 'import' }, // validation error
+            ],
+          },
+        },
+        reply
+      );
+      const result = reply.send.mock.calls[0][0];
+      // imported row comes first in original order
+      expect(result.imported).toBe(1);
+      // skip row (row 2) appears in skipped
+      expect(result.skipped[0].reason).toBe('Manual skip');
+      // validation error (row 3) appears in errors
+      expect(result.errors).toHaveLength(1);
+    });
   });
 
   describe('GET /groups/export-mappings', () => {

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -1151,6 +1151,11 @@ describe('Groups Routes', () => {
   });
 
   describe('POST /groups/import-mappings', () => {
+    beforeEach(() => {
+      User.findByEmails.mockResolvedValue([]);
+      Group.findByNames.mockResolvedValue([]);
+    });
+
     it('rejects unauthenticated request', () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
@@ -1193,8 +1198,10 @@ describe('Groups Routes', () => {
 
     it('imports a valid row successfully', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: '00000000-0000-4000-8000-000000000010' });
-      Group.findByName.mockResolvedValue({ id: '10000000-0000-4000-8000-000000000001' });
+      User.findByEmails.mockResolvedValue([
+        { id: '00000000-0000-4000-8000-000000000010', email: 'alice@test.com', role_name: 'user' },
+      ]);
+      Group.findByNames.mockResolvedValue([{ id: '10000000-0000-4000-8000-000000000001', name: 'Team A' }]);
       Group.assignUserToGroup.mockResolvedValue();
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
@@ -1206,6 +1213,33 @@ describe('Groups Routes', () => {
       );
       expect(Group.assignUserToGroup).toHaveBeenCalled();
       expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 1, skipped: [], errors: [] }));
+    });
+
+    it('performs exactly 2 batch DB queries for a valid import', async () => {
+      const { handlers } = setupRoute();
+      User.findByEmails.mockResolvedValue([
+        { id: 'u1', email: 'a@test.com', role_name: 'user' },
+        { id: 'u2', email: 'b@test.com', role_name: 'user' },
+      ]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
+      Group.assignUserToGroup.mockResolvedValue();
+      const reply = mockReply();
+      await handlers['/groups/import-mappings_post'](
+        {
+          user: { id: 'u1', role: 'admin' },
+          body: {
+            rows: [
+              { email: 'a@test.com', groupName: 'Team A', action: 'import' },
+              { email: 'b@test.com', groupName: 'Team A', action: 'import' },
+            ],
+          },
+        },
+        reply
+      );
+      expect(User.findByEmails).toHaveBeenCalledTimes(1);
+      expect(Group.findByNames).toHaveBeenCalledTimes(1);
+      expect(Group.assignUserToGroup).toHaveBeenCalledTimes(2);
+      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 2 }));
     });
 
     it('skips a row when action is skip', async () => {
@@ -1228,7 +1262,8 @@ describe('Groups Routes', () => {
 
     it('skips row when user not found', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue(null);
+      User.findByEmails.mockResolvedValue([]); // email not in DB
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1243,8 +1278,8 @@ describe('Groups Routes', () => {
 
     it('skips row when group not found', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: 'u1' });
-      Group.findByName.mockResolvedValue(null);
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([]); // group not in DB
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1259,8 +1294,8 @@ describe('Groups Routes', () => {
 
     it('records error when group is full', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: 'u1' });
-      Group.findByName.mockResolvedValue({ id: 'g1' });
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
       const fullErr = new Error('Group is full');
       fullErr.statusCode = 409;
       Group.assignUserToGroup.mockRejectedValue(fullErr);
@@ -1276,9 +1311,11 @@ describe('Groups Routes', () => {
       expect(result.errors[0].error).toBe('Group is full');
     });
 
-    it('records per-row DB error in errors array', async () => {
+    it('records per-row error when assignUserToGroup throws an unexpected error', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockRejectedValue(new Error('DB down'));
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
+      Group.assignUserToGroup.mockRejectedValue(new Error('DB connection lost'));
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1291,9 +1328,25 @@ describe('Groups Routes', () => {
       expect(result.errors[0].error).toBe('Failed to process row');
     });
 
+    it('returns 500 when batch lookup fails', async () => {
+      const { handlers } = setupRoute();
+      User.findByEmails.mockRejectedValue(new Error('DB down'));
+      const reply = mockReply();
+      await handlers['/groups/import-mappings_post'](
+        {
+          user: { id: 'u1', role: 'admin' },
+          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
+        },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to import mappings' });
+    });
+
     it('skips row when target user is an admin', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: 'admin1', role_name: 'admin' });
+      User.findByEmails.mockResolvedValue([{ id: 'admin1', email: 'admin@test.com', role_name: 'admin' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1309,7 +1362,8 @@ describe('Groups Routes', () => {
 
     it('skips row when target user is an assignment_manager', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: 'am1', role_name: 'assignment_manager' });
+      User.findByEmails.mockResolvedValue([{ id: 'am1', email: 'am@test.com', role_name: 'assignment_manager' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](
         {
@@ -1325,8 +1379,8 @@ describe('Groups Routes', () => {
 
     it('imports successfully when target user is a normal user', async () => {
       const { handlers } = setupRoute();
-      User.findByEmail.mockResolvedValue({ id: 'u2', role_name: 'user' });
-      Group.findByName.mockResolvedValue({ id: 'g1' });
+      User.findByEmails.mockResolvedValue([{ id: 'u2', email: 'normaluser@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
       Group.assignUserToGroup.mockResolvedValue();
       const reply = mockReply();
       await handlers['/groups/import-mappings_post'](

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -1394,6 +1394,48 @@ describe('Groups Routes', () => {
       const result = reply.send.mock.calls[0][0];
       expect(result.imported).toBe(1);
     });
+
+    it('returns 409 when two groups share the same name differing only by case', async () => {
+      const { handlers } = setupRoute();
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([
+        { id: 'g1', name: 'Team A' },
+        { id: 'g2', name: 'team a' },
+      ]);
+      const reply = mockReply();
+      await handlers['/groups/import-mappings_post'](
+        {
+          user: { id: 'u1', role: 'admin' },
+          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
+        },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('Ambiguous group name') })
+      );
+      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('does not flag collision when two group rows share the same id (deduplication)', async () => {
+      const { handlers } = setupRoute();
+      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([
+        { id: 'g1', name: 'Team A' },
+        { id: 'g1', name: 'Team A' },
+      ]);
+      Group.assignUserToGroup.mockResolvedValue();
+      const reply = mockReply();
+      await handlers['/groups/import-mappings_post'](
+        {
+          user: { id: 'u1', role: 'admin' },
+          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
+        },
+        reply
+      );
+      expect(reply.code).not.toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 1 }));
+    });
   });
 
   describe('GET /groups/export-mappings', () => {

--- a/backend/tests/unit/models/group.test.js
+++ b/backend/tests/unit/models/group.test.js
@@ -378,6 +378,53 @@ describe('Group Model', () => {
     });
   });
 
+  describe('findByNames', () => {
+    it('returns groups matching the given names (case-insensitive)', async () => {
+      const mockGroups = [
+        { id: '10000000-0000-4000-8000-000000000001', name: 'Team Alpha', enabled: true, max_members: null },
+        { id: '10000000-0000-4000-8000-000000000002', name: 'Team Beta', enabled: true, max_members: 5 },
+      ];
+      pool.query.mockResolvedValue({ rows: mockGroups });
+
+      const result = await Group.findByNames(['Team Alpha', 'Team Beta']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE LOWER(name) = ANY($1)'), [
+        ['team alpha', 'team beta'],
+      ]);
+      expect(result).toEqual(mockGroups);
+    });
+
+    it('lowercases all names before querying', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await Group.findByNames(['UPPER GROUP', 'MiXeD Group']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.any(String), [['upper group', 'mixed group']]);
+    });
+
+    it('returns empty array without querying when names is empty', async () => {
+      const result = await Group.findByNames([]);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when names is undefined', async () => {
+      const result = await Group.findByNames(undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no names match', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findByNames(['nonexistent group']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('findByName', () => {
     it('returns group when name matches (case-insensitive)', async () => {
       const mockGroup = {

--- a/backend/tests/unit/models/user.test.js
+++ b/backend/tests/unit/models/user.test.js
@@ -144,6 +144,123 @@ describe('User Model', () => {
     });
   });
 
+  describe('findByEmails', () => {
+    it('returns users matching the given emails', async () => {
+      const mockUsers = [
+        { id: 'u1', email: 'a@test.com', role_name: 'user' },
+        { id: 'u2', email: 'b@test.com', role_name: 'user' },
+      ];
+      pool.query.mockResolvedValue({ rows: mockUsers });
+
+      const result = await User.findByEmails(['a@test.com', 'b@test.com']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE u.email = ANY($1)'), [
+        ['a@test.com', 'b@test.com'],
+      ]);
+      expect(result).toEqual(mockUsers);
+    });
+
+    it('returns empty array without querying when emails is empty', async () => {
+      const result = await User.findByEmails([]);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when emails is undefined', async () => {
+      const result = await User.findByEmails(undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no emails match', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await User.findByEmails(['nobody@test.com']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findByUsernames', () => {
+    it('returns users matching the given usernames (case-insensitive)', async () => {
+      const mockUsers = [
+        { id: 'u1', username: 'alice', email: 'a@test.com', role_name: 'user' },
+        { id: 'u2', username: 'bob', email: 'b@test.com', role_name: 'admin' },
+      ];
+      pool.query.mockResolvedValue({ rows: mockUsers });
+
+      const result = await User.findByUsernames(['Alice', 'Bob']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE LOWER(u.username) = ANY($1)'), [
+        ['alice', 'bob'],
+      ]);
+      expect(result).toEqual(mockUsers);
+    });
+
+    it('lowercases all usernames before querying', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByUsernames(['UPPER', 'MiXeD']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.any(String), [['upper', 'mixed']]);
+    });
+
+    it('returns empty array without querying when usernames is empty', async () => {
+      const result = await User.findByUsernames([]);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when usernames is undefined', async () => {
+      const result = await User.findByUsernames(undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findByStudentIds', () => {
+    it('returns users matching the given student IDs', async () => {
+      const mockUsers = [
+        { id: 'u1', username: 'alice', student_id: 'S001' },
+        { id: 'u2', username: 'bob', student_id: 'S002' },
+      ];
+      pool.query.mockResolvedValue({ rows: mockUsers });
+
+      const result = await User.findByStudentIds(['S001', 'S002']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE student_id = ANY($1)'), [
+        ['S001', 'S002'],
+      ]);
+      expect(result).toEqual(mockUsers);
+    });
+
+    it('returns empty array without querying when studentIds is empty', async () => {
+      const result = await User.findByStudentIds([]);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when studentIds is undefined', async () => {
+      const result = await User.findByStudentIds(undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no student IDs match', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await User.findByStudentIds(['S999']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('findByEmail', () => {
     it('returns user by email', async () => {
       const mockUser = {

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2724,6 +2724,35 @@ describe('Users Routes', () => {
       });
     });
 
+    it('returns errors sorted by row number when validation and processing errors are interleaved', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      // Row 1: valid schema, but User.create throws a duplicate-entry DB error → error row 1 (second pass)
+      // Row 2: fails Zod validation → error row 2 (first pass)
+      // Without the sort, errors would be [row 2, row 1]; with sort they should be [row 1, row 2]
+      const dbError = Object.assign(new Error('unique violation'), { code: '23505' });
+      User.create.mockRejectedValueOnce(dbError);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'alice', email: 'a@test.com', firstName: 'Alice', lastName: 'A' }, // row 1: valid but DB error
+            { username: '', email: 'not-an-email', firstName: '', lastName: '' }, // row 2: schema error
+          ],
+        }),
+        mockReply
+      );
+
+      const result = mockReply.send.mock.calls[0][0];
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0].row).toBe(1);
+      expect(result.errors[1].row).toBe(2);
+    });
+
     it('detects email conflict after overwrite changes an existing user email', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2693,6 +2693,37 @@ describe('Users Routes', () => {
       });
     });
 
+    it('map-sync uses role_name from roleRecord not a hardcoded string', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      // Simulate a role whose name differs from 'user' to confirm no hardcoding
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'student' });
+      User.create.mockResolvedValueOnce({ id: 'u1', username: 'alice', email: 'a@test.com', student_id: null });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'alice', email: 'a@test.com', firstName: 'Alice', lastName: 'A' },
+            { username: 'bob', email: 'a@test.com', firstName: 'Bob', lastName: 'B' },
+          ],
+        }),
+        mockReply
+      );
+
+      // Second row has same email — caught by map-sync; role_name from roleRecord means the
+      // 'student' role_name does not accidentally satisfy the admin/AM guard, so the error
+      // is the expected duplicate-email reason (not silently skipped or misclassified)
+      expect(User.create).toHaveBeenCalledTimes(1);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 1,
+        skipped: 0,
+        errors: [{ row: 2, identifier: 'bob', reason: 'Email already in use by another user' }],
+      });
+    });
+
     it('detects email conflict after overwrite changes an existing user email', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2238,6 +2238,12 @@ describe('Users Routes', () => {
       body,
     });
 
+    beforeEach(() => {
+      User.findByUsernames.mockResolvedValue([]);
+      User.findByEmails.mockResolvedValue([]);
+      User.findByStudentIds.mockResolvedValue([]);
+    });
+
     it('rejects unauthenticated request', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
@@ -2285,9 +2291,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
+      // Empty batch results — no existing user with this username/email/studentId
       User.create.mockResolvedValue({
         id: '00000000-0000-4000-8000-000000000002',
         username: 'newuser',
@@ -2310,13 +2314,38 @@ describe('Users Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: 0, errors: [] });
     });
 
+    it('performs exactly 3 batch DB queries for a valid import', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.create
+        .mockResolvedValueOnce({ id: 'u1', username: 'user1', email: 'u1@test.com' })
+        .mockResolvedValueOnce({ id: 'u2', username: 'user2', email: 'u2@test.com' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'user1', email: 'u1@test.com', firstName: 'A', lastName: 'B' },
+            { username: 'user2', email: 'u2@test.com', firstName: 'C', lastName: 'D' },
+          ],
+        }),
+        mockReply
+      );
+
+      expect(User.findByUsernames).toHaveBeenCalledTimes(1);
+      expect(User.findByEmails).toHaveBeenCalledTimes(1);
+      expect(User.findByStudentIds).toHaveBeenCalledTimes(1);
+      expect(User.create).toHaveBeenCalledTimes(2);
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 2, skipped: 0, errors: [] });
+    });
+
     it('sends setup email when sendSetupEmail is true', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
       const newUser = { id: 'u2', username: 'newuser', email: 'new@test.com' };
       User.create.mockResolvedValue(newUser);
       PasswordResetToken.deleteStaleForUser.mockResolvedValue();
@@ -2343,9 +2372,6 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
       User.create.mockResolvedValue({ id: 'u2', username: 'newuser', email: 'new@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2365,11 +2391,15 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000002',
-        username: 'existing',
-        role_name: 'user',
-      });
+      User.findByUsernames.mockResolvedValue([
+        {
+          id: '00000000-0000-4000-8000-000000000002',
+          username: 'existing',
+          email: 'existing@test.com',
+          student_id: null,
+          role_name: 'user',
+        },
+      ]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2390,10 +2420,15 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: '00000000-0000-4000-8000-000000000002', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
+      const existingUser = {
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'existing',
+        email: 'old@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      // No email/studentId conflicts
       User.update.mockResolvedValue({ ...existingUser, email: 'new@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2418,9 +2453,14 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: '00000000-0000-4000-8000-000000000002', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue(null);
+      const existingUser = {
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'existing',
+        email: 'existing@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
       User.update.mockResolvedValue({ ...existingUser, email: 'new@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2445,10 +2485,14 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: '00000000-0000-4000-8000-000000000002', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
+      const existingUser = {
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'existing',
+        email: 'existing@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
       User.update.mockResolvedValue({ ...existingUser, email: 'new@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2474,7 +2518,15 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue({ id: 'u2', username: 'admin', role_name: 'admin' });
+      User.findByUsernames.mockResolvedValue([
+        {
+          id: 'u2',
+          username: 'admin',
+          email: 'admin@test.com',
+          student_id: null,
+          role_name: 'admin',
+        },
+      ]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2549,9 +2601,6 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
       User.create.mockResolvedValue({ id: 'u1', username: 'fnonly', email: 'fn@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2572,9 +2621,6 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
       User.create.mockResolvedValue({ id: 'u1', username: 'lnonly', email: 'ln@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2591,13 +2637,104 @@ describe('Users Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: 0, errors: [] });
     });
 
+    it('catches within-batch duplicate email via map-sync after create', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      // Batch lookups return empty — neither user exists yet
+      User.create.mockResolvedValueOnce({ id: 'u1', username: 'alice', email: 'same@test.com', student_id: null });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'alice', email: 'same@test.com', firstName: 'Alice', lastName: 'A' },
+            { username: 'bob', email: 'same@test.com', firstName: 'Bob', lastName: 'B' },
+          ],
+        }),
+        mockReply
+      );
+
+      // First row created, second caught by the synced emailMap — not by a DB constraint
+      expect(User.create).toHaveBeenCalledTimes(1);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 1,
+        skipped: 0,
+        errors: [{ row: 2, identifier: 'bob', reason: 'Email already in use by another user' }],
+      });
+    });
+
+    it('catches within-batch duplicate studentId via map-sync after create', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.create.mockResolvedValueOnce({ id: 'u1', username: 'alice', email: 'a@test.com', student_id: 'S100' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'alice', email: 'a@test.com', firstName: 'Alice', lastName: 'A', studentId: 'S100' },
+            { username: 'bob', email: 'b@test.com', firstName: 'Bob', lastName: 'B', studentId: 'S100' },
+          ],
+        }),
+        mockReply
+      );
+
+      expect(User.create).toHaveBeenCalledTimes(1);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 1,
+        skipped: 0,
+        errors: [{ row: 2, identifier: 'bob', reason: 'Student ID already in use by another user' }],
+      });
+    });
+
+    it('detects email conflict after overwrite changes an existing user email', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      const existingUser = {
+        id: 'u2',
+        username: 'existing',
+        email: 'old@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      User.update.mockResolvedValue({ ...existingUser, email: 'new@test.com' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      // Row 1 overwrites 'existing' to use 'new@test.com'; row 2 tries to create a user with the same email
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'existing', email: 'new@test.com', firstName: 'Ex', lastName: 'User' },
+            { username: 'newcomer', email: 'new@test.com', firstName: 'New', lastName: 'User' },
+          ],
+          conflictAction: 'overwrite',
+        }),
+        mockReply
+      );
+
+      expect(User.update).toHaveBeenCalledTimes(1);
+      expect(User.create).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 1,
+        skipped: 0,
+        errors: [{ row: 2, identifier: 'newcomer', reason: 'Email already in use by another user' }],
+      });
+    });
+
     it('records error for row-level database failures', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
       User.create.mockRejectedValue(new Error('DB constraint violation'));
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2621,12 +2758,16 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername
-        .mockResolvedValueOnce(null) // new
-        .mockResolvedValueOnce({ id: 'u2', username: 'existing', role_name: 'user' }) // skip
-        .mockResolvedValueOnce(null); // missing fields row — won't reach findByUsername
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue(null);
+      // Batch returns 'existing' user; 'newuser' and invalid row are not in DB
+      User.findByUsernames.mockResolvedValue([
+        {
+          id: 'u2',
+          username: 'existing',
+          email: 'ex@test.com',
+          student_id: null,
+          role_name: 'user',
+        },
+      ]);
       User.create.mockResolvedValue({ id: 'u3', username: 'newuser', email: 'new@test.com' });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
@@ -2667,12 +2808,29 @@ describe('Users Routes', () => {
       expect(mockReply.code).toHaveBeenCalledWith(500);
     });
 
+    it('returns 500 when batch lookup fails', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.findByUsernames.mockRejectedValue(new Error('DB down'));
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({ users: [{ username: 'u', email: 'e@e.com', firstName: 'F', lastName: 'L' }] }),
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+
     it('errors when new user email conflicts with existing user', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue({ id: 'other', username: 'other', email: 'taken@test.com' });
+      // 'newuser' not in usernameMap, but 'taken@test.com' is in emailMap (owned by 'other')
+      User.findByEmails.mockResolvedValue([{ id: 'other', email: 'taken@test.com' }]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2696,9 +2854,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue({ id: 'other', username: 'other', student_id: 'S123' });
+      User.findByStudentIds.mockResolvedValue([{ id: 'other', student_id: 'S123' }]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2724,9 +2880,16 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: 'u2', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue({ id: 'u3', username: 'other', email: 'taken@test.com' });
+      const existingUser = {
+        id: 'u2',
+        username: 'existing',
+        email: 'old@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      // A different user (u3) owns 'taken@test.com'
+      User.findByEmails.mockResolvedValue([{ id: 'u3', email: 'taken@test.com' }]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2751,11 +2914,17 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: 'u2', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue({ id: 'u2', username: 'existing', email: 'same@test.com' });
-      User.findByStudentId.mockResolvedValue(null);
-      User.update.mockResolvedValue({ ...existingUser, email: 'same@test.com' });
+      const existingUser = {
+        id: 'u2',
+        username: 'existing',
+        email: 'same@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      // The same user owns 'same@test.com'
+      User.findByEmails.mockResolvedValue([{ id: 'u2', email: 'same@test.com' }]);
+      User.update.mockResolvedValue({ ...existingUser });
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
@@ -2776,10 +2945,16 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
-      const existingUser = { id: 'u2', username: 'existing', role_name: 'user' };
-      User.findByUsername.mockResolvedValue(existingUser);
-      User.findByEmail.mockResolvedValue(null);
-      User.findByStudentId.mockResolvedValue({ id: 'u3', username: 'other', student_id: 'S123' });
+      const existingUser = {
+        id: 'u2',
+        username: 'existing',
+        email: 'ex@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      // A different user (u3) owns student ID 'S123'
+      User.findByStudentIds.mockResolvedValue([{ id: 'u3', student_id: 'S123' }]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };


### PR DESCRIPTION
## Summary
- Replace per-row DB queries in `groups/import-mappings` (2 queries per row → 2 total) and `users/import` (3 queries per row → 3 total) with upfront batch lookups plus in-memory Maps
- Add 4 new batch model methods: `Group.findByNames`, `User.findByEmails`, `User.findByUsernames`, `User.findByStudentIds`
- Keep user import Maps in sync after each create/update so within-batch duplicates (email, username, studentId) are caught cleanly instead of falling to DB constraint errors
- `assignUserToGroup` remains per-row — required for its transactional row-level lock on group capacity

## Test plan
- [x] All 602 backend unit tests pass
- [x] All 509 frontend unit tests pass
- [x] All 139 backend integration tests pass (Testcontainers Postgres)
- [x] All 81 Playwright e2e tests pass
- [x] Coverage above thresholds (95.7% statements, 85.8% branches, 98.1% functions)
- [x] Lint passes with zero warnings
- [x] Prettier formatting clean
- [x] New tests verify batch query count (exactly 2 for group import, 3 for user import)
- [x] New tests verify within-batch duplicate detection via map-sync (email, studentId, cross-path overwrite+create)