### PR TITLE
test: address MEDIUM and LOW test coverage gaps

### DIFF
--- a/backend/tests/integration/auth.test.js
+++ b/backend/tests/integration/auth.test.js
@@ -2,6 +2,7 @@
 
 const { buildTestServer, closeTestServer } = require('./helpers/server');
 const { cleanDatabase, createUser, loginAs, getPool } = require('./helpers/db');
+const config = require('../../src/config/index');
 
 let app;
 let adminToken;
@@ -158,6 +159,22 @@ describe('POST /api/auth/register', () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  it('returns 403 when registration is disabled', async () => {
+    const original = config.app.registrationEnabled;
+    config.app.registrationEnabled = false;
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/auth/register',
+        payload: { username: 'blocked', email: 'blocked@test.com', firstName: 'B', lastName: 'L' },
+      });
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res.body).error).toMatch(/disabled/i);
+    } finally {
+      config.app.registrationEnabled = original;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -197,6 +214,26 @@ describe('GET /api/auth/me', () => {
       method: 'GET',
       url: '/api/auth/me',
       headers: { authorization: 'Bearer invalid.token.here' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when JWT belongs to a deleted user', async () => {
+    const u = await createUser({ username: 'todelete', email: 'todelete@test.com' });
+    const token = await loginAs(app, 'todelete', 'TestPass123!');
+
+    // Delete the user via admin
+    await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+
+    // Token is still valid JWT, but user no longer exists in DB
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { authorization: `Bearer ${token}` },
     });
     expect(res.statusCode).toBe(401);
   });

