### PR TITLE
test: address HIGH test coverage gaps across all suites

### DIFF
--- a/backend/tests/integration/groups.test.js
+++ b/backend/tests/integration/groups.test.js
@@ -626,3 +626,181 @@ describe('GET /api/groups/export-mappings', () => {
     expect(res.statusCode).toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/groups/:id/join — disabled user
+// ---------------------------------------------------------------------------
+describe('POST /api/groups/:id/join — disabled user', () => {
+  it('disabled user attempting to join returns 403', async () => {
+    const g = await createGroup({ name: 'DisabledJoinGroup', enabled: true });
+    // Create user as enabled, get token, then disable the account
+    const u = await createUser({ username: 'disableduser', email: 'disabled@test.com' });
+    const disabledToken = await loginAs(app, 'disableduser', 'TestPass123!');
+
+    // Disable the user via admin
+    await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { email: u.email, firstName: 'Dis', lastName: 'Abled', enabled: false },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${disabledToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/disabled/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/groups/:id/leave — disabled user and locked system
+// ---------------------------------------------------------------------------
+describe('POST /api/groups/:id/leave — disabled user and locked system', () => {
+  it('disabled user attempting to leave returns 403', async () => {
+    const g = await createGroup({ name: 'DisabledLeaveGroup', enabled: true });
+    // Create user as enabled, join group, then disable
+    const u = await createUser({ username: 'disleave', email: 'disleave@test.com' });
+    const tempToken = await loginAs(app, 'disleave', 'TestPass123!');
+
+    // Join the group while enabled
+    await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${tempToken}` },
+    });
+
+    // Disable the user via admin
+    await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { email: u.email, firstName: 'Dis', lastName: 'Leave', enabled: false },
+    });
+
+    // Try to leave while disabled (token still valid but account disabled)
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/leave`,
+      headers: { authorization: `Bearer ${tempToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/disabled/i);
+  });
+
+  it('user attempting to leave when group_join_locked=true returns 403', async () => {
+    const g = await createGroup({ name: 'LockedLeaveGroup', enabled: true });
+
+    // Join the group first
+    await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+
+    // Lock group joining
+    await app.inject({
+      method: 'PUT',
+      url: '/api/config/group_join_locked',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { value: 'true' },
+    });
+
+    // Try to leave while locked
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/leave`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/locked/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RBAC: AM on admin-only group endpoints
+// ---------------------------------------------------------------------------
+describe('RBAC: AM on admin-only group endpoints', () => {
+  it('DELETE /api/groups/:id with AM token returns 403', async () => {
+    const g = await createGroup({ name: 'AMDeleteTarget' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('POST /api/groups/bulk with AM token returns 403', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: [{ name: 'AMBulkGroup' }],
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/groups/:id — maxMembers boundary
+// ---------------------------------------------------------------------------
+describe('PUT /api/groups/:id — maxMembers boundary', () => {
+  it('setting maxMembers exactly equal to current member count succeeds', async () => {
+    const g = await createGroup({ name: 'BoundaryGroup', maxMembers: 10 });
+    // Add exactly 3 members
+    for (let i = 0; i < 3; i++) {
+      const u = await createUser({ username: `bnd${i}`, email: `bnd${i}@test.com` });
+      await app.inject({
+        method: 'PUT',
+        url: `/api/users/${u.id}/group`,
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: { groupId: g.id },
+      });
+    }
+    // Set maxMembers = 3 (exactly the current count)
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'BoundaryGroup', enabled: true, maxMembers: 3 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).group.max_members).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/groups/import-mappings — full group error path
+// ---------------------------------------------------------------------------
+describe('POST /api/groups/import-mappings — full group error path', () => {
+  it('importing a user mapping to a full group records an error', async () => {
+    const g = await createGroup({ name: 'FullImportGroup', maxMembers: 1 });
+    // Fill the group with one member
+    const filler = await createUser({ username: 'filler', email: 'filler@test.com' });
+    await app.inject({
+      method: 'PUT',
+      url: `/api/users/${filler.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { groupId: g.id },
+    });
+
+    // Try to import another user into the full group
+    await createUser({ username: 'overflow', email: 'overflow@test.com' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/import-mappings',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        rows: [{ email: 'overflow@test.com', groupName: 'FullImportGroup' }],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.errors.length).toBe(1);
+    expect(body.errors[0].error).toMatch(/full/i);
+  });
+});

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -805,3 +805,193 @@ describe('POST /api/users/import', () => {
     expect(res.statusCode).toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/users/send-setup-emails
+// ---------------------------------------------------------------------------
+describe('POST /api/users/send-setup-emails', () => {
+  it('admin can send setup emails to all pending users', async () => {
+    // Create pending users via the API (no password = pending)
+    await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'pending1',
+        email: 'pending1@test.com',
+        firstName: 'P',
+        lastName: 'One',
+        sendSetupEmail: false,
+      },
+    });
+    await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'pending2',
+        email: 'pending2@test.com',
+        firstName: 'P',
+        lastName: 'Two',
+        sendSetupEmail: false,
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sent).toBeGreaterThanOrEqual(2);
+  });
+
+  it('admin can send to specific userIds list', async () => {
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'specific1',
+        email: 'specific1@test.com',
+        firstName: 'S',
+        lastName: 'One',
+        sendSetupEmail: false,
+      },
+    });
+    const userId = JSON.parse(createRes.body).user.id;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [userId] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sent).toBe(1);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 for regular user', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 when exceeding 500 userIds', async () => {
+    const fakeIds = Array.from({ length: 501 }, (_, i) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: fakeIds },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/500/);
+  });
+
+  it('returns 400 for invalid UUID in userIds', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: ['not-a-uuid'] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
+  });
+
+  it('silently skips non-pending users in userIds', async () => {
+    // user1 is active (created with password via createUser helper), not pending
+    const listRes = await app.inject({
+      method: 'GET',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    // user1 is active, not pending — should be filtered out
+    expect(body.sent).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/users/:id/group — AM RBAC
+// ---------------------------------------------------------------------------
+describe('PUT /api/users/:id/group — AM RBAC', () => {
+  it('assignment_manager can assign a user to a group', async () => {
+    const u = await createUser({ username: 'amtarget', email: 'amtarget@test.com' });
+    const g = await createGroup({ name: 'AMAssignGroup' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}/group`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { groupId: g.id },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).user.groupId).toBe(g.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/users/:id — AM role escalation prevention
+// ---------------------------------------------------------------------------
+describe('PUT /api/users/:id — AM role escalation', () => {
+  it('assignment_manager cannot change a user role', async () => {
+    const u = await createUser({ username: 'norolechange', email: 'norolechange@test.com' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: u.email, firstName: 'No', lastName: 'Change', role: 'admin' },
+    });
+    // AM cannot escalate role — the role field should be ignored (not applied)
+    expect(res.statusCode).toBe(200);
+
+    // Verify via a fresh GET that the role was NOT changed
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(getRes.body).user.role_name).toBe('user');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RBAC: AM on admin-only endpoints (users)
+// ---------------------------------------------------------------------------
+describe('RBAC: AM on admin-only user endpoints', () => {
+  it('DELETE /api/users/:id with AM token returns 403', async () => {
+    const u = await createUser({ username: 'amdeletetarget', email: 'amdel@test.com' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -812,7 +812,7 @@ describe('POST /api/users/import', () => {
 describe('POST /api/users/send-setup-emails', () => {
   it('admin can send setup emails to all pending users', async () => {
     // Create pending users via the API (no password = pending)
-    await app.inject({
+    const res1 = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
@@ -824,7 +824,8 @@ describe('POST /api/users/send-setup-emails', () => {
         sendSetupEmail: false,
       },
     });
-    await app.inject({
+    expect(res1.statusCode).toBe(201);
+    const res2 = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
@@ -836,6 +837,7 @@ describe('POST /api/users/send-setup-emails', () => {
         sendSetupEmail: false,
       },
     });
+    expect(res2.statusCode).toBe(201);
 
     const res = await app.inject({
       method: 'POST',

--- a/backend/tests/unit/auth.test.js
+++ b/backend/tests/unit/auth.test.js
@@ -648,6 +648,33 @@ describe('Auth Routes', () => {
         },
       });
     });
+
+    it('returns 401 when user found in token but deleted from DB', async () => {
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      User.findById.mockResolvedValue(null);
+
+      const request = { user: { id: '00000000-0000-4000-8000-000000000001' } };
+      await capturedHandlers['/auth/me'](request, mockReply);
+
+      expect(User.findById).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User not found' });
+    });
+
+    it('returns 500 on DB error', async () => {
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      User.findById.mockRejectedValue(new Error('DB connection lost'));
+
+      const request = { user: { id: '00000000-0000-4000-8000-000000000001' } };
+      await capturedHandlers['/auth/me'](request, mockReply);
+
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Failed to retrieve user info' });
+    });
   });
 
   describe('POST /auth/forgot-password', () => {

--- a/backend/tests/unit/models/user.test.js
+++ b/backend/tests/unit/models/user.test.js
@@ -635,6 +635,24 @@ describe('User Model', () => {
     });
   });
 
+  describe('activate', () => {
+    it('sets user status to active', async () => {
+      pool.query.mockResolvedValue({});
+
+      await User.activate('u0000000-0000-0000-0000-000000000001');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining("status = 'active'"), [
+        'u0000000-0000-0000-0000-000000000001',
+      ]);
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(User.activate('u0000000-0000-0000-0000-000000000001')).rejects.toThrow('connection refused');
+    });
+  });
+
   describe('bulkDelete', () => {
     it('executes DELETE … WHERE id = ANY and returns row count', async () => {
       pool.query.mockResolvedValue({ rowCount: 2 });

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -816,6 +816,23 @@ describe('Users Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'groupId is required' });
     });
 
+    it('returns 400 when groupId is a non-null non-UUID string', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id/group_put'](
+        {
+          params: { id: '00000000-0000-4000-8000-000000000001' },
+          body: { groupId: 'not-a-uuid' },
+        },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid groupId format' });
+    });
+
     it('returns 404 when user not found', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);

--- a/frontend/tests/unit/App.test.jsx
+++ b/frontend/tests/unit/App.test.jsx
@@ -101,4 +101,37 @@ describe('App', () => {
 
     expect(screen.getByText('Groups Page')).toBeInTheDocument();
   });
+
+  it('redirects authenticated user from /login to /dashboard', () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      loading: false,
+      isAdmin: false,
+      isAssignmentManager: false,
+      user: { username: 'member', role: 'normal_user' },
+    });
+
+    window.history.pushState({}, '', '/login');
+    render(<App />);
+
+    expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
+  });
+
+  it('redirects authenticated user from /register to /dashboard when registration enabled', () => {
+    useAuth.mockReturnValue({
+      isAuthenticated: true,
+      loading: false,
+      isAdmin: false,
+      isAssignmentManager: false,
+      user: { username: 'member', role: 'normal_user' },
+      registrationEnabled: true,
+    });
+
+    window.history.pushState({}, '', '/register');
+    render(<App />);
+
+    expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+    expect(screen.queryByText('Register Page')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/unit/App.test.jsx
+++ b/frontend/tests/unit/App.test.jsx
@@ -63,7 +63,7 @@ describe('App', () => {
       loading: false,
       isAdmin: false,
       isAssignmentManager: false,
-      user: { username: 'member', role: 'normal_user' },
+      user: { username: 'member', role: 'user' },
     });
 
     window.history.pushState({}, '', '/dashboard');
@@ -108,7 +108,7 @@ describe('App', () => {
       loading: false,
       isAdmin: false,
       isAssignmentManager: false,
-      user: { username: 'member', role: 'normal_user' },
+      user: { username: 'member', role: 'user' },
     });
 
     window.history.pushState({}, '', '/login');
@@ -124,7 +124,7 @@ describe('App', () => {
       loading: false,
       isAdmin: false,
       isAssignmentManager: false,
-      user: { username: 'member', role: 'normal_user' },
+      user: { username: 'member', role: 'user' },
       registrationEnabled: true,
     });
 

--- a/frontend/tests/unit/components/UserMenu.test.jsx
+++ b/frontend/tests/unit/components/UserMenu.test.jsx
@@ -77,6 +77,20 @@ describe('UserMenu', () => {
       expect(screen.queryByRole('button', { name: /edit profile/i })).not.toBeInTheDocument();
     });
 
+    it('closes dropdown when trigger button is clicked a second time', async () => {
+      const user = setup();
+      renderMenu();
+      const trigger = screen.getByRole('button', { name: /testuser/i });
+
+      // Open
+      await user.click(trigger);
+      expect(screen.getByRole('button', { name: /edit profile/i })).toBeInTheDocument();
+
+      // Close by clicking trigger again
+      await user.click(trigger);
+      expect(screen.queryByRole('button', { name: /edit profile/i })).not.toBeInTheDocument();
+    });
+
     it('calls logout when Logout is clicked', async () => {
       const user = setup();
       renderMenu();
@@ -116,6 +130,14 @@ describe('UserMenu', () => {
 
     it('hides Student ID field for admin role', async () => {
       const user = setup({ user: { ...baseUser, role: 'admin' } });
+      renderMenu();
+      await user.click(screen.getByRole('button', { name: /testuser/i }));
+      await user.click(screen.getByRole('button', { name: /edit profile/i }));
+      expect(screen.queryByLabelText(/student id/i)).not.toBeInTheDocument();
+    });
+
+    it('hides Student ID field for assignment_manager role', async () => {
+      const user = setup({ user: { ...baseUser, role: 'assignment_manager' } });
       renderMenu();
       await user.click(screen.getByRole('button', { name: /testuser/i }));
       await user.click(screen.getByRole('button', { name: /edit profile/i }));

--- a/frontend/tests/unit/pages/Login.test.jsx
+++ b/frontend/tests/unit/pages/Login.test.jsx
@@ -104,4 +104,76 @@ describe('Login page', () => {
 
     expect(screen.queryByRole('link', { name: /register here/i })).not.toBeInTheDocument();
   });
+
+  it('shows "Signing in..." and disables button during login API call', async () => {
+    let resolveLogin;
+    mockLogin.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLogin = resolve;
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'testuser');
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const button = screen.getByRole('button', { name: /signing in/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Signing in...');
+
+    resolveLogin({ success: true });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled();
+    });
+  });
+
+  it('shows validation error and does not call login when username is empty', async () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    // Only fill password, leave username empty
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    // Bypass HTML required by clearing the field and submitting programmatically
+    // The native required attr may block submit, so we need to use the schema path.
+    // Instead, type a space (DOMPurify trims to empty) to trigger schema validation.
+    await userEvent.type(screen.getByLabelText(/username/i), '   ');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error and does not call login when password is empty', async () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/username/i), 'testuser');
+    // Type a single space in password — schema trims/validates to empty → "Password is required"
+    // However the password field is not sanitized. A space is a valid single char
+    // which is min(1) so it passes. Instead, remove the required attribute to allow
+    // empty submission, then let the Zod schema reject it.
+    const passwordInput = screen.getByLabelText(/password/i);
+    passwordInput.removeAttribute('required');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Password is required')).toBeInTheDocument();
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/tests/unit/pages/Register.test.jsx
+++ b/frontend/tests/unit/pages/Register.test.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Register from '../../../src/pages/Register.jsx';
@@ -215,5 +215,93 @@ describe('Register page', () => {
     await waitFor(() => {
       expect(screen.getByText('Registration failed. Please try again.')).toBeInTheDocument();
     });
+  });
+
+  it('shows validation error when username is blank and does not call register', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    // Type whitespace-only username (DOMPurify trims to empty, triggering schema error)
+    await user.type(screen.getByLabelText(/username/i), '   ');
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/first name/i), 'Test');
+    await user.type(screen.getByLabelText(/last name/i), 'User');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Username is required')).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when email format is invalid', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/username/i), 'validuser');
+    await user.type(screen.getByLabelText(/email/i), 'not-an-email');
+    await user.type(screen.getByLabelText(/first name/i), 'Test');
+    await user.type(screen.getByLabelText(/last name/i), 'User');
+    // Use fireEvent.submit to bypass HTML5 type="email" native validation
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid email format')).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when first name is missing', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/username/i), 'validuser');
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    // Type whitespace-only first name (DOMPurify trims to empty)
+    await user.type(screen.getByLabelText(/first name/i), '   ');
+    await user.type(screen.getByLabelText(/last name/i), 'User');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('First name is required')).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when last name is missing', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/username/i), 'validuser');
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/first name/i), 'Test');
+    // Type whitespace-only last name (DOMPurify trims to empty)
+    await user.type(screen.getByLabelText(/last name/i), '   ');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Last name is required')).toBeInTheDocument();
+    });
+    expect(mockRegister).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/unit/utils/schemas.test.js
+++ b/frontend/tests/unit/utils/schemas.test.js
@@ -12,6 +12,7 @@ import {
   studentIdSchema,
   groupNameSchema,
   registerSchema,
+  createUserSchema,
   changePasswordSchema,
   createGroupSchema,
   updateGroupSchema,
@@ -430,6 +431,94 @@ describe('registerSchema', () => {
   it('rejects invalid email format', () => {
     const result = parseBody(registerSchema, { ...validBody, email: 'not-an-email' });
     expect(result.error).toBe('Invalid email format');
+  });
+});
+
+// ── createUserSchema ─────────────────────────────────────────────────────────
+
+describe('createUserSchema', () => {
+  const validBody = {
+    username: 'alice',
+    email: 'alice@example.com',
+    firstName: 'Alice',
+    lastName: 'Smith',
+  };
+
+  it('accepts valid input with all required fields', () => {
+    const data = ok(createUserSchema, validBody);
+    expect(data.username).toBe('alice');
+    expect(data.email).toBe('alice@example.com');
+    expect(data.firstName).toBe('Alice');
+    expect(data.lastName).toBe('Smith');
+  });
+
+  it('accepts optional role field', () => {
+    const data = ok(createUserSchema, { ...validBody, role: 'assignment_manager' });
+    expect(data.role).toBe('assignment_manager');
+  });
+
+  it('accepts optional groupId as valid UUID', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      groupId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+    expect(data.groupId).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('accepts optional studentId', () => {
+    const data = ok(createUserSchema, { ...validBody, studentId: 'STU-001' });
+    expect(data.studentId).toBe('STU-001');
+  });
+
+  it('coerces empty string groupId to null', () => {
+    const data = ok(createUserSchema, { ...validBody, groupId: '' });
+    expect(data.groupId).toBeNull();
+  });
+
+  it('accepts sendSetupEmail as true', () => {
+    const data = ok(createUserSchema, { ...validBody, sendSetupEmail: true });
+    expect(data.sendSetupEmail).toBe(true);
+  });
+
+  it('accepts sendSetupEmail as false', () => {
+    const data = ok(createUserSchema, { ...validBody, sendSetupEmail: false });
+    expect(data.sendSetupEmail).toBe(false);
+  });
+
+  it('rejects missing username', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { username: _u, ...body } = validBody;
+    const result = parseBody(createUserSchema, body);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('rejects missing email', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { email: _e, ...body } = validBody;
+    const result = parseBody(createUserSchema, body);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('rejects missing firstName', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { firstName: _f, ...body } = validBody;
+    const result = parseBody(createUserSchema, body);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('rejects missing lastName', () => {
+    // eslint-disable-next-line no-unused-vars
+    const { lastName: _l, ...body } = validBody;
+    const result = parseBody(createUserSchema, body);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('rejects invalid role value', () => {
+    expect(err(createUserSchema, { ...validBody, role: 'superuser' })).toEqual(expect.any(String));
+  });
+
+  it('rejects invalid groupId (non-UUID)', () => {
+    expect(err(createUserSchema, { ...validBody, groupId: 'not-a-uuid' })).toEqual(expect.any(String));
   });
 });
 

--- a/tests/e2e/assignment-manager.spec.js
+++ b/tests/e2e/assignment-manager.spec.js
@@ -2,7 +2,7 @@
 
 const { test, expect } = require('@playwright/test');
 const { loginAs } = require('../helpers/auth');
-const { cleanDatabase, createUser, createGroup } = require('../helpers/db');
+const { cleanDatabase, createUser, createGroup, assignUserToGroup } = require('../helpers/db');
 
 test.describe('Assignment Manager', () => {
   test.beforeEach(async ({ page }) => {
@@ -48,5 +48,27 @@ test.describe('Assignment Manager', () => {
 
     // Group name appears in the user row's group cell (title attribute is unique)
     await expect(page.locator('[title="AssignGroup"]')).toBeVisible();
+  });
+
+  test('can unassign a user from a group', async ({ page }) => {
+    const group = await createGroup({ name: 'UnassignGroup' });
+    await createUser({ username: 'assigned', email: 'assigned@test.com', role: 'user' });
+    await assignUserToGroup('assigned', group.id);
+
+    await page.goto('/users');
+
+    // Verify the user is currently in the group
+    const row = page.locator('table tbody tr').filter({ hasText: 'assigned' });
+    await expect(row.locator('[title="UnassignGroup"]')).toBeVisible({ timeout: 10000 });
+
+    // Click the Assign Group button for the user
+    await row.getByRole('button', { name: 'Assign Group' }).click();
+
+    // Select "No Group" to unassign
+    await page.getByRole('combobox', { name: /assign to group/i }).selectOption({ value: '' });
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Group column should now show "Not assigned"
+    await expect(row.locator('[title="Not assigned"]')).toBeVisible({ timeout: 10000 });
   });
 });

--- a/tests/e2e/forgot-password.spec.js
+++ b/tests/e2e/forgot-password.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { test, expect } = require('@playwright/test');
+const { loginAs } = require('../helpers/auth');
 const { cleanDatabase, createUser, createPasswordResetToken } = require('../helpers/db');
 
 test.describe('Forgot Password', () => {
@@ -20,18 +21,18 @@ test.describe('Forgot Password', () => {
     await page.goto('/forgot-password');
     await page.getByPlaceholder('Enter your email address').fill('resetuser@test.com');
     await page.getByRole('button', { name: 'Send Reset Link' }).click();
-    await expect(
-      page.getByText(/reset link has been sent|if that email is registered/i)
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/reset link has been sent|if that email is registered/i)).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test('shows success message even for unknown email (avoids email enumeration)', async ({ page }) => {
     await page.goto('/forgot-password');
     await page.getByPlaceholder('Enter your email address').fill('nobody@nowhere.com');
     await page.getByRole('button', { name: 'Send Reset Link' }).click();
-    await expect(
-      page.getByText(/reset link has been sent|if that email is registered/i)
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/reset link has been sent|if that email is registered/i)).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test('back to login link navigates to /login', async ({ page }) => {
@@ -68,9 +69,7 @@ test.describe('Set Password', () => {
     await page.getByPlaceholder('At least 6 characters').fill('NewPass123!');
     await page.getByPlaceholder('Repeat your password').fill('NewPass123!');
     await page.getByRole('button', { name: 'Set Password' }).click();
-    await expect(
-      page.getByText(/password set successfully|you can now log in/i)
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/password set successfully|you can now log in/i)).toBeVisible({ timeout: 10000 });
     await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
   });
 
@@ -102,5 +101,27 @@ test.describe('Set Password', () => {
     await page.getByPlaceholder('Repeat your password').fill('NewPass123!');
     await page.getByRole('button', { name: 'Set Password' }).click();
     await expect(page.getByText(/invalid or expired token|failed to set password/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('setup token allows first-login password set and login', async ({ page }) => {
+    const user = await createUser({ username: 'setupuser', email: 'setupuser@test.com', password: 'TempPass000!' });
+    const token = await createPasswordResetToken(user.email, { tokenType: 'setup' });
+
+    // Navigate to set-password with the setup token
+    await page.goto(`/set-password?token=${token}`);
+    await expect(page.getByText('Set your password')).toBeVisible({ timeout: 10000 });
+
+    // Set a new password
+    await page.getByPlaceholder('At least 6 characters').fill('SetupNew123!');
+    await page.getByPlaceholder('Repeat your password').fill('SetupNew123!');
+    await page.getByRole('button', { name: 'Set Password' }).click();
+
+    // Should show success and redirect to login
+    await expect(page.getByText(/password set successfully|you can now log in/i)).toBeVisible({ timeout: 10000 });
+    await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
+
+    // Login with the new password
+    await loginAs(page, 'setupuser', 'SetupNew123!');
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10000 });
   });
 });

--- a/tests/e2e/import-users.spec.js
+++ b/tests/e2e/import-users.spec.js
@@ -67,6 +67,38 @@ test.describe('Import Users', () => {
     }
   });
 
+  test('overwrite conflict action imports existing user successfully', async ({ page }) => {
+    await createUser({ username: 'existuser', email: 'existuser@test.com', firstName: 'Old', lastName: 'Name' });
+
+    const csvContent = 'username,email,firstName,lastName\nexistuser,existuser@test.com,New,Updated\n';
+    const tmpPath = path.join(os.tmpdir(), `import-overwrite-${Date.now()}.csv`);
+
+    try {
+      fs.writeFileSync(tmpPath, csvContent, 'utf8');
+      await loginAsAdmin(page);
+      await page.goto('/users/import');
+
+      await page.locator('input[aria-label="Upload CSV file"]').setInputFiles(tmpPath);
+
+      // Step 2: Map Columns
+      await expect(page.getByRole('button', { name: /preview import/i })).toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: /preview import/i }).click();
+
+      // Step 3: Preview — default conflict action is "skip", change to "overwrite"
+      await expect(page.getByText('Existing – skip')).toBeVisible({ timeout: 10000 });
+      await page.locator('input[type="radio"][value="overwrite"]').check();
+      await expect(page.getByText('Existing – overwrite')).toBeVisible({ timeout: 10000 });
+
+      await page.getByRole('button', { name: /^import$/i }).click();
+
+      // Step 4: Result
+      await expect(page.getByText('Import Complete')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText(/1 imported/)).toBeVisible();
+    } finally {
+      fs.rmSync(tmpPath, { force: true });
+    }
+  });
+
   test('preview shows invalid for rows with missing required fields', async ({ page }) => {
     // Row has username but no email — email is a required field
     const csvContent = 'username,email,firstName,lastName\nnoemail,,Missing,Email\n';

--- a/tests/e2e/users-advanced.spec.js
+++ b/tests/e2e/users-advanced.spec.js
@@ -70,6 +70,32 @@ test.describe('Users — Enable/Disable via Edit Modal', () => {
   });
 });
 
+test.describe('Users — Role Change via Edit Modal', () => {
+  test.beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  test('admin can change user role to assignment manager', async ({ page }) => {
+    await createUser({ username: 'roleuser', email: 'roleuser@test.com', role: 'user' });
+    await loginAsAdmin(page);
+    await page.goto('/users');
+
+    const row = page.locator('table tbody tr').filter({ hasText: 'roleuser' });
+    await row.locator('button[aria-label="Edit User Profile"]').click();
+    await expect(page.getByRole('heading', { name: 'Edit User' })).toBeVisible();
+
+    // Change role dropdown to assignment_manager (scoped to the edit modal form)
+    const roleSelect = page.locator('form').getByRole('combobox');
+    await roleSelect.selectOption('assignment_manager');
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('User updated successfully')).toBeVisible({ timeout: 5000 });
+
+    // The role badge in the table should display "Assignment Manager"
+    await expect(row.getByText('Assignment Manager')).toBeVisible({ timeout: 10000 });
+  });
+});
+
 test.describe('Delete User — constraints', () => {
   test.beforeEach(async () => {
     await cleanDatabase();


### PR DESCRIPTION
## Summary

- Add 50 new tests across unit, integration, frontend, and E2E to close HIGH-severity coverage gaps
- Total test count: 1347 → 1397 (+50 tests)
- All RBAC blind spots for assignment_manager role now covered
- Frontend client-side validation, schema, and component interaction gaps filled

## Changes by area

### Backend unit (+5)
- `User.activate` model: success + DB error propagation
- `GET /auth/me`: deleted user (401) + DB error (500) paths
- `PUT /users/:id/group`: invalid non-UUID groupId (400)

### Integration (+17)
- `POST /users/send-setup-emails`: 7 tests (admin flow, auth, validation, edge cases)
- AM RBAC: can assign groups, cannot escalate roles, blocked from admin-only endpoints
- Disabled user: blocked from join and leave
- Locked system: leave blocked for regular users
- `maxMembers` boundary: exactly equal to current count succeeds
- Full group import-mappings: error recorded in response

### Frontend unit (+24)
- Login/Register: client-side schema validation (empty fields, invalid email)
- Login: loading/disabled button state during API call
- `App.jsx`: PublicRoute redirects authenticated users away from /login and /register
- `createUserSchema`: 10 tests (groupId null coercion, sendSetupEmail, required fields)
- `UserMenu`: AM role hides student ID field, dropdown toggle close

### E2E (+4)
- AM can unassign a user from a group
- Admin can change user role via edit modal
- Import users with "overwrite" conflict action
- Setup-type token first-login journey (set password → login)

## Test plan

- [x] Backend unit: 613 passed
- [x] Frontend unit: 533 passed
- [x] Integration: 158 passed
- [x] E2E: 93 passed
- [x] Lint: clean
- [x] Format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)