### PR TITLE
test: address critical test coverage gaps

### DIFF
--- a/backend/tests/integration/auth.test.js
+++ b/backend/tests/integration/auth.test.js
@@ -315,4 +315,65 @@ describe('POST /api/auth/set-password', () => {
     expect(loginBody.token).toBeDefined();
     expect(loginBody.user.username).toBe('e2euser');
   });
+
+  it('rejects a token that has already been used', async () => {
+    const db = getPool();
+    const PasswordResetToken = require('../../src/models/PasswordResetToken');
+
+    // Create a user and a setup token
+    await createUser({ username: 'reuse_user', email: 'reuse@test.com', password: 'OldPass123!' });
+    const { rows } = await db.query("SELECT id FROM users WHERE username = 'reuse_user'");
+    const tokenRow = await PasswordResetToken.create(rows[0].id, 'setup');
+
+    // First use — should succeed
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/auth/set-password',
+      payload: { token: tokenRow.token, password: 'NewPass123!' },
+    });
+    expect(first.statusCode).toBe(200);
+
+    // Second use — same token should be rejected
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/auth/set-password',
+      payload: { token: tokenRow.token, password: 'AnotherPass1!' },
+    });
+    expect(second.statusCode).toBe(400);
+    expect(JSON.parse(second.body).error).toMatch(/invalid|expired/i);
+  });
+
+  it('resets password for an active user with a reset-type token', async () => {
+    const db = getPool();
+    const PasswordResetToken = require('../../src/models/PasswordResetToken');
+
+    // Create an already-active user
+    await createUser({ username: 'reset_user', email: 'reset@test.com', password: 'OldPass123!' });
+    const { rows } = await db.query("SELECT id FROM users WHERE username = 'reset_user'");
+    const tokenRow = await PasswordResetToken.create(rows[0].id, 'reset');
+
+    // Set password using a reset-type token
+    const setRes = await app.inject({
+      method: 'POST',
+      url: '/api/auth/set-password',
+      payload: { token: tokenRow.token, password: 'ResetPass123!' },
+    });
+    expect(setRes.statusCode).toBe(200);
+
+    // Verify login with new password works
+    const loginRes = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'reset_user', password: 'ResetPass123!' },
+    });
+    expect(loginRes.statusCode).toBe(200);
+
+    // Verify old password no longer works
+    const oldLogin = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'reset_user', password: 'OldPass123!' },
+    });
+    expect(oldLogin.statusCode).toBe(401);
+  });
 });