--- a/backend/tests/integration/groups.test.js
+++ b/backend/tests/integration/groups.test.js
@@ -775,6 +775,72 @@ describe('PUT /api/groups/:id — maxMembers boundary', () => {
 // ---------------------------------------------------------------------------
 // POST /api/groups/import-mappings — full group error path
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// POST /api/groups/import-mappings — skip-action rows
+// ---------------------------------------------------------------------------
+describe('POST /api/groups/import-mappings — skip-action rows', () => {
+  it('rows with action=skip appear in the skipped response', async () => {
+    await createGroup({ name: 'SkipActionGroup', enabled: true });
+    await createUser({ username: 'skipuser', email: 'skipuser@test.com' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/import-mappings',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        rows: [
+          { email: 'skipuser@test.com', groupName: 'SkipActionGroup' },
+          { email: 'skipped@test.com', groupName: 'SkipActionGroup', action: 'skip', skipReason: 'Duplicate entry' },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(1);
+    expect(body.skipped.some((s) => s.email === 'skipped@test.com' && s.reason === 'Duplicate entry')).toBe(true);
+  });
+
+  it('skip-action row with no skipReason defaults to "Skipped"', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/import-mappings',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        rows: [{ email: 'noop@test.com', groupName: 'AnyGroup', action: 'skip' }],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.skipped).toHaveLength(1);
+    expect(body.skipped[0].reason).toBe('Skipped');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/groups/:id/join and /leave — invalid UUID in path
+// ---------------------------------------------------------------------------
+describe('POST /api/groups/:id/join and /leave — invalid UUID', () => {
+  it('join with invalid UUID returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/not-a-uuid/join',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
+  });
+
+  it('leave with invalid UUID returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups/not-a-uuid/leave',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
+  });
+});
+
 describe('POST /api/groups/import-mappings — full group error path', () => {
   it('importing a user mapping to a full group records an error', async () => {
     const g = await createGroup({ name: 'FullImportGroup', maxMembers: 1 });

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -997,3 +997,156 @@ describe('RBAC: AM on admin-only user endpoints', () => {
     expect(res.statusCode).toBe(403);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /api/users?groupId= — filter by group
+// ---------------------------------------------------------------------------
+describe('GET /api/users?groupId=<uuid>', () => {
+  it('returns only users in the specified group', async () => {
+    const g = await createGroup({ name: 'FilterGroup' });
+    const inGroup = await createUser({ username: 'ingroup', email: 'ingroup@test.com' });
+    await createUser({ username: 'nogroup', email: 'nogroup@test.com' });
+
+    // Assign inGroup user to the group
+    await app.inject({
+      method: 'PUT',
+      url: `/api/users/${inGroup.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { groupId: g.id },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/users?groupId=${g.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.users.every((u) => u.group_id === g.id)).toBe(true);
+    expect(body.users.some((u) => u.username === 'ingroup')).toBe(true);
+    expect(body.users.some((u) => u.username === 'nogroup')).toBe(false);
+  });
+
+  it('groupId=none returns only ungrouped users', async () => {
+    const g = await createGroup({ name: 'SomeGroup' });
+    const grouped = await createUser({ username: 'grouped', email: 'grouped@test.com' });
+    await createUser({ username: 'ungrouped', email: 'ungrouped@test.com' });
+
+    await app.inject({
+      method: 'PUT',
+      url: `/api/users/${grouped.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { groupId: g.id },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users?groupId=none',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.users.every((u) => u.group_id === null)).toBe(true);
+    expect(body.users.some((u) => u.username === 'ungrouped')).toBe(true);
+    expect(body.users.some((u) => u.username === 'grouped')).toBe(false);
+  });
+
+  it('returns 400 for invalid groupId filter', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users?groupId=not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/groupId/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/users/import — within-batch duplicate detection
+// ---------------------------------------------------------------------------
+describe('POST /api/users/import — within-batch duplicate email', () => {
+  it('detects duplicate emails within the same batch', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        users: [
+          { username: 'dup1', email: 'same@test.com', firstName: 'Dup', lastName: 'One' },
+          { username: 'dup2', email: 'same@test.com', firstName: 'Dup', lastName: 'Two' },
+        ],
+        conflictAction: 'skip',
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    // First row imports, second row errors because email is already taken by the first
+    expect(body.imported).toBe(1);
+    expect(body.errors.length).toBe(1);
+    expect(body.errors[0].reason).toMatch(/email/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/users/import — invalid conflictAction
+// ---------------------------------------------------------------------------
+describe('POST /api/users/import — invalid conflictAction', () => {
+  it('returns 400 for an invalid conflictAction value', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        users: [{ username: 'x', email: 'x@test.com', firstName: 'X', lastName: 'Y' }],
+        conflictAction: 'merge',
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/conflictAction/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/users/:id — admin changes role from user to assignment_manager
+// ---------------------------------------------------------------------------
+describe('PUT /api/users/:id — admin role change', () => {
+  it('admin changes role from user to assignment_manager and verifies via GET', async () => {
+    const u = await createUser({ username: 'rolechange', email: 'rolechange@test.com', role: 'user' });
+
+    const putRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { email: u.email, firstName: 'Role', lastName: 'Change', role: 'assignment_manager' },
+    });
+    expect(putRes.statusCode).toBe(200);
+
+    // Verify the role was actually updated
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(getRes.statusCode).toBe(200);
+    expect(JSON.parse(getRes.body).user.role_name).toBe('assignment_manager');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/users/:id/password — admin cannot change another user's password
+// ---------------------------------------------------------------------------
+describe('PUT /api/users/:id/password — admin cross-user', () => {
+  it('admin cannot change another user password (returns 403)', async () => {
+    const other = await createUser({ username: 'adminpassvictim', email: 'apv@test.com' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${other.id}/password`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { currentPassword: 'TestPass123!', newPassword: 'NewPass456!' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -160,6 +160,15 @@ describe('Groups Routes', () => {
       });
     });
 
+    it('returns 400 for invalid UUID in path param', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ params: { id: 'not-a-uuid' } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
+      expect(Group.findById).not.toHaveBeenCalled();
+    });
+
     it('returns 404 when group not found', async () => {
       const { handlers } = setupRoute();
       Group.findById.mockResolvedValue(null);
@@ -332,6 +341,23 @@ describe('Groups Routes', () => {
       );
       expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
+    });
+
+    it('returns 500 when Group.findByName rejects with DB error', async () => {
+      const { handlers } = setupRoute();
+      Group.findByName.mockRejectedValue(new Error('connection refused'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      const reply = mockReply();
+      await handlers['/groups_post'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
+          body: { name: 'New Group' },
+        },
+        reply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to create group' });
     });
   });
 

--- a/backend/tests/unit/models/group.test.js
+++ b/backend/tests/unit/models/group.test.js
@@ -471,6 +471,12 @@ describe('Group Model', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Group.getExportMappings()).rejects.toThrow('connection refused');
+    });
   });
 
   describe('assignUserToGroup', () => {
@@ -680,6 +686,19 @@ describe('Group Model', () => {
       const result = await Group.bulkCreate(input);
 
       expect(result).toEqual([row]);
+    });
+
+    it('returns empty array and commits when input is empty', async () => {
+      mockClient.query
+        .mockResolvedValueOnce() // BEGIN
+        .mockResolvedValueOnce(); // COMMIT
+
+      const result = await Group.bulkCreate([]);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, 'COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
 
     it('releases client even when ROLLBACK itself throws', async () => {

--- a/backend/tests/unit/models/role.test.js
+++ b/backend/tests/unit/models/role.test.js
@@ -119,5 +119,22 @@ describe('Role Model', () => {
 
       expect(result).toEqual(mockRole);
     });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Role.create('moderator')).rejects.toThrow('connection refused');
+    });
+
+    it('propagates duplicate-name constraint error (23505)', async () => {
+      const uniqueErr = new Error('duplicate key value violates unique constraint');
+      uniqueErr.code = '23505';
+      pool.query.mockRejectedValue(uniqueErr);
+
+      await expect(Role.create('admin')).rejects.toMatchObject({
+        message: 'duplicate key value violates unique constraint',
+        code: '23505',
+      });
+    });
   });
 });

--- a/backend/tests/unit/models/user.test.js
+++ b/backend/tests/unit/models/user.test.js
@@ -86,6 +86,12 @@ describe('User Model', () => {
       expect(pool.query).not.toHaveBeenCalled();
       expect(result).toEqual([]);
     });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(User.findByIds(['u0000000-0000-0000-0000-000000000001'])).rejects.toThrow('connection refused');
+    });
   });
 
   describe('findById', () => {
@@ -361,6 +367,22 @@ describe('User Model', () => {
       expect(result).toEqual(mockCreatedUser);
     });
 
+    it('propagates DB error from pool.query', async () => {
+      const userData = {
+        username: 'newuser',
+        email: 'new@test.com',
+        password: 'password123',
+        studentId: null,
+        groupId: null,
+        roleId: 'r0000000-0000-0000-0000-000000000003',
+      };
+
+      bcrypt.hash.mockResolvedValue('hashedPassword123');
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(User.create(userData)).rejects.toThrow('connection refused');
+    });
+
     it('creates user with custom roleId', async () => {
       const userData = {
         username: 'adminuser',
@@ -542,6 +564,15 @@ describe('User Model', () => {
       const result = await User.updatePassword('u0000000-0000-0000-0000-000000000999', 'newpassword');
 
       expect(result).toBeUndefined();
+    });
+
+    it('propagates bcrypt.hash error', async () => {
+      bcrypt.hash.mockRejectedValue(new Error('hash failure'));
+
+      await expect(User.updatePassword('u0000000-0000-0000-0000-000000000001', 'newpassword')).rejects.toThrow(
+        'hash failure'
+      );
+      expect(pool.query).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/tests/unit/components/CsvDropzone.test.jsx
+++ b/frontend/tests/unit/components/CsvDropzone.test.jsx
@@ -58,6 +58,27 @@ describe('CsvDropzone', () => {
     expect(onFile).toHaveBeenCalledWith(file);
   });
 
+  it('handles full drag-and-drop flow (dragOver then drop with CSV)', () => {
+    const onFile = jest.fn();
+    render(<CsvDropzone onFile={onFile} />);
+    const file = makeCsvFile('name,email\nAlice,a@b.com', 'roster.csv');
+    const dropzone = screen.getByRole('button', { name: /click to browse/i });
+
+    // dragOver must not reject the drop
+    act(() => {
+      fireEvent.dragOver(dropzone);
+    });
+
+    // drop delivers the file
+    act(() => {
+      fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+    });
+
+    expect(onFile).toHaveBeenCalledTimes(1);
+    expect(onFile.mock.calls[0][0].name).toBe('roster.csv');
+    expect(onFile.mock.calls[0][0].type).toBe('text/csv');
+  });
+
   it('does not call onFile when drop has no files', () => {
     const onFile = jest.fn();
     render(<CsvDropzone onFile={onFile} />);

--- a/frontend/tests/unit/context/AuthContext.test.jsx
+++ b/frontend/tests/unit/context/AuthContext.test.jsx
@@ -6,8 +6,19 @@ import { AuthProvider, useAuth } from '../../../src/context/AuthContext.jsx';
 jest.mock('@/utils/api');
 
 function TestHarness() {
-  const { user, loading, token, isAuthenticated, isAdmin, isAssignmentManager, login, register, logout, refreshUser } =
-    useAuth();
+  const {
+    user,
+    loading,
+    token,
+    isAuthenticated,
+    isAdmin,
+    isAssignmentManager,
+    login,
+    register,
+    logout,
+    refreshUser,
+    registrationEnabled,
+  } = useAuth();
 
   const handleLogin = async () => {
     const result = await login('demo', 'password');
@@ -27,6 +38,7 @@ function TestHarness() {
       <div data-testid="user">{user?.username ?? 'none'}</div>
       <div data-testid="is-admin">{isAdmin ? 'yes' : 'no'}</div>
       <div data-testid="is-assignment-manager">{isAssignmentManager ? 'yes' : 'no'}</div>
+      <div data-testid="registration-enabled">{registrationEnabled ? 'yes' : 'no'}</div>
       <button onClick={handleLogin}>Login</button>
       <button onClick={handleRegister}>Register</button>
       <button onClick={logout}>Logout</button>
@@ -146,6 +158,30 @@ describe('AuthContext', () => {
     });
 
     expect(window.__authResult).toEqual({ success: false, error: 'Invalid credentials' });
+  });
+
+  it('login error includes status field from response', async () => {
+    api.post.mockRejectedValue({
+      response: { data: { error: 'Account locked' }, status: 403 },
+    });
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await userEvent.click(screen.getByText('Login'));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalled();
+    });
+
+    expect(window.__authResult).toEqual({
+      success: false,
+      error: 'Account locked',
+      status: 403,
+    });
   });
 
   it('register sends expected payload and returns success message', async () => {
@@ -277,6 +313,43 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('auth')).toHaveTextContent('no');
     expect(screen.getByTestId('user')).toHaveTextContent('none');
     expect(screen.getByTestId('token')).toHaveTextContent('none');
+  });
+});
+
+describe('registrationEnabled config', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('sets registrationEnabled to true when /auth/config returns true', async () => {
+    api.get.mockResolvedValue({ data: { registrationEnabled: true } });
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('registration-enabled')).toHaveTextContent('yes');
+    });
+  });
+
+  it('defaults registrationEnabled to false when /auth/config call fails', async () => {
+    api.get.mockRejectedValue(new Error('network error'));
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('loaded');
+    });
+
+    expect(screen.getByTestId('registration-enabled')).toHaveTextContent('no');
   });
 });
 

--- a/frontend/tests/unit/pages/Dashboard.test.jsx
+++ b/frontend/tests/unit/pages/Dashboard.test.jsx
@@ -59,6 +59,26 @@ describe('Dashboard page', () => {
     expect(screen.getByRole('link', { name: /manage groups/i })).toBeInTheDocument();
   });
 
+  it('shows Manage Users but not Manage Groups for assignment_manager role', () => {
+    useAuth.mockReturnValue({
+      user: { username: 'manager', email: 'manager@example.com', role: 'assignment_manager' },
+      logout: mockLogout,
+      refreshUser: mockRefreshUser,
+      isAdmin: false,
+      isAssignmentManager: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /manage groups/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
+  });
+
   it('hides administration block for normal users', () => {
     render(
       <MemoryRouter>

--- a/frontend/tests/unit/pages/SetPassword.test.jsx
+++ b/frontend/tests/unit/pages/SetPassword.test.jsx
@@ -37,6 +37,15 @@ describe('SetPassword page', () => {
     expect(screen.queryByPlaceholderText('At least 6 characters')).not.toBeInTheDocument();
   });
 
+  it('renders the form (not "Invalid Link") when token is non-empty but invalid', () => {
+    renderWithToken('not-a-real-token');
+
+    expect(screen.queryByText('Invalid Link')).not.toBeInTheDocument();
+    expect(screen.getByText('Set your password')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('At least 6 characters')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /set password/i })).toBeInTheDocument();
+  });
+
   it('renders the set password form when token is present', () => {
     renderWithToken('abc123token');
 

--- a/frontend/tests/unit/pages/Settings.test.jsx
+++ b/frontend/tests/unit/pages/Settings.test.jsx
@@ -156,6 +156,36 @@ describe('Settings page', () => {
     });
   });
 
+  it('auto-dismisses success message after timeout', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    api.get.mockResolvedValue({
+      data: { config: [{ key: 'group_join_locked', value: 'false' }] },
+    });
+    api.put.mockResolvedValue({});
+
+    render(
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => screen.getByRole('button', { name: /enable group join lock/i }));
+
+    await user.click(screen.getByRole('button', { name: /enable group join lock/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings updated successfully')).toBeInTheDocument();
+    });
+
+    jest.advanceTimersByTime(2000);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Settings updated successfully')).not.toBeInTheDocument();
+    });
+  });
+
   it('shows error message when update fails', async () => {
     api.get.mockResolvedValue({
       data: { config: [{ key: 'group_join_locked', value: 'false' }] },

--- a/frontend/tests/unit/utils/api.test.js
+++ b/frontend/tests/unit/utils/api.test.js
@@ -1,25 +1,31 @@
 import api from '@/utils/api';
 
 describe('api request interceptor', () => {
-  it('attaches Authorization header when localStorage has a token', async () => {
-    localStorage.setItem('token', 'test-jwt-token');
+  const mockAdapter = jest.fn().mockResolvedValue({ data: {}, status: 200, headers: {} });
+  let originalAdapter;
 
-    // Run a request config through the interceptor chain
-    const config = { headers: {} };
-    // Axios interceptors are stored in api.interceptors.request.handlers
-    const interceptor = api.interceptors.request.handlers[0];
-    const result = interceptor.fulfilled(config);
-
-    expect(result.headers.Authorization).toBe('Bearer test-jwt-token');
+  beforeEach(() => {
+    localStorage.clear();
+    mockAdapter.mockClear();
+    originalAdapter = api.defaults.adapter;
+    api.defaults.adapter = mockAdapter;
   });
 
-  it('does not attach Authorization header when no token in localStorage', () => {
-    localStorage.removeItem('token');
+  afterEach(() => {
+    localStorage.clear();
+    api.defaults.adapter = originalAdapter;
+  });
 
-    const config = { headers: {} };
-    const interceptor = api.interceptors.request.handlers[0];
-    const result = interceptor.fulfilled(config);
+  it('attaches Authorization header when localStorage has a token', async () => {
+    localStorage.setItem('token', 'test-jwt-token');
+    await api.get('/test');
+    const config = mockAdapter.mock.calls[0][0];
+    expect(config.headers.get('Authorization')).toBe('Bearer test-jwt-token');
+  });
 
-    expect(result.headers.Authorization).toBeUndefined();
+  it('does not attach Authorization header when no token in localStorage', async () => {
+    await api.get('/test');
+    const config = mockAdapter.mock.calls[0][0];
+    expect(config.headers.has('Authorization')).toBe(false);
   });
 });

--- a/frontend/tests/unit/utils/api.test.js
+++ b/frontend/tests/unit/utils/api.test.js
@@ -1,0 +1,25 @@
+import api from '@/utils/api';
+
+describe('api request interceptor', () => {
+  it('attaches Authorization header when localStorage has a token', async () => {
+    localStorage.setItem('token', 'test-jwt-token');
+
+    // Run a request config through the interceptor chain
+    const config = { headers: {} };
+    // Axios interceptors are stored in api.interceptors.request.handlers
+    const interceptor = api.interceptors.request.handlers[0];
+    const result = interceptor.fulfilled(config);
+
+    expect(result.headers.Authorization).toBe('Bearer test-jwt-token');
+  });
+
+  it('does not attach Authorization header when no token in localStorage', () => {
+    localStorage.removeItem('token');
+
+    const config = { headers: {} };
+    const interceptor = api.interceptors.request.handlers[0];
+    const result = interceptor.fulfilled(config);
+
+    expect(result.headers.Authorization).toBeUndefined();
+  });
+});

--- a/frontend/tests/unit/utils/formatting.test.js
+++ b/frontend/tests/unit/utils/formatting.test.js
@@ -1,0 +1,27 @@
+import { formatRoleName } from '@/utils/formatting';
+
+describe('formatRoleName', () => {
+  it('formats "admin" as "Admin"', () => {
+    expect(formatRoleName('admin')).toBe('Admin');
+  });
+
+  it('formats "assignment_manager" as "Assignment Manager"', () => {
+    expect(formatRoleName('assignment_manager')).toBe('Assignment Manager');
+  });
+
+  it('formats "user" as "User"', () => {
+    expect(formatRoleName('user')).toBe('User');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(formatRoleName(undefined)).toBe('');
+  });
+
+  it('returns empty string for null', () => {
+    expect(formatRoleName(null)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(formatRoleName('')).toBe('');
+  });
+});

--- a/tests/e2e/auth.spec.js
+++ b/tests/e2e/auth.spec.js
@@ -87,5 +87,15 @@ test.describe('Authentication', () => {
       await page.goto('/groups');
       await expect(page).toHaveURL(/\/login/);
     });
+
+    test('redirects /settings to /login', async ({ page }) => {
+      await page.goto('/settings');
+      await expect(page).toHaveURL(/\/login/);
+    });
+
+    test('redirects /users/import to /login', async ({ page }) => {
+      await page.goto('/users/import');
+      await expect(page).toHaveURL(/\/login/);
+    });
   });
 });

--- a/tests/e2e/forgot-password.spec.js
+++ b/tests/e2e/forgot-password.spec.js
@@ -35,6 +35,25 @@ test.describe('Forgot Password', () => {
     });
   });
 
+  test('does not submit with empty email field', async ({ page }) => {
+    await page.goto('/forgot-password');
+    const emailInput = page.getByPlaceholder('Enter your email address');
+
+    // Ensure the field is empty
+    await expect(emailInput).toHaveValue('');
+
+    // Click submit — HTML5 required validation should prevent submission
+    await page.getByRole('button', { name: 'Send Reset Link' }).click();
+
+    // The input should report a validity error (browser native validation)
+    const isInvalid = await emailInput.evaluate((el) => !el.validity.valid);
+    expect(isInvalid).toBe(true);
+
+    // No success or error banners should appear (form was not submitted)
+    await expect(page.locator('.bg-green-50')).not.toBeVisible();
+    await expect(page.locator('.bg-red-50')).not.toBeVisible();
+  });
+
   test('back to login link navigates to /login', async ({ page }) => {
     await page.goto('/forgot-password');
     await page.getByRole('link', { name: 'Back to login' }).click();


### PR DESCRIPTION
## Summary

- Add 40 new tests across all 4 suites to close remaining MEDIUM and LOW coverage gaps
- Total test count: 1397 → 1437 (+40 tests)
- Completes the full test quality audit (CRITICAL → HIGH → MEDIUM → LOW)

## Changes by area

### Backend unit (+9)
- Model error propagation: User.create, User.updatePassword, User.findByIds, Role.create, Group.getExportMappings
- Role.create: duplicate-name constraint (23505) test
- Group.bulkCreate: empty array input
- GET /groups/:id: invalid UUID returns 400
- POST /groups: Group.findByName DB error returns 500

### Integration (+13)
- GET /users?groupId: filter by group, ungrouped users, invalid UUID
- POST /auth/register: registration disabled returns 403
- POST /users/import: within-batch duplicate email detection, invalid conflictAction
- POST /groups/import-mappings: skip-action rows in response
- GET /auth/me: deleted user JWT returns 401
- PUT /users/:id: admin role change verified via GET
- POST /groups/:id/join and /leave: invalid UUID returns 400
- PUT /users/:id/password: admin cannot change another user's password

### Frontend unit (+15)
- AuthContext: registrationEnabled flag, login error status field
- Dashboard: assignment_manager role rendering
- Settings: success message auto-dismiss timeout
- SetPassword: invalid token renders form (not "Invalid Link")
- CsvDropzone: drag-and-drop file handling
- **NEW** formatting.test.js: formatRoleName with all roles + edge cases
- **NEW** api.test.js: Axios interceptor auth header attach/omit

### E2E (+3)
- Unauthenticated /settings and /users/import redirect to /login
- Forgot-password empty email validation

## Test plan

- [x] Backend unit: 622 passed
- [x] Frontend unit: 548 passed
- [x] Integration: 171 passed
- [x] E2E: 96 passed
- [x] Lint: clean
- [x] Format: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)