--- a/backend/tests/integration/auth.test.js
+++ b/backend/tests/integration/auth.test.js
@@ -322,7 +322,8 @@ describe('POST /api/auth/set-password', () => {
 
     // Create a user and a setup token
     await createUser({ username: 'reuse_user', email: 'reuse@test.com', password: 'OldPass123!' });
-    const { rows } = await db.query("SELECT id FROM users WHERE username = 'reuse_user'");
+    const { rows } = await db.query('SELECT id FROM users WHERE username = $1', ['reuse_user']);
+    expect(rows).toHaveLength(1);
     const tokenRow = await PasswordResetToken.create(rows[0].id, 'setup');
 
     // First use — should succeed
@@ -349,7 +350,8 @@ describe('POST /api/auth/set-password', () => {
 
     // Create an already-active user
     await createUser({ username: 'reset_user', email: 'reset@test.com', password: 'OldPass123!' });
-    const { rows } = await db.query("SELECT id FROM users WHERE username = 'reset_user'");
+    const { rows } = await db.query('SELECT id FROM users WHERE username = $1', ['reset_user']);
+    expect(rows).toHaveLength(1);
     const tokenRow = await PasswordResetToken.create(rows[0].id, 'reset');
 
     // Set password using a reset-type token

--- a/backend/tests/unit/auth.test.js
+++ b/backend/tests/unit/auth.test.js
@@ -878,6 +878,8 @@ describe('Auth Routes', () => {
 
       await capturedHandlers['/auth/set-password']({ body: { token: 'validtoken', password: 'newpass1' } }, mockReply);
 
+      expect(PasswordResetToken.markUsed).toHaveBeenCalledTimes(1);
+      expect(User.updatePassword).toHaveBeenCalledTimes(1);
       const markUsedOrder = PasswordResetToken.markUsed.mock.invocationCallOrder[0];
       const updatePasswordOrder = User.updatePassword.mock.invocationCallOrder[0];
       expect(markUsedOrder).toBeLessThan(updatePasswordOrder);

--- a/backend/tests/unit/auth.test.js
+++ b/backend/tests/unit/auth.test.js
@@ -862,6 +862,27 @@ describe('Auth Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ message: 'Password set successfully. You can now log in.' });
     });
 
+    it('calls markUsed before updatePassword to prevent token replay', async () => {
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      PasswordResetToken.findByToken.mockResolvedValue({
+        id: 't1',
+        user_id: '00000000-0000-4000-8000-000000000001',
+        token_type: 'reset',
+        used: false,
+        expires_at: new Date(Date.now() + 3600000),
+      });
+      User.updatePassword.mockResolvedValue();
+      PasswordResetToken.markUsed.mockResolvedValue();
+
+      await capturedHandlers['/auth/set-password']({ body: { token: 'validtoken', password: 'newpass1' } }, mockReply);
+
+      const markUsedOrder = PasswordResetToken.markUsed.mock.invocationCallOrder[0];
+      const updatePasswordOrder = User.updatePassword.mock.invocationCallOrder[0];
+      expect(markUsedOrder).toBeLessThan(updatePasswordOrder);
+    });
+
     it('activates user when token type is setup', async () => {
       const authRoutes = require('../../src/routes/auth');
       authRoutes(mockFastify, {});

--- a/tests/e2e/auth.spec.js
+++ b/tests/e2e/auth.spec.js
@@ -60,6 +60,18 @@ test.describe('Authentication', () => {
     });
   });
 
+  test.describe('Disabled account', () => {
+    test('disabled user cannot log in', async ({ page }) => {
+      await createUser({ username: 'disableduser', email: 'disabled@test.com', enabled: false });
+      await page.goto('/login');
+      await page.fill('#username', 'disableduser');
+      await page.fill('#password', 'TestPass123!');
+      await page.click('button[type="submit"]');
+      await expect(page.locator('.bg-red-50')).toBeVisible();
+      await expect(page).toHaveURL(/\/login/);
+    });
+  });
+
   test.describe('Unauthenticated access', () => {
     test('redirects /dashboard to /login', async ({ page }) => {
       await page.goto('/dashboard');

--- a/tests/e2e/forgot-password.spec.js
+++ b/tests/e2e/forgot-password.spec.js
@@ -91,4 +91,16 @@ test.describe('Set Password', () => {
     await page.getByRole('button', { name: 'Set Password' }).click();
     await expect(page.getByText(/invalid or expired token|failed to set password/i)).toBeVisible({ timeout: 10000 });
   });
+
+  test('shows error for expired token', async ({ page }) => {
+    const user = await createUser({ username: 'expireduser', email: 'expired@test.com' });
+    const token = await createPasswordResetToken(user.email, {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    await page.goto(`/set-password?token=${token}`);
+    await page.getByPlaceholder('At least 6 characters').fill('NewPass123!');
+    await page.getByPlaceholder('Repeat your password').fill('NewPass123!');
+    await page.getByRole('button', { name: 'Set Password' }).click();
+    await expect(page.getByText(/invalid or expired token|failed to set password/i)).toBeVisible({ timeout: 10000 });
+  });
 });

--- a/tests/e2e/register.spec.js
+++ b/tests/e2e/register.spec.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { cleanDatabase, createUser, createPasswordResetToken } = require('../helpers/db');
+const { loginAs } = require('../helpers/auth');
+
+/**
+ * Navigate to the register page via the Login page's "Register here" link.
+ * Direct navigation to /register hits the catch-all redirect before the
+ * registrationEnabled config fetch completes, so we use the link instead.
+ */
+async function goToRegister(page) {
+  await page.goto('/login');
+  const registerLink = page.getByRole('link', { name: /register here/i });
+  await expect(registerLink).toBeVisible({ timeout: 10000 });
+  await registerLink.click();
+  await expect(page).toHaveURL(/\/register/);
+}
+
+test.describe('Self-Registration', () => {
+  test.beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  test('register page is accessible and shows the form', async ({ page }) => {
+    await goToRegister(page);
+    await expect(page.getByRole('heading', { name: 'Create Account' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByPlaceholder('Choose a username')).toBeVisible();
+    await expect(page.getByPlaceholder('Enter your email')).toBeVisible();
+    await expect(page.getByPlaceholder('Enter your first name')).toBeVisible();
+    await expect(page.getByPlaceholder('Enter your last name')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create account' })).toBeVisible();
+  });
+
+  test('successful registration shows success message and redirects to login', async ({ page }) => {
+    await goToRegister(page);
+    await page.getByPlaceholder('Choose a username').fill('newuser');
+    await page.getByPlaceholder('Enter your email').fill('newuser@test.com');
+    await page.getByPlaceholder('Enter your first name').fill('New');
+    await page.getByPlaceholder('Enter your last name').fill('User');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.getByText(/registration successful/i)).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
+  });
+
+  test('full registration flow: register → set password → login', async ({ page }) => {
+    await goToRegister(page);
+    await page.getByPlaceholder('Choose a username').fill('fullflowuser');
+    await page.getByPlaceholder('Enter your email').fill('fullflow@test.com');
+    await page.getByPlaceholder('Enter your first name').fill('Full');
+    await page.getByPlaceholder('Enter your last name').fill('Flow');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.getByText(/registration successful/i)).toBeVisible({ timeout: 10000 });
+
+    // Create a setup token (simulates the emailed link)
+    const token = await createPasswordResetToken('fullflow@test.com', { tokenType: 'setup' });
+
+    // Set password
+    await page.goto(`/set-password?token=${token}`);
+    await page.getByPlaceholder('At least 6 characters').fill('SecurePass123!');
+    await page.getByPlaceholder('Repeat your password').fill('SecurePass123!');
+    await page.getByRole('button', { name: 'Set Password' }).click();
+    await expect(page.getByText(/password set successfully/i)).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 });
+
+    // Login with the new credentials
+    await loginAs(page, 'fullflowuser', 'SecurePass123!');
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('rejects registration with duplicate username', async ({ page }) => {
+    await createUser({ username: 'taken', email: 'taken@test.com' });
+    await goToRegister(page);
+    await page.getByPlaceholder('Choose a username').fill('taken');
+    await page.getByPlaceholder('Enter your email').fill('different@test.com');
+    await page.getByPlaceholder('Enter your first name').fill('Dup');
+    await page.getByPlaceholder('Enter your last name').fill('User');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('rejects registration with duplicate email', async ({ page }) => {
+    await createUser({ username: 'original', email: 'shared@test.com' });
+    await goToRegister(page);
+    await page.getByPlaceholder('Choose a username').fill('newname');
+    await page.getByPlaceholder('Enter your email').fill('shared@test.com');
+    await page.getByPlaceholder('Enter your first name').fill('Dup');
+    await page.getByPlaceholder('Enter your last name').fill('Email');
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page.locator('.bg-red-50')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('"Already have an account?" link navigates to login', async ({ page }) => {
+    await goToRegister(page);
+    await page.getByRole('link', { name: 'Already have an account? Sign in' }).click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -127,6 +127,7 @@ module.exports = async function globalSetup() {
     process.env.ADMIN_PASSWORD = ADMIN_PASSWORD;
     process.env.CORS_ORIGIN = `http://localhost:${FRONTEND_PORT}`;
     process.env.APP_URL = `http://localhost:${FRONTEND_PORT}`;
+    process.env.REGISTRATION_ENABLED = 'true';
 
     const { createSQL } = require(path.join(BACKEND_DIR, 'src', 'db', 'schema'));
     await client.query(createSQL);


### PR DESCRIPTION
## Summary

- Add 11 new tests across unit, integration, and E2E to close 6 critical coverage gaps identified by an independent test quality audit
- Security-critical auth flows (token replay, expired tokens, disabled accounts) now have regression-safe test coverage
- Self-registration E2E flow (6 tests) added — previously had zero coverage

## Changes

**Backend unit** (`backend/tests/unit/auth.test.js`):
- Verify `markUsed` is called before `updatePassword` via `invocationCallOrder` to prevent token replay if password update fails

**Integration** (`backend/tests/integration/auth.test.js`):
- Test that a used set-password token is rejected on second use (token replay prevention)
- Test reset-type token flow: active user resets password, new password works, old password rejected

**E2E** (`tests/e2e/auth.spec.js`):
- Disabled user cannot log in — error shown, stays on `/login`

**E2E** (`tests/e2e/forgot-password.spec.js`):
- Expired set-password token is rejected with error message

**E2E** (`tests/e2e/register.spec.js`) — **NEW**:
- Register page accessible via Login "Register here" link
- Successful registration shows success message and redirects to login
- Full flow: register → set password via setup token → login
- Duplicate username rejected
- Duplicate email rejected
- "Already have an account?" link navigates to login

**Config** (`tests/global-setup.js`):
- Enable `REGISTRATION_ENABLED=true` in E2E environment

## Test plan

- [x] Backend unit tests: 608 passed
- [x] Integration tests: 141 passed
- [x] E2E tests: 89 passed (was 81)
- [x] Lint: clean
- [x] Format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)