### PR TITLE
feat: add Subject → Assignment → Group hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,14 @@ pnpm --filter gap-frontend lint:fix     # Auto-fix frontend lint issues
 - `backend/src/middleware/auth.js` — Fastify plugin: registers `@fastify/jwt`, provides `verifyToken` decorator
 - `backend/src/middleware/rbac.js` — Fastify plugin: `checkRole` checks if user's role is in the allowed list (admin
   always passes); also provides `requireAdmin` and `requireAssignmentManager` helpers
-- `backend/src/models/` — Data access layer (User, Group, Role) using raw SQL via `pg` pool
-- `backend/src/routes/` — Route handlers registered as Fastify plugins (auth, users, groups)
+- `backend/src/models/` — Data access layer (User, Subject, Assignment, Group, UserGroup, Role) using raw SQL via `pg`
+  pool
+- `backend/src/routes/` — Route handlers registered as Fastify plugins (auth, users, subjects, assignments, groups,
+  config)
+- Data hierarchy: subjects → assignments → groups. Users enrol in subjects (`user_subjects` m2m); group membership is
+  per assignment (`user_groups`, at most one group per user per assignment); AM scoping via `assignment_managers` m2m.
+  Group placement requires membership of the parent subject — enforced in `UserGroup.assignUserToGroup` for all callers,
+  including admins.
 - `backend/src/config/` — Environment config and database pool setup
 - `backend/Dockerfile` — Production image (pnpm deploy multi-stage); `backend/Dockerfile.dev` — Dev image
 
@@ -87,14 +93,22 @@ pnpm --filter gap-frontend lint:fix     # Auto-fix frontend lint issues
 
 - `frontend/src/context/AuthContext.jsx` — Global auth state (JWT token, user info, login/logout)
 - `frontend/src/components/ProtectedRoute.jsx` — Route guard that checks auth and role
-- `frontend/src/pages/` — Page components (Login, Register, Dashboard, Users, Groups)
+- `frontend/src/pages/` — Page components (Login, Register, Dashboard, Users, Subjects, SubjectDetail, Groups)
+- Routes: `/subjects`, `/subjects/:subjectId`, `/subjects/:subjectId/assignments/:assignmentId` (groups); `/groups`
+  redirects to `/subjects`
 - Uses `@` path alias mapped to `src/` (configured in vite and jest)
 
 ### Three-Tier Role System
 
-- **Admin** — Full CRUD on users and groups
-- **Assignment Manager** — View users, assign users to groups
-- **User** — View own profile and groups
+- **Admin** — Full CRUD on subjects, assignments, groups, and users; enrols users in subjects
+- **Assignment Manager** — Scoped via `assignment_managers`: create/update/delete groups and assign subject members to
+  groups only in managed assignments; sees/imports users only for subjects where they manage an assignment
+- **User** — View own profile/subjects; self join/leave one group per assignment within enrolled subjects (global join
+  lock applies)
+
+Deleting subjects/assignments uses two-step typed confirmation in the UI; cascades assignments → groups → memberships,
+never user accounts. Migration 013 destructively drops legacy flat groups and `users.group_id` (user accounts
+preserved).
 
 ### Testing Setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,11 +100,19 @@ pnpm --filter gap-frontend lint:fix     # Auto-fix frontend lint issues
 
 ### Three-Tier Role System
 
-- **Admin** — Full CRUD on subjects, assignments, groups, and users; enrols users in subjects
+- **Admin** — Full CRUD on subjects, assignments, groups, and users; enrols users in subjects. `GET /users` (and the
+  frontend `/users` + `/users/import` routes) are admin-only.
 - **Assignment Manager** — Scoped via `assignment_managers`: create/update/delete groups and assign subject members to
-  groups only in managed assignments; sees/imports users only for subjects where they manage an assignment
+  groups only in managed assignments; manages members per subject (create, suspend/enable, setup emails) only for
+  subjects containing an assignment they manage — same scope applies to `PUT /users/:id`; setting `enabled` there is
+  admin-only
 - **User** — View own profile/subjects; self join/leave one group per assignment within enrolled subjects (global join
   lock applies)
+
+Per-subject suspension (`user_subjects.enabled`, migration 014, `PUT /subjects/:id/users/:userId`): suspending deletes
+the member's group memberships within that subject (not restored on re-enable); suspended members are hidden from their
+own session (`/auth/me`) and treated as non-members by all scope checks, but staff still see them in
+`GET /subjects/:id/users` with `membership_enabled: false`.
 
 Deleting subjects/assignments uses two-step typed confirmation in the UI; cascades assignments → groups → memberships,
 never user accounts. Migration 013 destructively drops legacy flat groups and `users.group_id` (user accounts

--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ Group Assignment Portal — a role-based access control system for managing stud
 
 ## Features
 
+- **Subject → Assignment → Group hierarchy** — Subjects contain assignments, assignments contain groups; users enrol in
+  subjects and hold at most one group per assignment
 - **JWT Authentication** — Secure login/logout with token-based auth; account setup and password reset via email
-- **User Management** — Create, update, enable/disable, bulk-delete, and CSV-import users
-- **Group Management** — Create, edit, bulk-create, enable/disable groups with optional member caps
-- **Role-Based Access Control (RBAC)** — Three-tier role system (Admin, Assignment Manager, User)
-- **Group Assignment** — Assign users to groups manually, via UI, or via CSV import/export
-- **Group Join/Leave** — Users can self-join/leave groups when the join lock is off
+- **User Management** — Create, update, enable/disable, bulk-delete, and CSV-import users into a target subject
+- **Group Management** — Create, edit, bulk-create, enable/disable per-assignment groups with optional member caps
+- **Role-Based Access Control (RBAC)** — Three-tier role system (Admin, Assignment Manager, User) with per-assignment
+  manager scoping
+- **Group Assignment** — Assign subject members to groups manually, via UI, or via per-assignment CSV import/export of
+  mappings
+- **Group Join/Leave** — Users can self-join/leave one group per assignment when the join lock is off
+- **Safe destructive deletes** — Two-step typed confirmation when deleting subjects or assignments (cascades to groups
+  and memberships, never user accounts)
 - **Email Notifications** — Account setup and password-reset emails (optional SMTP; links logged to console when
   disabled)
 - **System Config** — Admins/AMs can lock/unlock group joining system-wide
@@ -27,6 +33,11 @@ Group Assignment Portal — a role-based access control system for managing stud
 
 All API routes are prefixed with `/api`. The production setup adds Traefik in front, terminating TLS and routing `/api`
 and `/health` to the backend, everything else to the frontend nginx.
+
+The data model is hierarchical: **subjects** contain **assignments**, and each assignment has its own **groups**. Users
+enrol in subjects (`user_subjects`), group membership is per assignment (`user_groups`, at most one group per user per
+assignment), and assignment managers are scoped to the assignments they manage (`assignment_managers`). A user can only
+be placed in a group of a subject they are enrolled in — enforced for all callers, including admins.
 
 ## Tech Stack
 
@@ -227,13 +238,21 @@ docker compose down -v                           # Stop and wipe all data
 
 ```bash
 cd backend
-npm run migrate        # Apply pending migrations (safe for existing data)
+npm run migrate        # Create tables if needed, apply pending migrations
 npm run migrate:up     # Alias for migrate
 npm run migrate:reset  # Full reset — drops all tables (requires confirmation in production)
 ```
 
 Incremental migrations live in `backend/src/db/migrations/` as numbered SQL files. Always add schema changes as a new
 migration file — never edit existing ones.
+
+> ⚠️ **Destructive upgrade to the subject/assignment hierarchy.** Migration `013_subject_assignment_hierarchy.sql` moves
+> the database from the old flat groups model to the Subject → Assignment → Group hierarchy using a **clean-reset
+> strategy**: it **drops the legacy `groups` table (including all group memberships) and removes the `users.group_id`
+> column**. User accounts are preserved. The recommended path when upgrading an existing deployment is a full reset
+> (`pnpm --filter gap-backend migrate:reset`) followed by re-creating subjects/assignments/groups; running plain
+> `migrate` on a legacy database also converges to the new schema but still destroys all existing group data. **Back up
+> your database before upgrading.** Databases created from the current schema are unaffected.
 
 ## Testing
 
@@ -276,11 +295,11 @@ Pre-commit hooks (Husky + lint-staged) automatically apply Prettier and ESLint o
 
 ## Role System
 
-| Role                   | Capabilities                                                                        |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| **Admin**              | Full access: manage users, groups, config; assign users to groups; bulk operations  |
-| **Assignment Manager** | View/create/edit users; assign users to groups; import/export mappings; lock config |
-| **User**               | View own profile and groups; self-join/leave groups (when join lock is off)         |
+| Role                   | Capabilities                                                                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Admin**              | Full access: manage subjects, assignments, groups, users, and config; enrol users in subjects; assign users to groups; bulk operations                                         |
+| **Assignment Manager** | Scoped to managed assignments: create/edit/delete groups and assign subject members to groups; sees and creates/imports users only in subjects where they manage an assignment |
+| **User**               | View own profile and enrolled subjects; self-join/leave one group per assignment (when join lock is off)                                                                       |
 
 ## Environment Variables Reference
 
@@ -327,8 +346,8 @@ gap-app/
 │   │   ├── middleware/
 │   │   │   ├── auth.js      # JWT plugin + verifyToken decorator
 │   │   │   └── rbac.js      # checkRole, requireAdmin, requireAssignmentManager
-│   │   ├── models/          # User, Group, Role, Config, PasswordResetToken
-│   │   ├── routes/          # auth, users, groups, config
+│   │   ├── models/          # User, Subject, Assignment, Group, UserGroup, Role, Config, PasswordResetToken
+│   │   ├── routes/          # auth, users, subjects, assignments, groups, config
 │   │   ├── services/
 │   │   │   └── email.js     # Nodemailer email service
 │   │   └── server.js        # App entry point
@@ -340,7 +359,7 @@ gap-app/
 │   │   ├── components/      # Header, ProtectedRoute, CsvDropzone, etc.
 │   │   ├── context/
 │   │   │   └── AuthContext.jsx
-│   │   ├── pages/           # Login, Register, Dashboard, Users, Groups, ImportGroupMappings
+│   │   ├── pages/           # Login, Register, Dashboard, Users, Subjects, SubjectDetail, Groups, ImportUsers, ImportGroupMappings, Settings
 │   │   └── utils/           # csv, formatting, schemas
 │   ├── tests/unit/
 │   ├── Dockerfile           # Production (multi-stage: build + nginx)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Group Assignment Portal — a role-based access control system for managing stud
 - **Subject → Assignment → Group hierarchy** — Subjects contain assignments, assignments contain groups; users enrol in
   subjects and hold at most one group per assignment
 - **JWT Authentication** — Secure login/logout with token-based auth; account setup and password reset via email
-- **User Management** — Create, update, enable/disable, bulk-delete, and CSV-import users into a target subject
+- **User Management** — Create, update, enable/disable, bulk-delete, and CSV-import users into a target subject;
+  per-subject membership suspension without touching the account
 - **Group Management** — Create, edit, bulk-create, enable/disable per-assignment groups with optional member caps
 - **Role-Based Access Control (RBAC)** — Three-tier role system (Admin, Assignment Manager, User) with per-assignment
   manager scoping
@@ -254,6 +255,9 @@ migration file — never edit existing ones.
 > `migrate` on a legacy database also converges to the new schema but still destroys all existing group data. **Back up
 > your database before upgrading.** Databases created from the current schema are unaffected.
 
+Migration `014_user_subjects_enabled.sql` adds the per-subject suspension flag (`user_subjects.enabled`) and is
+non-destructive — all existing memberships default to enabled.
+
 ## Testing
 
 ### Backend unit tests
@@ -295,11 +299,11 @@ Pre-commit hooks (Husky + lint-staged) automatically apply Prettier and ESLint o
 
 ## Role System
 
-| Role                   | Capabilities                                                                                                                                                                   |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Admin**              | Full access: manage subjects, assignments, groups, users, and config; enrol users in subjects; assign users to groups; bulk operations                                         |
-| **Assignment Manager** | Scoped to managed assignments: create/edit/delete groups and assign subject members to groups; sees and creates/imports users only in subjects where they manage an assignment |
-| **User**               | View own profile and enrolled subjects; self-join/leave one group per assignment (when join lock is off)                                                                       |
+| Role                   | Capabilities                                                                                                                                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Admin**              | Full access: manage subjects, assignments, groups, users, and config; enrol users in subjects; suspend/re-enable subject memberships; assign users to groups; bulk operations; the global Users page is Admin-only          |
+| **Assignment Manager** | Scoped to managed assignments: create/edit/delete groups and assign subject members to groups; manages members (create, suspend/enable, setup emails) inside subjects where they manage an assignment, via the subject page |
+| **User**               | View own profile and enrolled subjects; self-join/leave one group per assignment (when join lock is off)                                                                                                                    |
 
 ## Environment Variables Reference
 

--- a/backend/src/db/migrate.js
+++ b/backend/src/db/migrate.js
@@ -10,20 +10,37 @@ const pool = new Pool(dbConfig);
 const { createSQL } = require('./schema');
 
 const dropSQL = `
+DROP TABLE IF EXISTS user_groups CASCADE;
+DROP TABLE IF EXISTS assignment_managers CASCADE;
+DROP TABLE IF EXISTS user_subjects CASCADE;
+DROP TABLE IF EXISTS password_reset_tokens CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
 DROP TABLE IF EXISTS groups CASCADE;
+DROP TABLE IF EXISTS assignments CASCADE;
+DROP TABLE IF EXISTS subjects CASCADE;
 DROP TABLE IF EXISTS roles CASCADE;
 DROP TABLE IF EXISTS config CASCADE;
 DROP TABLE IF EXISTS schema_migrations CASCADE;
 `;
 
-const sampleGroupsSQL = `
-INSERT INTO groups (name, enabled) VALUES
-  ('Team Alpha', true),
-  ('Team Beta', true),
-  ('Team Gamma', true),
-  ('Team Delta', false)
-ON CONFLICT (name) DO NOTHING;
+// Minimal dev seed: one subject with one assignment and sample groups under it.
+const sampleHierarchySQL = `
+WITH subj AS (
+  INSERT INTO subjects (name) VALUES ('Sample Subject')
+  ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+), assign AS (
+  INSERT INTO assignments (subject_id, name)
+  SELECT id, 'Assignment 1' FROM subj
+  ON CONFLICT (subject_id, name) DO UPDATE SET name = EXCLUDED.name
+  RETURNING id
+)
+INSERT INTO groups (assignment_id, name, enabled)
+SELECT assign.id, g.name, g.enabled
+FROM assign,
+     (VALUES ('Team Alpha', true), ('Team Beta', true),
+             ('Team Gamma', true), ('Team Delta', false)) AS g(name, enabled)
+ON CONFLICT (assignment_id, name) DO NOTHING;
 `;
 
 function askConfirmation(question) {
@@ -126,8 +143,8 @@ async function migrate() {
       [adminUsername, 'admin@gap.local', passwordHash]
     );
 
-    // Insert sample groups
-    await client.query(sampleGroupsSQL);
+    // Insert sample subject/assignment/groups hierarchy
+    await client.query(sampleHierarchySQL);
 
     // Run pending incremental migrations
     await runMigrations(client);

--- a/backend/src/db/migrations/013_subject_assignment_hierarchy.sql
+++ b/backend/src/db/migrations/013_subject_assignment_hierarchy.sql
@@ -1,0 +1,117 @@
+-- 013: Subject → Assignment → Group hierarchy.
+--
+-- *** DESTRUCTIVE ON LEGACY DATABASES ***
+-- Databases created before this migration have a flat `groups` table and a
+-- `users.group_id` column. Per the approved clean-reset strategy this
+-- migration DROPS the legacy groups table (and all group memberships) and
+-- removes users.group_id. User accounts are preserved. On databases created
+-- from the current base schema this migration is a no-op apart from
+-- re-attaching updated_at triggers.
+
+-- Drop the legacy flat groups table (detected by the absence of assignment_id).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = current_schema() AND table_name = 'groups'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'groups' AND column_name = 'assignment_id'
+  ) THEN
+    DROP TABLE groups CASCADE;
+  END IF;
+END $$;
+
+ALTER TABLE users DROP COLUMN IF EXISTS group_id;
+DROP INDEX IF EXISTS idx_users_group_id;
+
+-- Hierarchy tables (no-ops when created by the base schema)
+CREATE TABLE IF NOT EXISTS subjects (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(100) UNIQUE NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (subject_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS groups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id UUID NOT NULL REFERENCES assignments(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  enabled BOOLEAN DEFAULT true,
+  max_members INTEGER DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (assignment_id, name),
+  UNIQUE (id, assignment_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_subjects (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, subject_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_groups (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  assignment_id UUID NOT NULL,
+  group_id UUID NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, assignment_id),
+  FOREIGN KEY (group_id, assignment_id)
+    REFERENCES groups(id, assignment_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS assignment_managers (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  assignment_id UUID NOT NULL REFERENCES assignments(id) ON DELETE CASCADE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, assignment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_assignments_subject_id ON assignments(subject_id);
+CREATE INDEX IF NOT EXISTS idx_groups_assignment_id ON groups(assignment_id);
+CREATE INDEX IF NOT EXISTS idx_groups_enabled ON groups(enabled);
+CREATE INDEX IF NOT EXISTS idx_user_subjects_subject_id ON user_subjects(subject_id);
+CREATE INDEX IF NOT EXISTS idx_user_groups_group_id ON user_groups(group_id);
+CREATE INDEX IF NOT EXISTS idx_user_groups_assignment_id ON user_groups(assignment_id);
+CREATE INDEX IF NOT EXISTS idx_assignment_managers_assignment_id ON assignment_managers(assignment_id);
+
+-- Re-attach updated_at triggers. Migration 008 created the function and the
+-- groups trigger, but on legacy databases that trigger died with the dropped
+-- table; recreate defensively for all hierarchy tables.
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_subjects_updated_at ON subjects;
+CREATE TRIGGER update_subjects_updated_at
+    BEFORE UPDATE ON subjects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_assignments_updated_at ON assignments;
+CREATE TRIGGER update_assignments_updated_at
+    BEFORE UPDATE ON assignments
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_groups_updated_at ON groups;
+CREATE TRIGGER update_groups_updated_at
+    BEFORE UPDATE ON groups
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/backend/src/db/migrations/014_user_subjects_enabled.sql
+++ b/backend/src/db/migrations/014_user_subjects_enabled.sql
@@ -1,0 +1,8 @@
+-- 014: Per-subject membership enablement.
+--
+-- Adds a reversible per-subject suspension flag to user_subjects. Suspending
+-- a member (enabled = false) also deletes their user_groups rows within the
+-- subject's assignments — that cleanup is application-enforced in
+-- Subject.setMemberEnabled, mirroring Subject.removeUser. Non-destructive to
+-- existing data: all current memberships default to enabled.
+ALTER TABLE user_subjects ADD COLUMN IF NOT EXISTS enabled BOOLEAN DEFAULT true;

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -75,10 +75,13 @@ CREATE TABLE IF NOT EXISTS users (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- User ↔ Subject membership (m2m)
+-- User ↔ Subject membership (m2m). "enabled" is the per-subject suspension
+-- flag: suspended members keep their roster row but lose subject access and
+-- group memberships (cleanup enforced in Subject.setMemberEnabled).
 CREATE TABLE IF NOT EXISTS user_subjects (
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  enabled BOOLEAN DEFAULT true,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (user_id, subject_id)
 );

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -4,6 +4,15 @@
  * Base schema DDL — side-effect-free, no imports.
  * Imported by both migrate.js (production runner) and the integration test
  * globalSetup so there is a single source of truth for the base schema.
+ *
+ * Hierarchy: subjects → assignments → groups.
+ * Users enrol in subjects (user_subjects m2m); group membership is per
+ * assignment (user_groups) with at most one group per (user, assignment).
+ * Assignment managers are scoped via assignment_managers m2m.
+ *
+ * NOTE: "a user may only be placed in a group of a subject they belong to"
+ * is enforced in the application layer (UserGroup.assignUserToGroup
+ * transaction), not by the database.
  */
 const createSQL = `
 -- Create roles table
@@ -18,17 +27,40 @@ CREATE TABLE IF NOT EXISTS roles (
 INSERT INTO roles (name) VALUES ('admin'), ('assignment_manager'), ('user')
 ON CONFLICT (name) DO NOTHING;
 
--- Create groups table
-CREATE TABLE IF NOT EXISTS groups (
+-- Create subjects table (top of the hierarchy)
+CREATE TABLE IF NOT EXISTS subjects (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   name VARCHAR(100) UNIQUE NOT NULL,
-  enabled BOOLEAN DEFAULT true,
-  max_members INTEGER DEFAULT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- Create users table
+-- Create assignments table (belongs to a subject; name unique per subject)
+CREATE TABLE IF NOT EXISTS assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (subject_id, name)
+);
+
+-- Create groups table (belongs to an assignment; name unique per assignment).
+-- UNIQUE (id, assignment_id) exists solely as the composite FK target that
+-- lets user_groups guarantee its group belongs to its assignment.
+CREATE TABLE IF NOT EXISTS groups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  assignment_id UUID NOT NULL REFERENCES assignments(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  enabled BOOLEAN DEFAULT true,
+  max_members INTEGER DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (assignment_id, name),
+  UNIQUE (id, assignment_id)
+);
+
+-- Create users table (no group_id — membership lives in user_groups)
 CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   username VARCHAR(100) UNIQUE NOT NULL,
@@ -37,19 +69,63 @@ CREATE TABLE IF NOT EXISTS users (
   first_name VARCHAR(100),
   last_name VARCHAR(100),
   student_id VARCHAR(50) UNIQUE,
-  group_id UUID REFERENCES groups(id) ON DELETE SET NULL,
   role_id UUID REFERENCES roles(id) ON DELETE RESTRICT,
   enabled BOOLEAN DEFAULT true,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- User ↔ Subject membership (m2m)
+CREATE TABLE IF NOT EXISTS user_subjects (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, subject_id)
+);
+
+-- Per-assignment group membership: at most ONE group per (user, assignment);
+-- composite FK pins the group to the same assignment.
+-- Guarded: on a legacy database the pre-hierarchy groups table (no
+-- assignment_id) still exists at this point, so the composite FK target is
+-- missing; migration 013 drops the legacy table and creates user_groups.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'groups' AND column_name = 'assignment_id'
+  ) THEN
+    CREATE TABLE IF NOT EXISTS user_groups (
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      assignment_id UUID NOT NULL,
+      group_id UUID NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (user_id, assignment_id),
+      FOREIGN KEY (group_id, assignment_id)
+        REFERENCES groups(id, assignment_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_groups_assignment_id ON groups(assignment_id);
+    CREATE INDEX IF NOT EXISTS idx_user_groups_group_id ON user_groups(group_id);
+    CREATE INDEX IF NOT EXISTS idx_user_groups_assignment_id ON user_groups(assignment_id);
+  END IF;
+END $$;
+
+-- Assignment-manager scoping (m2m)
+CREATE TABLE IF NOT EXISTS assignment_managers (
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  assignment_id UUID NOT NULL REFERENCES assignments(id) ON DELETE CASCADE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (user_id, assignment_id)
+);
+
 -- Create indexes for performance
-CREATE INDEX IF NOT EXISTS idx_users_group_id ON users(group_id);
 CREATE INDEX IF NOT EXISTS idx_users_role_id ON users(role_id);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_assignments_subject_id ON assignments(subject_id);
 CREATE INDEX IF NOT EXISTS idx_groups_enabled ON groups(enabled);
+CREATE INDEX IF NOT EXISTS idx_user_subjects_subject_id ON user_subjects(subject_id);
+CREATE INDEX IF NOT EXISTS idx_assignment_managers_assignment_id ON assignment_managers(assignment_id);
 
 -- Create schema_migrations table to track incremental migrations
 CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/backend/src/middleware/rbac.js
+++ b/backend/src/middleware/rbac.js
@@ -1,4 +1,5 @@
 const fp = require('fastify-plugin');
+const Assignment = require('../models/Assignment');
 
 async function rbacPlugin(fastify, _options) {
   // Decorate fastify with RBAC helpers
@@ -26,6 +27,26 @@ async function rbacPlugin(fastify, _options) {
   // Helper to check if user is assignment_manager or admin
   fastify.decorate('requireAssignmentManager', async (request, reply) => {
     return fastify.checkRole(request, reply, ['assignment_manager', 'admin']);
+  });
+
+  // Scoped check: admin always passes; an assignment_manager passes only for
+  // assignments they manage (assignment_managers table). Everyone else is 403.
+  fastify.decorate('assertManagesAssignment', async (request, reply, assignmentId) => {
+    if (!request.user) {
+      reply.code(401).send({ error: 'Unauthorized' });
+      return false;
+    }
+
+    if (request.user.role === 'admin') {
+      return true;
+    }
+
+    if (request.user.role === 'assignment_manager' && (await Assignment.isManager(request.user.id, assignmentId))) {
+      return true;
+    }
+
+    reply.code(403).send({ error: 'Forbidden: You do not manage this assignment' });
+    return false;
   });
 }
 

--- a/backend/src/models/Assignment.js
+++ b/backend/src/models/Assignment.js
@@ -1,0 +1,207 @@
+const pool = require('../db/pool');
+
+class Assignment {
+  static async findAll(filters = {}) {
+    const conditions = [];
+    const values = [];
+    let idx = 1;
+
+    if (filters.subjectId) {
+      conditions.push(`a.subject_id = $${idx++}`);
+      values.push(filters.subjectId);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const result = await pool.query(
+      `SELECT a.*, s.name AS subject_name,
+              (SELECT COUNT(*) FROM groups WHERE assignment_id = a.id)::int AS group_count
+       FROM assignments a
+       JOIN subjects s ON s.id = a.subject_id
+       ${where}
+       ORDER BY s.name, a.name`,
+      values
+    );
+    return result.rows;
+  }
+
+  static async findById(id) {
+    const result = await pool.query(
+      `SELECT a.*, s.name AS subject_name,
+              (SELECT COUNT(*) FROM groups WHERE assignment_id = a.id)::int AS group_count
+       FROM assignments a
+       JOIN subjects s ON s.id = a.subject_id
+       WHERE a.id = $1`,
+      [id]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async findByName(subjectId, name) {
+    const result = await pool.query('SELECT * FROM assignments WHERE subject_id = $1 AND LOWER(name) = LOWER($2)', [
+      subjectId,
+      name,
+    ]);
+    return result.rows[0] || null;
+  }
+
+  static async create(subjectId, name) {
+    const result = await pool.query('INSERT INTO assignments (subject_id, name) VALUES ($1, $2) RETURNING *', [
+      subjectId,
+      name,
+    ]);
+    return result.rows[0];
+  }
+
+  static async update(id, updates) {
+    const fieldMap = {
+      name: 'name',
+    };
+
+    const setClauses = [];
+    const values = [];
+    let paramIndex = 1;
+
+    for (const [jsKey, dbCol] of Object.entries(fieldMap)) {
+      // eslint-disable-next-line security/detect-object-injection
+      if (updates[jsKey] !== undefined) {
+        setClauses.push(`${dbCol} = $${paramIndex}`);
+        // eslint-disable-next-line security/detect-object-injection
+        values.push(updates[jsKey]);
+        paramIndex++;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      return this.findById(id);
+    }
+
+    setClauses.push('updated_at = CURRENT_TIMESTAMP');
+    values.push(id);
+
+    const result = await pool.query(
+      `UPDATE assignments SET ${setClauses.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
+      values
+    );
+    return result.rows[0];
+  }
+
+  static async delete(id) {
+    const result = await pool.query('DELETE FROM assignments WHERE id = $1 RETURNING *', [id]);
+    return result.rows[0];
+  }
+
+  /** Assignments in the user's subjects (derived participation). */
+  static async findForUser(userId) {
+    const result = await pool.query(
+      `SELECT a.*, s.name AS subject_name
+       FROM assignments a
+       JOIN subjects s ON s.id = a.subject_id
+       JOIN user_subjects us ON us.subject_id = a.subject_id
+       WHERE us.user_id = $1
+       ORDER BY s.name, a.name`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  /** Assignments the user manages. */
+  static async findManagedBy(userId) {
+    const result = await pool.query(
+      `SELECT a.*, s.name AS subject_name
+       FROM assignments a
+       JOIN subjects s ON s.id = a.subject_id
+       JOIN assignment_managers am ON am.assignment_id = a.id
+       WHERE am.user_id = $1
+       ORDER BY s.name, a.name`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  static async isManager(userId, assignmentId) {
+    const result = await pool.query('SELECT 1 FROM assignment_managers WHERE user_id = $1 AND assignment_id = $2', [
+      userId,
+      assignmentId,
+    ]);
+    return result.rows.length > 0;
+  }
+
+  static async getManagers(assignmentId) {
+    const result = await pool.query(
+      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.enabled, u.status
+       FROM users u
+       JOIN assignment_managers am ON am.user_id = u.id
+       WHERE am.assignment_id = $1
+       ORDER BY u.username`,
+      [assignmentId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Replace the full manager set for an assignment in a single transaction.
+   *
+   * @param {string} assignmentId
+   * @param {string[]} userIds Empty array clears all managers.
+   */
+  static async setManagers(assignmentId, userIds) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      await client.query('DELETE FROM assignment_managers WHERE assignment_id = $1', [assignmentId]);
+
+      if (userIds && userIds.length > 0) {
+        await client.query(
+          `INSERT INTO assignment_managers (assignment_id, user_id)
+           SELECT $1, unnest($2::uuid[])
+           ON CONFLICT (user_id, assignment_id) DO NOTHING`,
+          [assignmentId, userIds]
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Add one user as manager of multiple assignments; existing rows are skipped.
+   *
+   * @param {string} userId
+   * @param {string[]} assignmentIds
+   * @returns {Promise<number>} Number of manager rows actually inserted.
+   */
+  static async addManagers(userId, assignmentIds) {
+    if (!assignmentIds || assignmentIds.length === 0) {
+      return 0;
+    }
+    const result = await pool.query(
+      `INSERT INTO assignment_managers (user_id, assignment_id)
+       SELECT $1, unnest($2::uuid[])
+       ON CONFLICT (user_id, assignment_id) DO NOTHING`,
+      [userId, assignmentIds]
+    );
+    return result.rowCount;
+  }
+
+  /** Whether the user manages at least one assignment within the subject. */
+  static async managesAnyInSubject(userId, subjectId) {
+    const result = await pool.query(
+      `SELECT 1
+       FROM assignment_managers am
+       JOIN assignments a ON a.id = am.assignment_id
+       WHERE am.user_id = $1 AND a.subject_id = $2
+       LIMIT 1`,
+      [userId, subjectId]
+    );
+    return result.rows.length > 0;
+  }
+}
+
+module.exports = Assignment;

--- a/backend/src/models/Assignment.js
+++ b/backend/src/models/Assignment.js
@@ -91,13 +91,13 @@ class Assignment {
     return result.rows[0];
   }
 
-  /** Assignments in the user's subjects (derived participation). */
+  /** Assignments in the user's subjects (derived participation, enabled memberships only). */
   static async findForUser(userId) {
     const result = await pool.query(
       `SELECT a.*, s.name AS subject_name
        FROM assignments a
        JOIN subjects s ON s.id = a.subject_id
-       JOIN user_subjects us ON us.subject_id = a.subject_id
+       JOIN user_subjects us ON us.subject_id = a.subject_id AND us.enabled = true
        WHERE us.user_id = $1
        ORDER BY s.name, a.name`,
       [userId]

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -1,37 +1,46 @@
 const pool = require('../db/pool');
 
+const MEMBER_COUNT_SUBQUERY = '(SELECT COUNT(*) FROM user_groups WHERE group_id = g.id)::int';
+
 class Group {
-  static async findAll() {
+  static async findAllByAssignment(assignmentId, { enabledOnly = false } = {}) {
+    const enabledClause = enabledOnly ? 'AND g.enabled = true' : '';
     const result = await pool.query(
-      `SELECT g.*, (SELECT COUNT(*) FROM users WHERE group_id = g.id)::int as member_count
-       FROM groups g ORDER BY g.name`
+      `SELECT g.*, ${MEMBER_COUNT_SUBQUERY} as member_count
+       FROM groups g
+       WHERE g.assignment_id = $1 ${enabledClause}
+       ORDER BY g.name`,
+      [assignmentId]
     );
     return result.rows;
   }
 
   static async findById(id) {
     const result = await pool.query(
-      `SELECT g.*, (SELECT COUNT(*) FROM users WHERE group_id = g.id)::int as member_count
-       FROM groups g WHERE g.id = $1`,
+      `SELECT g.*, a.name AS assignment_name, a.subject_id, s.name AS subject_name,
+              ${MEMBER_COUNT_SUBQUERY} as member_count
+       FROM groups g
+       JOIN assignments a ON a.id = g.assignment_id
+       JOIN subjects s ON s.id = a.subject_id
+       WHERE g.id = $1`,
       [id]
     );
-    return result.rows[0];
+    return result.rows[0] || null;
   }
 
-  static async findEnabled() {
-    const result = await pool.query(
-      `SELECT g.*, (SELECT COUNT(*) FROM users WHERE group_id = g.id)::int as member_count
-       FROM groups g WHERE g.enabled = true ORDER BY g.name`
-    );
+  static async findByIds(ids) {
+    if (!ids || ids.length === 0) {
+      return [];
+    }
+    const result = await pool.query('SELECT id, assignment_id, name FROM groups WHERE id = ANY($1)', [ids]);
     return result.rows;
   }
 
-  static async create(name, enabled = true, maxMembers = null) {
-    const result = await pool.query('INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *', [
-      name,
-      enabled,
-      maxMembers,
-    ]);
+  static async create(assignmentId, name, enabled = true, maxMembers = null) {
+    const result = await pool.query(
+      'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+      [assignmentId, name, enabled, maxMembers]
+    );
     return result.rows[0];
   }
 
@@ -76,64 +85,19 @@ class Group {
   }
 
   static async getMemberCount(groupId) {
-    const result = await pool.query('SELECT COUNT(*)::int as count FROM users WHERE group_id = $1', [groupId]);
+    const result = await pool.query('SELECT COUNT(*)::int as count FROM user_groups WHERE group_id = $1', [groupId]);
     return result.rows[0].count;
   }
 
   /**
-   * Atomically assign a user to a group, checking capacity under a row-level lock.
-   * Throws an error with a `statusCode` property on failure so the caller can respond appropriately.
-   */
-  static async assignUserToGroup(userId, groupId) {
-    const client = await pool.connect();
-    try {
-      await client.query('BEGIN');
-
-      // Lock the group row and get current capacity info atomically
-      const groupResult = await client.query(
-        `SELECT g.*,
-           (SELECT COUNT(*)::int FROM users WHERE group_id = g.id AND enabled = true) AS member_count
-         FROM groups g
-         WHERE g.id = $1
-         FOR UPDATE`,
-        [groupId]
-      );
-
-      const group = groupResult.rows[0];
-      if (!group) {
-        const err = new Error('Group not found');
-        err.statusCode = 404;
-        throw err;
-      }
-
-      if (group.max_members !== null && group.member_count >= group.max_members) {
-        const err = new Error('Group is full');
-        err.statusCode = 409;
-        throw err;
-      }
-
-      await client.query('UPDATE users SET group_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2', [
-        groupId,
-        userId,
-      ]);
-
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    } finally {
-      client.release();
-    }
-  }
-
-  /**
-   * Insert multiple groups in a single transaction.
+   * Insert multiple groups for an assignment in a single transaction.
    * Rolls back and re-throws on any error, including unique-constraint violations.
    *
+   * @param {string} assignmentId
    * @param {Array<{name: string, enabled: boolean, maxMembers: number|null}>} groups
    * @returns {Promise<Array>} The inserted rows.
    */
-  static async bulkCreate(groups) {
+  static async bulkCreate(assignmentId, groups) {
     const client = await pool.connect();
     try {
       await client.query('BEGIN');
@@ -141,8 +105,8 @@ class Group {
       const created = [];
       for (const { name, enabled, maxMembers } of groups) {
         const result = await client.query(
-          'INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *',
-          [name, enabled, maxMembers]
+          'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+          [assignmentId, name, enabled, maxMembers]
         );
         created.push(result.rows[0]);
       }
@@ -168,42 +132,23 @@ class Group {
     return result.rowCount;
   }
 
-  static async findByName(name) {
-    const result = await pool.query('SELECT * FROM groups WHERE LOWER(name) = LOWER($1)', [name]);
+  static async findByName(assignmentId, name) {
+    const result = await pool.query('SELECT * FROM groups WHERE assignment_id = $1 AND LOWER(name) = LOWER($2)', [
+      assignmentId,
+      name,
+    ]);
     return result.rows[0] || null;
   }
 
-  static async findByNames(names) {
+  static async findByNames(assignmentId, names) {
     if (!names || names.length === 0) {
       return [];
     }
     const lower = names.map((n) => n.toLowerCase());
-    const result = await pool.query('SELECT * FROM groups WHERE LOWER(name) = ANY($1)', [lower]);
-    return result.rows;
-  }
-
-  static async getExportMappings() {
-    const result = await pool.query(
-      `SELECT u.email, g.name AS group_name
-       FROM users u
-       JOIN groups g ON u.group_id = g.id
-       JOIN roles r ON u.role_id = r.id
-       WHERE r.name = 'user' AND u.group_id IS NOT NULL
-       ORDER BY g.name, u.email`
-    );
-    return result.rows;
-  }
-
-  static async getMembers(groupId) {
-    const result = await pool.query(
-      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
-              u.enabled, u.created_at, r.name as role_name
-       FROM users u
-       JOIN roles r ON u.role_id = r.id
-       WHERE u.group_id = $1
-       ORDER BY u.username`,
-      [groupId]
-    );
+    const result = await pool.query('SELECT * FROM groups WHERE assignment_id = $1 AND LOWER(name) = ANY($2::text[])', [
+      assignmentId,
+      lower,
+    ]);
     return result.rows;
   }
 }

--- a/backend/src/models/Subject.js
+++ b/backend/src/models/Subject.js
@@ -70,26 +70,36 @@ class Subject {
     return result.rows[0];
   }
 
-  /** Subjects the user is enrolled in. */
-  static async findForUser(userId) {
+  /**
+   * Subjects the user is enrolled in. By default only enabled (non-suspended)
+   * memberships are returned; includeDisabled returns every membership, each
+   * row tagged with membership_enabled.
+   */
+  static async findForUser(userId, { includeDisabled = false } = {}) {
     const result = await pool.query(
-      `SELECT s.*
-       FROM subjects s
-       JOIN user_subjects us ON us.subject_id = s.id
-       WHERE us.user_id = $1
-       ORDER BY s.name`,
+      includeDisabled
+        ? `SELECT s.*, us.enabled AS membership_enabled
+           FROM subjects s
+           JOIN user_subjects us ON us.subject_id = s.id
+           WHERE us.user_id = $1
+           ORDER BY s.name`
+        : `SELECT s.*
+           FROM subjects s
+           JOIN user_subjects us ON us.subject_id = s.id
+           WHERE us.user_id = $1 AND us.enabled = true
+           ORDER BY s.name`,
       [userId]
     );
     return result.rows;
   }
 
-  /** Subject rows for a batch of users, each row tagged with user_id. */
+  /** Subject rows (all memberships, tagged) for a batch of users, each row tagged with user_id. */
   static async findForUsers(userIds) {
     if (!userIds || userIds.length === 0) {
       return [];
     }
     const result = await pool.query(
-      `SELECT us.user_id, s.id, s.name
+      `SELECT us.user_id, s.id, s.name, us.enabled AS membership_enabled
        FROM subjects s
        JOIN user_subjects us ON us.subject_id = s.id
        WHERE us.user_id = ANY($1)
@@ -102,7 +112,7 @@ class Subject {
   static async getMembers(subjectId) {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
-              u.enabled, u.status, r.name as role_name
+              u.enabled, u.status, r.name as role_name, us.enabled AS membership_enabled
        FROM users u
        JOIN user_subjects us ON us.user_id = u.id
        LEFT JOIN roles r ON u.role_id = r.id
@@ -167,11 +177,48 @@ class Subject {
     }
   }
 
+  /**
+   * Enable or suspend a user's membership in the subject. Suspension also
+   * removes the user's group memberships within the subject's assignments,
+   * in a single transaction (mirrors removeUser).
+   *
+   * @returns {Promise<boolean>} true if a membership row was updated.
+   */
+  static async setMemberEnabled(subjectId, userId, enabled) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      if (enabled === false) {
+        await client.query(
+          `DELETE FROM user_groups ug
+           USING assignments a
+           WHERE ug.assignment_id = a.id AND a.subject_id = $1 AND ug.user_id = $2`,
+          [subjectId, userId]
+        );
+      }
+
+      const result = await client.query(
+        'UPDATE user_subjects SET enabled = $3 WHERE subject_id = $1 AND user_id = $2',
+        [subjectId, userId, enabled]
+      );
+
+      await client.query('COMMIT');
+      return result.rowCount > 0;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Suspended memberships do not count — a suspended user is not a member. */
   static async isMember(subjectId, userId) {
-    const result = await pool.query('SELECT 1 FROM user_subjects WHERE subject_id = $1 AND user_id = $2', [
-      subjectId,
-      userId,
-    ]);
+    const result = await pool.query(
+      'SELECT 1 FROM user_subjects WHERE subject_id = $1 AND user_id = $2 AND enabled = true',
+      [subjectId, userId]
+    );
     return result.rows.length > 0;
   }
 }

--- a/backend/src/models/Subject.js
+++ b/backend/src/models/Subject.js
@@ -1,0 +1,179 @@
+const pool = require('../db/pool');
+
+class Subject {
+  static async findAll() {
+    const result = await pool.query(
+      `SELECT s.*,
+              (SELECT COUNT(*) FROM assignments WHERE subject_id = s.id)::int AS assignment_count,
+              (SELECT COUNT(*) FROM user_subjects WHERE subject_id = s.id)::int AS member_count
+       FROM subjects s ORDER BY s.name`
+    );
+    return result.rows;
+  }
+
+  static async findById(id) {
+    const result = await pool.query(
+      `SELECT s.*,
+              (SELECT COUNT(*) FROM assignments WHERE subject_id = s.id)::int AS assignment_count,
+              (SELECT COUNT(*) FROM user_subjects WHERE subject_id = s.id)::int AS member_count
+       FROM subjects s WHERE s.id = $1`,
+      [id]
+    );
+    return result.rows[0] || null;
+  }
+
+  static async findByName(name) {
+    const result = await pool.query('SELECT * FROM subjects WHERE LOWER(name) = LOWER($1)', [name]);
+    return result.rows[0] || null;
+  }
+
+  static async create(name) {
+    const result = await pool.query('INSERT INTO subjects (name) VALUES ($1) RETURNING *', [name]);
+    return result.rows[0];
+  }
+
+  static async update(id, updates) {
+    const fieldMap = {
+      name: 'name',
+    };
+
+    const setClauses = [];
+    const values = [];
+    let paramIndex = 1;
+
+    for (const [jsKey, dbCol] of Object.entries(fieldMap)) {
+      // eslint-disable-next-line security/detect-object-injection
+      if (updates[jsKey] !== undefined) {
+        setClauses.push(`${dbCol} = $${paramIndex}`);
+        // eslint-disable-next-line security/detect-object-injection
+        values.push(updates[jsKey]);
+        paramIndex++;
+      }
+    }
+
+    if (setClauses.length === 0) {
+      return this.findById(id);
+    }
+
+    setClauses.push('updated_at = CURRENT_TIMESTAMP');
+    values.push(id);
+
+    const result = await pool.query(
+      `UPDATE subjects SET ${setClauses.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
+      values
+    );
+    return result.rows[0];
+  }
+
+  static async delete(id) {
+    const result = await pool.query('DELETE FROM subjects WHERE id = $1 RETURNING *', [id]);
+    return result.rows[0];
+  }
+
+  /** Subjects the user is enrolled in. */
+  static async findForUser(userId) {
+    const result = await pool.query(
+      `SELECT s.*
+       FROM subjects s
+       JOIN user_subjects us ON us.subject_id = s.id
+       WHERE us.user_id = $1
+       ORDER BY s.name`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  /** Subject rows for a batch of users, each row tagged with user_id. */
+  static async findForUsers(userIds) {
+    if (!userIds || userIds.length === 0) {
+      return [];
+    }
+    const result = await pool.query(
+      `SELECT us.user_id, s.id, s.name
+       FROM subjects s
+       JOIN user_subjects us ON us.subject_id = s.id
+       WHERE us.user_id = ANY($1)
+       ORDER BY s.name`,
+      [userIds]
+    );
+    return result.rows;
+  }
+
+  static async getMembers(subjectId) {
+    const result = await pool.query(
+      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
+              u.enabled, u.status, r.name as role_name
+       FROM users u
+       JOIN user_subjects us ON us.user_id = u.id
+       LEFT JOIN roles r ON u.role_id = r.id
+       WHERE us.subject_id = $1
+       ORDER BY u.username`,
+      [subjectId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Enrol multiple users in the subject; already-enrolled users are skipped.
+   *
+   * @param {string} subjectId
+   * @param {string[]} userIds
+   * @returns {Promise<number>} Number of memberships actually inserted.
+   */
+  static async addUsers(subjectId, userIds) {
+    if (!userIds || userIds.length === 0) {
+      return 0;
+    }
+    const result = await pool.query(
+      `INSERT INTO user_subjects (subject_id, user_id)
+       SELECT $1, unnest($2::uuid[])
+       ON CONFLICT (user_id, subject_id) DO NOTHING`,
+      [subjectId, userIds]
+    );
+    return result.rowCount;
+  }
+
+  /**
+   * Remove a user from the subject AND from any group memberships within the
+   * subject's assignments, in a single transaction (prevents orphaned
+   * user_groups rows for a subject the user no longer belongs to).
+   *
+   * @returns {Promise<boolean>} true if a subject membership was removed.
+   */
+  static async removeUser(subjectId, userId) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      await client.query(
+        `DELETE FROM user_groups ug
+         USING assignments a
+         WHERE ug.assignment_id = a.id AND a.subject_id = $1 AND ug.user_id = $2`,
+        [subjectId, userId]
+      );
+
+      const result = await client.query('DELETE FROM user_subjects WHERE subject_id = $1 AND user_id = $2', [
+        subjectId,
+        userId,
+      ]);
+
+      await client.query('COMMIT');
+      return result.rowCount > 0;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async isMember(subjectId, userId) {
+    const result = await pool.query('SELECT 1 FROM user_subjects WHERE subject_id = $1 AND user_id = $2', [
+      subjectId,
+      userId,
+    ]);
+    return result.rows.length > 0;
+  }
+}
+
+module.exports = Subject;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -25,11 +25,36 @@ class User {
       conditions.push(`u.status = $${idx++}`);
       values.push(filters.status);
     }
-    if (filters.groupId === 'none') {
-      conditions.push('u.group_id IS NULL');
-    } else if (filters.groupId) {
-      conditions.push(`u.group_id = $${idx++}`);
+    if (filters.subjectId) {
+      conditions.push(`EXISTS (SELECT 1 FROM user_subjects us WHERE us.user_id = u.id AND us.subject_id = $${idx++})`);
+      values.push(filters.subjectId);
+    }
+    if (filters.assignmentId && filters.groupId === 'none') {
+      // Enrolled in the assignment's subject but not in any group for that assignment
+      conditions.push(
+        `EXISTS (SELECT 1 FROM user_subjects us
+                 JOIN assignments a ON a.subject_id = us.subject_id
+                 WHERE us.user_id = u.id AND a.id = $${idx++})`
+      );
+      values.push(filters.assignmentId);
+      conditions.push(
+        `NOT EXISTS (SELECT 1 FROM user_groups ug WHERE ug.user_id = u.id AND ug.assignment_id = $${idx++})`
+      );
+      values.push(filters.assignmentId);
+    } else if (filters.groupId && filters.groupId !== 'none') {
+      conditions.push(`EXISTS (SELECT 1 FROM user_groups ug WHERE ug.user_id = u.id AND ug.group_id = $${idx++})`);
       values.push(filters.groupId);
+    }
+    if (filters.managedBy) {
+      // Assignment-manager scoping: users enrolled in subjects containing
+      // assignments managed by this user
+      conditions.push(
+        `EXISTS (SELECT 1 FROM user_subjects us
+                 JOIN assignments a ON a.subject_id = us.subject_id
+                 JOIN assignment_managers am ON am.assignment_id = a.id
+                 WHERE us.user_id = u.id AND am.user_id = $${idx++})`
+      );
+      values.push(filters.managedBy);
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -37,10 +62,8 @@ class User {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
               u.enabled, u.status, u.created_at,
-              u.group_id, g.name as group_name,
               u.role_id, r.name as role_name
        FROM users u
-       LEFT JOIN groups g ON u.group_id = g.id
        LEFT JOIN roles r ON u.role_id = r.id
        ${where}
        ORDER BY u.username`,
@@ -56,10 +79,8 @@ class User {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
               u.enabled, u.status, u.created_at,
-              u.group_id, g.name as group_name,
               u.role_id, r.name as role_name
        FROM users u
-       LEFT JOIN groups g ON u.group_id = g.id
        LEFT JOIN roles r ON u.role_id = r.id
        WHERE u.id = ANY($1)`,
       [ids]
@@ -71,10 +92,8 @@ class User {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
               u.enabled, u.status, u.created_at,
-              u.group_id, g.name as group_name,
               u.role_id, r.name as role_name
        FROM users u
-       LEFT JOIN groups g ON u.group_id = g.id
        LEFT JOIN roles r ON u.role_id = r.id
        WHERE u.id = $1`,
       [id]
@@ -86,10 +105,8 @@ class User {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.password_hash, u.first_name, u.last_name,
               u.student_id, u.enabled, u.status,
-              u.group_id, g.name as group_name,
               u.role_id, r.name as role_name
        FROM users u
-       LEFT JOIN groups g ON u.group_id = g.id
        LEFT JOIN roles r ON u.role_id = r.id
        WHERE LOWER(u.username) = LOWER($1)`,
       [username]
@@ -100,7 +117,7 @@ class User {
   static async findByEmail(email) {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
-              u.group_id, u.enabled, u.status, u.created_at, u.updated_at,
+              u.enabled, u.status, u.created_at, u.updated_at,
               u.role_id, r.name as role_name
        FROM users u
        LEFT JOIN roles r ON u.role_id = r.id
@@ -112,7 +129,7 @@ class User {
 
   static async findByStudentId(studentId) {
     const result = await pool.query(
-      `SELECT id, username, email, first_name, last_name, student_id, group_id, enabled, status, created_at, updated_at, role_id
+      `SELECT id, username, email, first_name, last_name, student_id, enabled, status, created_at, updated_at, role_id
        FROM users WHERE student_id = $1`,
       [studentId]
     );
@@ -125,7 +142,7 @@ class User {
     }
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
-              u.group_id, u.enabled, u.status, u.created_at, u.updated_at,
+              u.enabled, u.status, u.created_at, u.updated_at,
               u.role_id, r.name as role_name
        FROM users u
        LEFT JOIN roles r ON u.role_id = r.id
@@ -143,10 +160,8 @@ class User {
     const result = await pool.query(
       `SELECT u.id, u.username, u.email, u.password_hash, u.first_name, u.last_name,
               u.student_id, u.enabled, u.status,
-              u.group_id, g.name as group_name,
               u.role_id, r.name as role_name
        FROM users u
-       LEFT JOIN groups g ON u.group_id = g.id
        LEFT JOIN roles r ON u.role_id = r.id
        WHERE LOWER(u.username) = ANY($1)`,
       [lower]
@@ -159,7 +174,7 @@ class User {
       return [];
     }
     const result = await pool.query(
-      `SELECT id, username, email, first_name, last_name, student_id, group_id, enabled, status, created_at, updated_at, role_id
+      `SELECT id, username, email, first_name, last_name, student_id, enabled, status, created_at, updated_at, role_id
        FROM users WHERE student_id = ANY($1)`,
       [studentIds]
     );
@@ -167,7 +182,7 @@ class User {
   }
 
   static async create(userData) {
-    const { username, email, password, firstName, lastName, studentId, groupId, roleId } = userData;
+    const { username, email, password, firstName, lastName, studentId, roleId } = userData;
 
     // If no password provided the account starts as 'pending'; the user sets a password via email link
     let passwordHash = null;
@@ -178,20 +193,10 @@ class User {
     }
 
     const result = await pool.query(
-      `INSERT INTO users (username, email, password_hash, first_name, last_name, student_id, group_id, role_id, status)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      `INSERT INTO users (username, email, password_hash, first_name, last_name, student_id, role_id, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
        RETURNING id, username, email, first_name, last_name, student_id, enabled, status, created_at`,
-      [
-        username,
-        email,
-        passwordHash,
-        firstName || username,
-        lastName || username,
-        studentId || null,
-        groupId || null,
-        roleId,
-        status,
-      ]
+      [username, email, passwordHash, firstName || username, lastName || username, studentId || null, roleId, status]
     );
     return result.rows[0];
   }
@@ -207,7 +212,6 @@ class User {
       firstName: 'first_name',
       lastName: 'last_name',
       studentId: 'student_id',
-      groupId: 'group_id',
       roleId: 'role_id',
       enabled: 'enabled',
       status: 'status',
@@ -232,20 +236,10 @@ class User {
 
     const result = await pool.query(
       `UPDATE users SET ${setClauses.join(', ')} WHERE id = $${paramIndex}
-       RETURNING id, username, email, first_name, last_name, student_id, group_id, enabled, status, created_at, updated_at, role_id`,
+       RETURNING id, username, email, first_name, last_name, student_id, enabled, status, created_at, updated_at, role_id`,
       values
     );
     return result.rows[0] || null;
-  }
-
-  static async updateGroup(userId, groupId) {
-    const result = await pool.query(
-      `UPDATE users
-       SET group_id = $1, updated_at = CURRENT_TIMESTAMP
-       WHERE id = $2 RETURNING *`,
-      [groupId, userId]
-    );
-    return result.rows[0];
   }
 
   static async updatePassword(id, newPassword) {

--- a/backend/src/models/UserGroup.js
+++ b/backend/src/models/UserGroup.js
@@ -1,0 +1,195 @@
+const pool = require('../db/pool');
+
+/**
+ * Per-assignment group membership (user_groups table).
+ * A user has at most one group per assignment (DB primary key), and may only
+ * be placed in a group of a subject they belong to — the latter is enforced
+ * here for ALL callers, admin included.
+ */
+class UserGroup {
+  static async findMembership(userId, assignmentId) {
+    const result = await pool.query('SELECT * FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      userId,
+      assignmentId,
+    ]);
+    return result.rows[0] || null;
+  }
+
+  /** All memberships for a user, with subject/assignment/group names. */
+  static async findMembershipsForUser(userId) {
+    const result = await pool.query(
+      `SELECT ug.assignment_id, a.name AS assignment_name,
+              a.subject_id, s.name AS subject_name,
+              ug.group_id, g.name AS group_name
+       FROM user_groups ug
+       JOIN groups g ON g.id = ug.group_id
+       JOIN assignments a ON a.id = ug.assignment_id
+       JOIN subjects s ON s.id = a.subject_id
+       WHERE ug.user_id = $1
+       ORDER BY s.name, a.name`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  /** Membership rows for a batch of users, each row tagged with user_id. */
+  static async findMembershipsForUsers(userIds) {
+    if (!userIds || userIds.length === 0) {
+      return [];
+    }
+    const result = await pool.query(
+      `SELECT ug.user_id, ug.assignment_id, a.name AS assignment_name,
+              a.subject_id, s.name AS subject_name,
+              ug.group_id, g.name AS group_name
+       FROM user_groups ug
+       JOIN groups g ON g.id = ug.group_id
+       JOIN assignments a ON a.id = ug.assignment_id
+       JOIN subjects s ON s.id = a.subject_id
+       WHERE ug.user_id = ANY($1)
+       ORDER BY s.name, a.name`,
+      [userIds]
+    );
+    return result.rows;
+  }
+
+  static async getMembers(groupId) {
+    const result = await pool.query(
+      `SELECT u.id, u.username, u.email, u.first_name, u.last_name, u.student_id,
+              u.enabled, u.created_at, r.name as role_name
+       FROM users u
+       JOIN user_groups ug ON ug.user_id = u.id
+       LEFT JOIN roles r ON u.role_id = r.id
+       WHERE ug.group_id = $1
+       ORDER BY u.username`,
+      [groupId]
+    );
+    return result.rows;
+  }
+
+  static async remove(userId, assignmentId) {
+    const result = await pool.query('DELETE FROM user_groups WHERE user_id = $1 AND assignment_id = $2 RETURNING *', [
+      userId,
+      assignmentId,
+    ]);
+    return result.rows[0] || null;
+  }
+
+  /** email → group_name pairs for one assignment (CSV export). */
+  static async getExportMappings(assignmentId) {
+    const result = await pool.query(
+      `SELECT u.email, g.name AS group_name
+       FROM user_groups ug
+       JOIN users u ON u.id = ug.user_id
+       JOIN groups g ON g.id = ug.group_id
+       JOIN roles r ON u.role_id = r.id
+       WHERE ug.assignment_id = $1 AND r.name = 'user'
+       ORDER BY g.name, u.email`,
+      [assignmentId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Atomically place a user in a group, checking (under a row-level lock on
+   * the group) that the group exists, the user belongs to the parent subject,
+   * the user has no other group in the assignment (unless `replace`), and
+   * capacity allows. Throws errors with a `statusCode` property.
+   *
+   * @param {string} userId
+   * @param {string} groupId
+   * @param {{replace?: boolean}} [options] replace=true (admin/AM reassignment)
+   *   swaps an existing membership; replace=false (self-service join) rejects
+   *   with 409 if one exists.
+   */
+  static async assignUserToGroup(userId, groupId, { replace = false } = {}) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Lock the group row and get capacity + hierarchy info atomically
+      const groupResult = await client.query(
+        `SELECT g.*, a.subject_id,
+           (SELECT COUNT(*)::int FROM user_groups ug
+            JOIN users u ON u.id = ug.user_id
+            WHERE ug.group_id = g.id AND u.enabled = true) AS member_count
+         FROM groups g
+         JOIN assignments a ON a.id = g.assignment_id
+         WHERE g.id = $1
+         FOR UPDATE OF g`,
+        [groupId]
+      );
+
+      const group = groupResult.rows[0];
+      if (!group) {
+        const err = new Error('Group not found');
+        err.statusCode = 404;
+        throw err;
+      }
+
+      // Universal constraint: the target user must belong to the parent subject
+      const memberResult = await client.query('SELECT 1 FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
+        userId,
+        group.subject_id,
+      ]);
+      if (memberResult.rows.length === 0) {
+        const err = new Error('User is not a member of this subject');
+        err.statusCode = 403;
+        throw err;
+      }
+
+      const existingResult = await client.query('SELECT * FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+        userId,
+        group.assignment_id,
+      ]);
+      const existing = existingResult.rows[0];
+
+      if (existing) {
+        if (!replace) {
+          const err = new Error('User is already in a group for this assignment');
+          err.statusCode = 409;
+          throw err;
+        }
+        if (existing.group_id === groupId) {
+          await client.query('COMMIT');
+          return;
+        }
+        await client.query('DELETE FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+          userId,
+          group.assignment_id,
+        ]);
+      }
+
+      if (group.max_members !== null && group.member_count >= group.max_members) {
+        const err = new Error('Group is full');
+        err.statusCode = 409;
+        throw err;
+      }
+
+      try {
+        await client.query('INSERT INTO user_groups (user_id, group_id, assignment_id) VALUES ($1, $2, $3)', [
+          userId,
+          groupId,
+          group.assignment_id,
+        ]);
+      } catch (insertErr) {
+        // Concurrent join to a different group of the same assignment slips
+        // past the SELECT above; the (user_id, assignment_id) PK catches it.
+        if (insertErr.code === '23505') {
+          const err = new Error('User is already in a group for this assignment');
+          err.statusCode = 409;
+          throw err;
+        }
+        throw insertErr;
+      }
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+module.exports = UserGroup;

--- a/backend/src/models/UserGroup.js
+++ b/backend/src/models/UserGroup.js
@@ -126,13 +126,14 @@ class UserGroup {
         throw err;
       }
 
-      // Universal constraint: the target user must belong to the parent subject
-      const memberResult = await client.query('SELECT 1 FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
-        userId,
-        group.subject_id,
-      ]);
+      // Universal constraint: the target user must be an active (non-suspended)
+      // member of the parent subject
+      const memberResult = await client.query(
+        'SELECT 1 FROM user_subjects WHERE user_id = $1 AND subject_id = $2 AND enabled = true',
+        [userId, group.subject_id]
+      );
       if (memberResult.rows.length === 0) {
-        const err = new Error('User is not a member of this subject');
+        const err = new Error('User is not an active member of this subject');
         err.statusCode = 403;
         throw err;
       }

--- a/backend/src/routes/assignments.js
+++ b/backend/src/routes/assignments.js
@@ -1,0 +1,550 @@
+const Assignment = require('../models/Assignment');
+const Subject = require('../models/Subject');
+const Group = require('../models/Group');
+const UserGroup = require('../models/UserGroup');
+const User = require('../models/User');
+const {
+  sanitize,
+  parseBody,
+  createAssignmentSchema,
+  updateAssignmentSchema,
+  setAssignmentManagersSchema,
+  importGroupMappingRowSchema,
+  validateUUID,
+} = require('../utils/schemas');
+const { logger } = require('../utils/logger');
+
+const _parsedImportMax = parseInt(process.env.MAX_IMPORT_SIZE || '2000', 10);
+const MAX_IMPORT_MAPPINGS = Number.isNaN(_parsedImportMax) ? 2000 : _parsedImportMax;
+
+async function assignmentsRoutes(fastify, _options) {
+  // Get all assignments, scoped to the caller's role (any authenticated user)
+  fastify.get(
+    '/assignments',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { subjectId } = request.query || {};
+        if (subjectId !== undefined && !validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const rows = await Assignment.findAll({ subjectId });
+        const { role, id: userId } = request.user;
+
+        let assignments;
+        if (role === 'admin') {
+          assignments = rows;
+        } else if (role === 'assignment_manager') {
+          // Assignments they manage, union assignments of subjects they belong to
+          const [managed, ownSubjects] = await Promise.all([
+            Assignment.findManagedBy(userId),
+            Assignment.findForUser(userId),
+          ]);
+          const allowedIds = new Set([...managed.map((a) => a.id), ...ownSubjects.map((a) => a.id)]);
+          assignments = rows.filter((a) => allowedIds.has(a.id));
+        } else {
+          const own = await Assignment.findForUser(userId);
+          const allowedIds = new Set(own.map((a) => a.id));
+          assignments = rows.filter((a) => allowedIds.has(a.id));
+        }
+
+        return reply.send({ assignments });
+      } catch (error) {
+        logger.error('Get assignments error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve assignments' });
+      }
+    }
+  );
+
+  // Get assignment by ID (admin, subject member, or its manager)
+  fastify.get(
+    '/assignments/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const allowed = await canAccessAssignment(request.user, assignment);
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this assignment' });
+        }
+
+        return reply.send({ assignment });
+      } catch (error) {
+        logger.error('Get assignment error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve assignment' });
+      }
+    }
+  );
+
+  // Create assignment (admin only)
+  fastify.post(
+    '/assignments',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { data: body, error: validationError } = parseBody(createAssignmentSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const subject = await Subject.findById(body.subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const existing = await Assignment.findByName(body.subjectId, body.name);
+        if (existing) {
+          return reply.code(409).send({ error: 'An assignment with this name already exists in this subject' });
+        }
+
+        const assignment = await Assignment.create(body.subjectId, body.name);
+        return reply.code(201).send({ message: 'Assignment created successfully', assignment });
+      } catch (error) {
+        logger.error('Create assignment error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to create assignment' });
+      }
+    }
+  );
+
+  // Update assignment (admin only)
+  fastify.put(
+    '/assignments/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const { data: body, error: validationError } = parseBody(updateAssignmentSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        if (body.name !== assignment.name) {
+          const duplicate = await Assignment.findByName(assignment.subject_id, body.name);
+          if (duplicate && duplicate.id !== assignmentId) {
+            return reply.code(409).send({ error: 'An assignment with this name already exists in this subject' });
+          }
+        }
+
+        const updated = await Assignment.update(assignmentId, { name: body.name });
+        return reply.send({ message: 'Assignment updated successfully', assignment: updated });
+      } catch (error) {
+        logger.error('Update assignment error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to update assignment' });
+      }
+    }
+  );
+
+  // Delete assignment (admin only)
+  fastify.delete(
+    '/assignments/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        await Assignment.delete(assignmentId);
+        return reply.send({ message: 'Assignment deleted successfully' });
+      } catch (error) {
+        logger.error('Delete assignment error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to delete assignment' });
+      }
+    }
+  );
+
+  // Get groups of an assignment (admin, subject member, or its manager); ?enabled=true filters
+  fastify.get(
+    '/assignments/:id/groups',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const allowed = await canAccessAssignment(request.user, assignment);
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this assignment' });
+        }
+
+        const { enabled } = request.query || {};
+        const groups = await Group.findAllByAssignment(assignmentId, { enabledOnly: enabled === 'true' });
+        return reply.send({ groups });
+      } catch (error) {
+        logger.error('Get assignment groups error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve groups' });
+      }
+    }
+  );
+
+  // Get assignment managers (admin only)
+  fastify.get(
+    '/assignments/:id/managers',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const managers = await Assignment.getManagers(assignmentId);
+        return reply.send({ managers });
+      } catch (error) {
+        logger.error('Get assignment managers error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve managers' });
+      }
+    }
+  );
+
+  // Replace assignment managers (admin only)
+  fastify.put(
+    '/assignments/:id/managers',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const { data: body, error: validationError } = parseBody(setAssignmentManagersSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        if (body.userIds.length > 0) {
+          const found = await User.findByIds(body.userIds);
+          const foundById = new Map(found.map((u) => [u.id, u]));
+          if (body.userIds.some((id) => !foundById.has(id))) {
+            return reply.code(400).send({ error: 'One or more users do not exist' });
+          }
+          if (found.some((u) => u.role_name !== 'assignment_manager')) {
+            return reply.code(400).send({ error: 'All managers must have the assignment_manager role' });
+          }
+        }
+
+        await Assignment.setManagers(assignmentId, body.userIds);
+        const managers = await Assignment.getManagers(assignmentId);
+        return reply.send({ message: 'Assignment managers updated successfully', managers });
+      } catch (error) {
+        logger.error('Set assignment managers error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to update managers' });
+      }
+    }
+  );
+
+  // Export user-group mappings for one assignment (admin, or its manager)
+  fastify.get(
+    '/assignments/:id/export-mappings',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const allowed = await fastify.assertManagesAssignment(request, reply, assignmentId);
+        if (!allowed) {
+          return reply;
+        }
+
+        const rows = await UserGroup.getExportMappings(assignmentId);
+        const mappings = rows.map((r) => ({ email: r.email, groupName: r.group_name }));
+        return reply.send({ mappings });
+      } catch (error) {
+        logger.error('Export assignment mappings error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to export mappings' });
+      }
+    }
+  );
+
+  // Import user-group mappings for one assignment from CSV (admin, or its manager)
+  fastify.post(
+    '/assignments/:id/import-mappings',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const assignmentId = request.params.id;
+        if (!validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignment ID' });
+        }
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const allowed = await fastify.assertManagesAssignment(request, reply, assignmentId);
+        if (!allowed) {
+          return reply;
+        }
+
+        const { rows } = request.body || {};
+
+        if (!Array.isArray(rows) || rows.length === 0) {
+          return reply.code(400).send({ error: 'No mappings to import' });
+        }
+
+        if (rows.length > MAX_IMPORT_MAPPINGS) {
+          return reply.code(400).send({ error: `Import exceeds maximum of ${MAX_IMPORT_MAPPINGS} rows` });
+        }
+
+        let imported = 0;
+        const skipped = [];
+        const errors = [];
+
+        // First pass: parse all rows while preserving input order for deterministic output
+        const parsedRows = [];
+        for (const rawRow of rows) {
+          if (rawRow.action === 'skip') {
+            const email = typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?';
+            const groupName = typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?';
+            const rawReason = typeof rawRow.skipReason === 'string' ? rawRow.skipReason : '';
+            const reason = sanitize(rawReason).slice(0, 500) || 'Skipped';
+            parsedRows.push({ type: 'skip', email, groupName, reason });
+            continue;
+          }
+
+          const parseResult = importGroupMappingRowSchema.safeParse(rawRow);
+          if (!parseResult.success) {
+            parsedRows.push({
+              type: 'invalid',
+              email: typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?',
+              groupName: typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?',
+              error: parseResult.error.issues[0]?.message || 'Validation failed',
+            });
+            continue;
+          }
+
+          parsedRows.push({ type: 'valid', ...parseResult.data });
+        }
+
+        // Batch lookups — 2 queries regardless of import size; groups scoped to this assignment
+        const validRows = parsedRows.filter((r) => r.type === 'valid');
+        const uniqueEmails = [...new Set(validRows.map((r) => r.email))];
+        const uniqueGroupNames = [...new Set(validRows.map((r) => r.groupName))];
+
+        const [usersArr, groupsArr] = await Promise.all([
+          User.findByEmails(uniqueEmails),
+          Group.findByNames(assignmentId, uniqueGroupNames),
+        ]);
+
+        const usersByEmail = new Map(usersArr.map((u) => [u.email, u]));
+        const groupsByName = new Map();
+        for (const group of groupsArr) {
+          const normalizedName = group.name.toLowerCase();
+          const existing = groupsByName.get(normalizedName);
+          if (existing && existing.id !== group.id) {
+            return reply.code(409).send({
+              error: `Ambiguous group name: "${group.name}" matches multiple groups that differ only by case`,
+            });
+          }
+          groupsByName.set(normalizedName, group);
+        }
+
+        // Second pass: emit results in original row order
+        for (const parsed of parsedRows) {
+          if (parsed.type === 'skip') {
+            skipped.push({ email: parsed.email, groupName: parsed.groupName, reason: parsed.reason });
+            continue;
+          }
+          if (parsed.type === 'invalid') {
+            errors.push({ email: parsed.email, groupName: parsed.groupName, error: parsed.error });
+            continue;
+          }
+
+          const { email, groupName } = parsed;
+          try {
+            const user = usersByEmail.get(email);
+            if (!user) {
+              skipped.push({ email, groupName, reason: 'User not found' });
+              continue;
+            }
+
+            if (user.role_name === 'admin' || user.role_name === 'assignment_manager') {
+              skipped.push({
+                email,
+                groupName,
+                reason: 'Admins and Assignment Managers cannot be assigned to a group',
+              });
+              continue;
+            }
+
+            const group = groupsByName.get(groupName.toLowerCase());
+            if (!group) {
+              skipped.push({ email, groupName, reason: 'Group not found' });
+              continue;
+            }
+
+            await UserGroup.assignUserToGroup(user.id, group.id, { replace: true });
+            imported++;
+          } catch (rowErr) {
+            if (rowErr.statusCode === 403) {
+              skipped.push({ email, groupName, reason: 'User is not a member of this subject' });
+              continue;
+            }
+            if (rowErr.statusCode === 409) {
+              skipped.push({ email, groupName, reason: 'Group is full' });
+              continue;
+            }
+            logger.error('Import mapping row error', { err: rowErr.message, code: rowErr.code });
+            errors.push({ email, groupName, error: 'Failed to process row' });
+          }
+        }
+
+        return reply.send({ imported, skipped, errors });
+      } catch (error) {
+        logger.error('Import assignment mappings error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to import mappings' });
+      }
+    }
+  );
+}
+
+/**
+ * Shared read-scope check: admin, subject member, or (for assignment managers)
+ * manager of this assignment.
+ */
+async function canAccessAssignment(user, assignment) {
+  if (user.role === 'admin') {
+    return true;
+  }
+  if (await Subject.isMember(assignment.subject_id, user.id)) {
+    return true;
+  }
+  if (user.role === 'assignment_manager') {
+    return Assignment.isManager(user.id, assignment.id);
+  }
+  return false;
+}
+
+module.exports = assignmentsRoutes;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,5 +1,8 @@
 const User = require('../models/User');
 const Role = require('../models/Role');
+const Subject = require('../models/Subject');
+const Assignment = require('../models/Assignment');
+const UserGroup = require('../models/UserGroup');
 const PasswordResetToken = require('../models/PasswordResetToken');
 const { sendPasswordResetEmail, sendPasswordSetupEmail } = require('../services/email');
 const config = require('../config/index');
@@ -138,15 +141,19 @@ async function authRoutes(fastify, _options) {
           return reply.code(401).send({ error: 'Invalid credentials' });
         }
 
-        // Generate JWT token
+        // Generate JWT token — identity claims only, hierarchy data stays out
         const token = await fastify.generateToken({
           id: user.id,
           username: user.username,
           email: user.email,
           role: user.role_name,
-          groupId: user.group_id,
-          groupName: user.group_name,
         });
+
+        const [subjects, memberships, managedAssignments] = await Promise.all([
+          Subject.findForUser(user.id),
+          UserGroup.findMembershipsForUser(user.id),
+          user.role_name === 'assignment_manager' ? Assignment.findManagedBy(user.id) : Promise.resolve([]),
+        ]);
 
         return reply.send({
           message: 'Login successful',
@@ -158,9 +165,10 @@ async function authRoutes(fastify, _options) {
             firstName: user.first_name,
             lastName: user.last_name,
             role: user.role_name,
-            groupId: user.group_id,
-            groupName: user.group_name,
             studentId: user.student_id,
+            subjects: subjects.map((s) => ({ id: s.id, name: s.name })),
+            memberships,
+            managedAssignments,
           },
         });
       } catch (error) {
@@ -192,6 +200,12 @@ async function authRoutes(fastify, _options) {
           return reply.code(401).send({ error: 'User not found' });
         }
 
+        const [subjects, memberships, managedAssignments] = await Promise.all([
+          Subject.findForUser(freshUser.id),
+          UserGroup.findMembershipsForUser(freshUser.id),
+          freshUser.role_name === 'assignment_manager' ? Assignment.findManagedBy(freshUser.id) : Promise.resolve([]),
+        ]);
+
         return reply.send({
           user: {
             id: freshUser.id,
@@ -200,9 +214,10 @@ async function authRoutes(fastify, _options) {
             firstName: freshUser.first_name,
             lastName: freshUser.last_name,
             role: freshUser.role_name,
-            groupId: freshUser.group_id,
-            groupName: freshUser.group_name,
             studentId: freshUser.student_id,
+            subjects: subjects.map((s) => ({ id: s.id, name: s.name })),
+            memberships,
+            managedAssignments,
           },
         });
       } catch (error) {

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -1,65 +1,22 @@
 const Group = require('../models/Group');
-const User = require('../models/User');
+const UserGroup = require('../models/UserGroup');
+const Assignment = require('../models/Assignment');
+const Subject = require('../models/Subject');
 const Config = require('../models/Config');
+const User = require('../models/User');
 const {
-  sanitize,
   parseBody,
   createGroupSchema,
   updateGroupSchema,
+  bulkCreateGroupsSchema,
   validateUUID,
-  importGroupMappingRowSchema,
-  bulkCreateGroupItemSchema,
-  BULK_CREATE_MAX,
 } = require('../utils/schemas');
 const { logger } = require('../utils/logger');
 
-const _parsedImportMax = parseInt(process.env.MAX_IMPORT_SIZE || '2000', 10);
-const MAX_IMPORT_MAPPINGS = Number.isNaN(_parsedImportMax) ? 2000 : _parsedImportMax;
+const MAX_BULK_DELETE = 2000;
 
 async function groupsRoutes(fastify, _options) {
-  // Get all groups (authenticated users)
-  fastify.get(
-    '/groups',
-    {
-      preHandler: async (request, reply) => {
-        if (!request.user) {
-          return reply.code(401).send({ error: 'Unauthorized' });
-        }
-      },
-    },
-    async (request, reply) => {
-      try {
-        const groups = await Group.findAll();
-        return reply.send({ groups });
-      } catch (error) {
-        logger.error('Get groups error', { err: error.message, code: error.code });
-        return reply.code(500).send({ error: 'Failed to retrieve groups' });
-      }
-    }
-  );
-
-  // Get enabled groups only (for user assignment dropdowns)
-  fastify.get(
-    '/groups/enabled',
-    {
-      preHandler: async (request, reply) => {
-        if (!request.user) {
-          return reply.code(401).send({ error: 'Unauthorized' });
-        }
-      },
-    },
-    async (request, reply) => {
-      try {
-        const groups = await Group.findEnabled();
-        return reply.send({ groups });
-      } catch (error) {
-        logger.error('Get enabled groups error', { err: error.message, code: error.code });
-        return reply.code(500).send({ error: 'Failed to retrieve groups' });
-      }
-    }
-  );
-
-  // Get group by ID
+  // Get group by ID (admin, subject members, or managing assignment managers)
   fastify.get(
     '/groups/:id',
     {
@@ -81,8 +38,21 @@ async function groupsRoutes(fastify, _options) {
           return reply.code(404).send({ error: 'Group not found' });
         }
 
+        // Scope: admin, subject member, or assignment manager of the parent assignment
+        const user = request.user;
+        let allowed = user.role === 'admin';
+        if (!allowed) {
+          allowed = await Subject.isMember(group.subject_id, user.id);
+        }
+        if (!allowed && user.role === 'assignment_manager') {
+          allowed = await Assignment.isManager(user.id, group.assignment_id);
+        }
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this group' });
+        }
+
         // Get group members
-        const members = await Group.getMembers(groupId);
+        const members = await UserGroup.getMembers(groupId);
 
         return reply.send({
           group: {
@@ -91,6 +61,10 @@ async function groupsRoutes(fastify, _options) {
             enabled: group.enabled,
             maxMembers: group.max_members,
             memberCount: group.member_count,
+            assignmentId: group.assignment_id,
+            assignmentName: group.assignment_name,
+            subjectId: group.subject_id,
+            subjectName: group.subject_name,
             createdAt: group.created_at,
             updatedAt: group.updated_at,
           },
@@ -103,17 +77,13 @@ async function groupsRoutes(fastify, _options) {
     }
   );
 
-  // Create new group (admin only)
+  // Create new group (admin or managing assignment manager)
   fastify.post(
     '/groups',
     {
       preHandler: async (request, reply) => {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.requireAdmin(request, reply);
-        if (!allowed) {
-          return reply;
         }
       },
     },
@@ -124,15 +94,25 @@ async function groupsRoutes(fastify, _options) {
           return reply.code(400).send({ error: validationError });
         }
 
-        const { name, enabled, maxMembers } = body;
+        const { assignmentId, name, enabled, maxMembers } = body;
 
-        // Check if group name already exists
-        const existingGroup = await Group.findByName(name);
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        const allowed = await fastify.assertManagesAssignment(request, reply, assignmentId);
+        if (!allowed) {
+          return reply;
+        }
+
+        // Check if group name already exists within the assignment
+        const existingGroup = await Group.findByName(assignmentId, name);
         if (existingGroup) {
           return reply.code(409).send({ error: 'Group name already exists' });
         }
 
-        const newGroup = await Group.create(name, enabled !== false, maxMembers ?? null);
+        const newGroup = await Group.create(assignmentId, name, enabled !== false, maxMembers ?? null);
 
         return reply.code(201).send({
           message: 'Group created successfully',
@@ -141,6 +121,7 @@ async function groupsRoutes(fastify, _options) {
             name: newGroup.name,
             enabled: newGroup.enabled,
             maxMembers: newGroup.max_members,
+            assignmentId: newGroup.assignment_id,
           },
         });
       } catch (error) {
@@ -150,7 +131,7 @@ async function groupsRoutes(fastify, _options) {
     }
   );
 
-  // Bulk create groups (admin only)
+  // Bulk create groups (admin or managing assignment manager)
   fastify.post(
     '/groups/bulk',
     {
@@ -158,43 +139,32 @@ async function groupsRoutes(fastify, _options) {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
         }
-        const allowed = await fastify.requireAdmin(request, reply);
-        if (!allowed) {
-          return reply;
-        }
       },
     },
     async (request, reply) => {
       try {
-        const body = request.body;
-
-        if (!Array.isArray(body)) {
-          return reply.code(400).send({ error: 'Request body must be a non-empty array' });
+        const { data: body, error: validationError } = parseBody(bulkCreateGroupsSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
         }
 
-        if (body.length === 0) {
-          return reply.code(400).send({ error: 'Request body must be a non-empty array' });
+        const { assignmentId, groups: items } = body;
+
+        const assignment = await Assignment.findById(assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
         }
 
-        if (body.length > BULK_CREATE_MAX) {
-          return reply.code(400).send({ error: `Batch size exceeds maximum of ${BULK_CREATE_MAX} groups per request` });
+        const allowed = await fastify.assertManagesAssignment(request, reply, assignmentId);
+        if (!allowed) {
+          return reply;
         }
 
-        // Validate each item and collect parsed results
-        const parsed = [];
-        for (let i = 0; i < body.length; i++) {
-          // eslint-disable-next-line security/detect-object-injection
-          const result = bulkCreateGroupItemSchema.safeParse(body[i]);
-          if (!result.success) {
-            const msg = result.error.issues[0]?.message || 'Validation failed';
-            return reply.code(400).send({ error: `items[${i}]: ${msg}` });
-          }
-          parsed.push({
-            name: result.data.name,
-            enabled: result.data.enabled !== false,
-            maxMembers: result.data.maxMembers ?? null,
-          });
-        }
+        const parsed = items.map((item) => ({
+          name: item.name,
+          enabled: item.enabled !== false,
+          maxMembers: item.maxMembers ?? null,
+        }));
 
         // Reject duplicate names within the batch (case-insensitive)
         const lowerNames = parsed.map((g) => g.name.toLowerCase());
@@ -203,7 +173,17 @@ async function groupsRoutes(fastify, _options) {
           return reply.code(400).send({ error: 'Duplicate group names within the batch are not allowed' });
         }
 
-        const groups = await Group.bulkCreate(parsed);
+        // Reject names that already exist within the assignment, listing conflicts
+        const existing = await Group.findByNames(
+          assignmentId,
+          parsed.map((g) => g.name)
+        );
+        if (existing.length > 0) {
+          const conflictNames = existing.map((g) => g.name).join(', ');
+          return reply.code(409).send({ error: `One or more group names already exist: ${conflictNames}` });
+        }
+
+        const groups = await Group.bulkCreate(assignmentId, parsed);
 
         return reply.code(201).send({
           message: 'Groups created successfully',
@@ -219,17 +199,13 @@ async function groupsRoutes(fastify, _options) {
     }
   );
 
-  // Update group (admin only)
+  // Update group (admin or managing assignment manager)
   fastify.put(
     '/groups/:id',
     {
       preHandler: async (request, reply) => {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.requireAdmin(request, reply);
-        if (!allowed) {
-          return reply;
         }
       },
     },
@@ -239,6 +215,17 @@ async function groupsRoutes(fastify, _options) {
         if (!validateUUID(groupId)) {
           return reply.code(400).send({ error: 'Invalid ID format' });
         }
+
+        const group = await Group.findById(groupId);
+        if (!group) {
+          return reply.code(404).send({ error: 'Group not found' });
+        }
+
+        const allowed = await fastify.assertManagesAssignment(request, reply, group.assignment_id);
+        if (!allowed) {
+          return reply;
+        }
+
         const { data: body, error: validationError } = parseBody(updateGroupSchema, request.body);
         if (validationError) {
           return reply.code(400).send({ error: validationError });
@@ -246,9 +233,12 @@ async function groupsRoutes(fastify, _options) {
 
         const { name, enabled, maxMembers } = body;
 
-        const group = await Group.findById(groupId);
-        if (!group) {
-          return reply.code(404).send({ error: 'Group not found' });
+        // If renaming, check the name is not taken by a different group in the assignment
+        if (name !== undefined) {
+          const existingGroup = await Group.findByName(group.assignment_id, name);
+          if (existingGroup && existingGroup.id !== groupId) {
+            return reply.code(409).send({ error: 'Group name already exists' });
+          }
         }
 
         // Validate maxMembers if provided
@@ -280,7 +270,7 @@ async function groupsRoutes(fastify, _options) {
     }
   );
 
-  // Bulk delete groups (admin only)
+  // Bulk delete groups (admin, or assignment manager for assignments they manage)
   fastify.delete(
     '/groups/bulk',
     {
@@ -288,7 +278,7 @@ async function groupsRoutes(fastify, _options) {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
         }
-        const allowed = await fastify.requireAdmin(request, reply);
+        const allowed = await fastify.requireAssignmentManager(request, reply);
         if (!allowed) {
           return reply;
         }
@@ -298,7 +288,7 @@ async function groupsRoutes(fastify, _options) {
       try {
         const { ids } = request.body || {};
 
-        if (!Array.isArray(ids) || ids.length === 0 || ids.length > 2000) {
+        if (!Array.isArray(ids) || ids.length === 0 || ids.length > MAX_BULK_DELETE) {
           return reply.code(400).send({ error: 'ids must be a non-empty array of up to 2000 items' });
         }
 
@@ -308,6 +298,18 @@ async function groupsRoutes(fastify, _options) {
         }
 
         const uniqueIds = [...new Set(ids)];
+
+        // Assignment managers may only delete groups of assignments they manage
+        if (request.user.role !== 'admin') {
+          const groups = await Group.findByIds(uniqueIds);
+          const assignmentIds = [...new Set(groups.map((g) => g.assignment_id))];
+          for (const assignmentId of assignmentIds) {
+            if (!(await Assignment.isManager(request.user.id, assignmentId))) {
+              return reply.code(403).send({ error: 'Forbidden: You do not manage this assignment' });
+            }
+          }
+        }
+
         const deleted = await Group.bulkDelete(uniqueIds);
         return reply.send({ message: 'Groups deleted successfully', deleted });
       } catch (error) {
@@ -317,17 +319,13 @@ async function groupsRoutes(fastify, _options) {
     }
   );
 
-  // Delete group (admin only)
+  // Delete group (admin or managing assignment manager)
   fastify.delete(
     '/groups/:id',
     {
       preHandler: async (request, reply) => {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.requireAdmin(request, reply);
-        if (!allowed) {
-          return reply;
         }
       },
     },
@@ -338,11 +336,17 @@ async function groupsRoutes(fastify, _options) {
           return reply.code(400).send({ error: 'Invalid ID format' });
         }
 
-        const deletedGroup = await Group.delete(groupId);
-
-        if (!deletedGroup) {
+        const group = await Group.findById(groupId);
+        if (!group) {
           return reply.code(404).send({ error: 'Group not found' });
         }
+
+        const allowed = await fastify.assertManagesAssignment(request, reply, group.assignment_id);
+        if (!allowed) {
+          return reply;
+        }
+
+        await Group.delete(groupId);
 
         return reply.send({ message: 'Group deleted successfully' });
       } catch (error) {
@@ -381,6 +385,16 @@ async function groupsRoutes(fastify, _options) {
           }
         }
 
+        // Re-check account state against the database — a disabled user may
+        // still hold a valid JWT.
+        const caller = await User.findById(userId);
+        if (!caller) {
+          return reply.code(404).send({ error: 'User not found' });
+        }
+        if (!caller.enabled) {
+          return reply.code(403).send({ error: 'Account is disabled' });
+        }
+
         const group = await Group.findById(groupId);
         if (!group) {
           return reply.code(404).send({ error: 'Group not found' });
@@ -390,29 +404,16 @@ async function groupsRoutes(fastify, _options) {
           return reply.code(400).send({ error: 'Cannot join a disabled group' });
         }
 
-        // Check user is not already in a group
-        const user = await User.findById(userId);
-        if (!user) {
-          return reply.code(404).send({ error: 'User not found' });
-        }
-        if (!user.enabled) {
-          return reply.code(403).send({ error: 'Account is disabled' });
-        }
-        if (user.group_id) {
-          return reply.code(400).send({ error: 'You are already in a group. Leave your current group first.' });
-        }
-
-        // Optimistic capacity pre-check (fast path) — the transactional lock inside
-        // assignUserToGroup prevents race conditions for near-simultaneous requests
-        if (group.max_members !== null && group.member_count >= group.max_members) {
-          return reply.code(409).send({ error: 'Group is full' });
-        }
-
-        // Assign user to group inside a transaction with row-level lock to prevent race conditions (H2)
-        await Group.assignUserToGroup(userId, groupId);
+        // Assign user to group inside a transaction with row-level lock; the model
+        // enforces subject membership (403), one-group-per-assignment (409), and
+        // capacity (409) via errors carrying a statusCode.
+        await UserGroup.assignUserToGroup(userId, groupId, { replace: false });
 
         return reply.send({ message: 'Successfully joined group', groupId, groupName: group.name });
       } catch (error) {
+        if (error.statusCode) {
+          return reply.code(error.statusCode).send({ error: error.message });
+        }
         logger.error('Join group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to join group' });
       }
@@ -448,184 +449,33 @@ async function groupsRoutes(fastify, _options) {
           }
         }
 
+        // Re-check account state against the database — a disabled user may
+        // still hold a valid JWT.
+        const caller = await User.findById(userId);
+        if (!caller) {
+          return reply.code(404).send({ error: 'User not found' });
+        }
+        if (!caller.enabled) {
+          return reply.code(403).send({ error: 'Account is disabled' });
+        }
+
         const group = await Group.findById(groupId);
         if (!group) {
           return reply.code(404).send({ error: 'Group not found' });
         }
 
-        // Check user is actually in this group
-        const user = await User.findById(userId);
-        if (!user) {
-          return reply.code(404).send({ error: 'User not found' });
-        }
-        if (!user.enabled) {
-          return reply.code(403).send({ error: 'Account is disabled' });
-        }
-        if (user.group_id !== groupId) {
+        // Check user is actually in this group for the assignment
+        const membership = await UserGroup.findMembership(userId, group.assignment_id);
+        if (!membership || membership.group_id !== groupId) {
           return reply.code(400).send({ error: 'You are not a member of this group' });
         }
 
-        await User.updateGroup(userId, null);
+        await UserGroup.remove(userId, group.assignment_id);
 
         return reply.send({ message: 'Successfully left group' });
       } catch (error) {
         logger.error('Leave group error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to leave group' });
-      }
-    }
-  );
-  // Import user-group mappings from CSV (admin/AM only)
-  fastify.post(
-    '/groups/import-mappings',
-    {
-      preHandler: async (request, reply) => {
-        if (!request.user) {
-          return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.requireAssignmentManager(request, reply);
-        if (!allowed) {
-          return reply;
-        }
-      },
-    },
-    async (request, reply) => {
-      try {
-        const { rows } = request.body || {};
-
-        if (!Array.isArray(rows) || rows.length === 0) {
-          return reply.code(400).send({ error: 'No mappings to import' });
-        }
-
-        if (rows.length > MAX_IMPORT_MAPPINGS) {
-          return reply.code(400).send({ error: `Import exceeds maximum of ${MAX_IMPORT_MAPPINGS} rows` });
-        }
-
-        let imported = 0;
-        const skipped = [];
-        const errors = [];
-
-        // First pass: parse all rows while preserving input order for deterministic output
-        const parsedRows = [];
-        for (const rawRow of rows) {
-          if (rawRow.action === 'skip') {
-            const email = typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?';
-            const groupName = typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?';
-            const rawReason = typeof rawRow.skipReason === 'string' ? rawRow.skipReason : '';
-            const reason = sanitize(rawReason).slice(0, 500) || 'Skipped';
-            parsedRows.push({ type: 'skip', email, groupName, reason });
-            continue;
-          }
-
-          const parseResult = importGroupMappingRowSchema.safeParse(rawRow);
-          if (!parseResult.success) {
-            parsedRows.push({
-              type: 'invalid',
-              email: typeof rawRow.email === 'string' ? sanitize(rawRow.email).slice(0, 255) : '?',
-              groupName: typeof rawRow.groupName === 'string' ? sanitize(rawRow.groupName).slice(0, 100) : '?',
-              error: parseResult.error.issues[0]?.message || 'Validation failed',
-            });
-            continue;
-          }
-
-          parsedRows.push({ type: 'valid', ...parseResult.data });
-        }
-
-        // Batch lookups — 2 queries regardless of import size
-        const validRows = parsedRows.filter((r) => r.type === 'valid');
-        const uniqueEmails = [...new Set(validRows.map((r) => r.email))];
-        const uniqueGroupNames = [...new Set(validRows.map((r) => r.groupName))];
-
-        const [usersArr, groupsArr] = await Promise.all([
-          User.findByEmails(uniqueEmails),
-          Group.findByNames(uniqueGroupNames),
-        ]);
-
-        const usersByEmail = new Map(usersArr.map((u) => [u.email, u]));
-        const groupsByName = new Map();
-        for (const group of groupsArr) {
-          const normalizedName = group.name.toLowerCase();
-          const existing = groupsByName.get(normalizedName);
-          if (existing && existing.id !== group.id) {
-            return reply.code(409).send({
-              error: `Ambiguous group name: "${group.name}" matches multiple groups that differ only by case`,
-            });
-          }
-          groupsByName.set(normalizedName, group);
-        }
-
-        // Second pass: emit results in original row order
-        for (const parsed of parsedRows) {
-          if (parsed.type === 'skip') {
-            skipped.push({ email: parsed.email, groupName: parsed.groupName, reason: parsed.reason });
-            continue;
-          }
-          if (parsed.type === 'invalid') {
-            errors.push({ email: parsed.email, groupName: parsed.groupName, error: parsed.error });
-            continue;
-          }
-
-          const { email, groupName } = parsed;
-          try {
-            const user = usersByEmail.get(email);
-            if (!user) {
-              skipped.push({ email, groupName, reason: 'User not found' });
-              continue;
-            }
-
-            if (user.role_name === 'admin' || user.role_name === 'assignment_manager') {
-              skipped.push({
-                email,
-                groupName,
-                reason: 'Admins and Assignment Managers cannot be assigned to a group',
-              });
-              continue;
-            }
-
-            const group = groupsByName.get(groupName.toLowerCase());
-            if (!group) {
-              skipped.push({ email, groupName, reason: 'Group not found' });
-              continue;
-            }
-
-            await Group.assignUserToGroup(user.id, group.id);
-            imported++;
-          } catch (rowErr) {
-            const reason = rowErr.statusCode === 409 ? 'Group is full' : 'Failed to process row';
-            logger.error('Import mapping row error', { err: rowErr.message, code: rowErr.code });
-            errors.push({ email, groupName, error: reason });
-          }
-        }
-
-        return reply.send({ imported, skipped, errors });
-      } catch (error) {
-        logger.error('Import group mappings error', { err: error.message, code: error.code });
-        return reply.code(500).send({ error: 'Failed to import mappings' });
-      }
-    }
-  );
-
-  // Export user-group mappings to CSV (admin/AM only)
-  fastify.get(
-    '/groups/export-mappings',
-    {
-      preHandler: async (request, reply) => {
-        if (!request.user) {
-          return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.requireAssignmentManager(request, reply);
-        if (!allowed) {
-          return reply;
-        }
-      },
-    },
-    async (request, reply) => {
-      try {
-        const rows = await Group.getExportMappings();
-        const mappings = rows.map((r) => ({ email: r.email, groupName: r.group_name }));
-        return reply.send({ mappings });
-      } catch (error) {
-        logger.error('Export group mappings error', { err: error.message, code: error.code });
-        return reply.code(500).send({ error: 'Failed to export mappings' });
       }
     }
   );

--- a/backend/src/routes/subjects.js
+++ b/backend/src/routes/subjects.js
@@ -1,0 +1,344 @@
+const Subject = require('../models/Subject');
+const Assignment = require('../models/Assignment');
+const User = require('../models/User');
+const {
+  parseBody,
+  createSubjectSchema,
+  updateSubjectSchema,
+  addSubjectUsersSchema,
+  validateUUID,
+} = require('../utils/schemas');
+const { logger } = require('../utils/logger');
+
+async function subjectsRoutes(fastify, _options) {
+  // Get all subjects, scoped to the caller's role (any authenticated user)
+  fastify.get(
+    '/subjects',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const rows = await Subject.findAll();
+        const { role, id: userId } = request.user;
+
+        let subjects;
+        if (role === 'admin') {
+          subjects = rows;
+        } else if (role === 'assignment_manager') {
+          // Subjects containing assignments they manage, union subjects they are members of
+          const [managed, memberOf] = await Promise.all([
+            Assignment.findManagedBy(userId),
+            Subject.findForUser(userId),
+          ]);
+          const allowedIds = new Set([...managed.map((a) => a.subject_id), ...memberOf.map((s) => s.id)]);
+          subjects = rows.filter((s) => allowedIds.has(s.id));
+        } else {
+          const memberOf = await Subject.findForUser(userId);
+          const allowedIds = new Set(memberOf.map((s) => s.id));
+          subjects = rows.filter((s) => allowedIds.has(s.id));
+        }
+
+        return reply.send({ subjects });
+      } catch (error) {
+        logger.error('Get subjects error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve subjects' });
+      }
+    }
+  );
+
+  // Get subject by ID with its assignments (admin, subject member, or managing AM)
+  fastify.get(
+    '/subjects/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const { role, id: userId } = request.user;
+        let allowed = role === 'admin';
+        if (!allowed) {
+          allowed = await Subject.isMember(subjectId, userId);
+        }
+        if (!allowed && role === 'assignment_manager') {
+          allowed = await Assignment.managesAnyInSubject(userId, subjectId);
+        }
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this subject' });
+        }
+
+        const assignments = await Assignment.findAll({ subjectId });
+        return reply.send({ subject, assignments });
+      } catch (error) {
+        logger.error('Get subject error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve subject' });
+      }
+    }
+  );
+
+  // Create subject (admin only)
+  fastify.post(
+    '/subjects',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { data: body, error: validationError } = parseBody(createSubjectSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const existing = await Subject.findByName(body.name);
+        if (existing) {
+          return reply.code(409).send({ error: 'A subject with this name already exists' });
+        }
+
+        const subject = await Subject.create(body.name);
+        return reply.code(201).send({ message: 'Subject created successfully', subject });
+      } catch (error) {
+        logger.error('Create subject error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to create subject' });
+      }
+    }
+  );
+
+  // Update subject (admin only)
+  fastify.put(
+    '/subjects/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const { data: body, error: validationError } = parseBody(updateSubjectSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        if (body.name !== subject.name) {
+          const duplicate = await Subject.findByName(body.name);
+          if (duplicate && duplicate.id !== subjectId) {
+            return reply.code(409).send({ error: 'A subject with this name already exists' });
+          }
+        }
+
+        const updated = await Subject.update(subjectId, { name: body.name });
+        return reply.send({ message: 'Subject updated successfully', subject: updated });
+      } catch (error) {
+        logger.error('Update subject error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to update subject' });
+      }
+    }
+  );
+
+  // Delete subject (admin only) — DB cascades assignments/groups/memberships; users survive
+  fastify.delete(
+    '/subjects/:id',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        await Subject.delete(subjectId);
+        return reply.send({ message: 'Subject deleted successfully' });
+      } catch (error) {
+        logger.error('Delete subject error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to delete subject' });
+      }
+    }
+  );
+
+  // Get subject members (admin, or AM managing an assignment in the subject)
+  fastify.get(
+    '/subjects/:id/users',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const { role, id: userId } = request.user;
+        const allowed =
+          role === 'admin' ||
+          (role === 'assignment_manager' && (await Assignment.managesAnyInSubject(userId, subjectId)));
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this subject' });
+        }
+
+        const users = await Subject.getMembers(subjectId);
+        return reply.send({ users });
+      } catch (error) {
+        logger.error('Get subject members error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to retrieve subject members' });
+      }
+    }
+  );
+
+  // Add users to subject (admin only)
+  fastify.post(
+    '/subjects/:id/users',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+
+        const { data: body, error: validationError } = parseBody(addSubjectUsersSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const found = await User.findByIds(body.userIds);
+        const foundIds = new Set(found.map((u) => u.id));
+        if (body.userIds.some((id) => !foundIds.has(id))) {
+          return reply.code(400).send({ error: 'One or more users do not exist' });
+        }
+
+        const added = await Subject.addUsers(subjectId, body.userIds);
+        return reply.send({ message: 'Users added to subject', added });
+      } catch (error) {
+        logger.error('Add subject users error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to add users to subject' });
+      }
+    }
+  );
+
+  // Remove user from subject (admin only) — model transactionally removes the
+  // user's group memberships within the subject
+  fastify.delete(
+    '/subjects/:id/users/:userId',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+        const allowed = await fastify.requireAdmin(request, reply);
+        if (!allowed) {
+          return reply;
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        const userId = request.params.userId;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+        if (!validateUUID(userId)) {
+          return reply.code(400).send({ error: 'Invalid user ID' });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const removed = await Subject.removeUser(subjectId, userId);
+        if (!removed) {
+          return reply.code(404).send({ error: 'User is not a member of this subject' });
+        }
+
+        return reply.send({ message: 'User removed from subject' });
+      } catch (error) {
+        logger.error('Remove subject user error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to remove user from subject' });
+      }
+    }
+  );
+}
+
+module.exports = subjectsRoutes;

--- a/backend/src/routes/subjects.js
+++ b/backend/src/routes/subjects.js
@@ -1,11 +1,13 @@
 const Subject = require('../models/Subject');
 const Assignment = require('../models/Assignment');
 const User = require('../models/User');
+const UserGroup = require('../models/UserGroup');
 const {
   parseBody,
   createSubjectSchema,
   updateSubjectSchema,
   addSubjectUsersSchema,
+  setMemberEnabledSchema,
   validateUUID,
 } = require('../utils/schemas');
 const { logger } = require('../utils/logger');
@@ -242,7 +244,27 @@ async function subjectsRoutes(fastify, _options) {
         }
 
         const users = await Subject.getMembers(subjectId);
-        return reply.send({ users });
+
+        // Attach each member's group memberships WITHIN this subject so the
+        // members view can offer group unassignment.
+        let membershipRows = [];
+        if (users.length > 0) {
+          membershipRows = await UserGroup.findMembershipsForUsers(users.map((u) => u.id));
+        }
+        const membershipsByUser = new Map();
+        for (const row of membershipRows) {
+          if (row.subject_id !== subjectId) {
+            continue;
+          }
+          const { user_id: uid, ...membership } = row;
+          if (!membershipsByUser.has(uid)) {
+            membershipsByUser.set(uid, []);
+          }
+          membershipsByUser.get(uid).push(membership);
+        }
+        const enriched = users.map((u) => ({ ...u, memberships: membershipsByUser.get(u.id) || [] }));
+
+        return reply.send({ users: enriched });
       } catch (error) {
         logger.error('Get subject members error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve subject members' });
@@ -292,6 +314,63 @@ async function subjectsRoutes(fastify, _options) {
       } catch (error) {
         logger.error('Add subject users error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to add users to subject' });
+      }
+    }
+  );
+
+  // Enable or suspend a subject member (admin, or AM managing an assignment in
+  // the subject) — suspension transactionally removes the user's group
+  // memberships within the subject
+  fastify.put(
+    '/subjects/:id/users/:userId',
+    {
+      preHandler: async (request, reply) => {
+        if (!request.user) {
+          return reply.code(401).send({ error: 'Unauthorized' });
+        }
+      },
+    },
+    async (request, reply) => {
+      try {
+        const subjectId = request.params.id;
+        const userId = request.params.userId;
+        if (!validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subject ID' });
+        }
+        if (!validateUUID(userId)) {
+          return reply.code(400).send({ error: 'Invalid user ID' });
+        }
+
+        const { role, id: callerId } = request.user;
+        const allowed =
+          role === 'admin' ||
+          (role === 'assignment_manager' && (await Assignment.managesAnyInSubject(callerId, subjectId)));
+        if (!allowed) {
+          return reply.code(403).send({ error: 'Forbidden: You do not have access to this subject' });
+        }
+
+        const { data: body, error: validationError } = parseBody(setMemberEnabledSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
+        }
+
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        const updated = await Subject.setMemberEnabled(subjectId, userId, body.enabled);
+        if (!updated) {
+          return reply.code(404).send({ error: 'User is not a member of this subject' });
+        }
+
+        return reply.send({
+          message: body.enabled ? 'Member enabled' : 'Member suspended',
+          membershipEnabled: body.enabled,
+        });
+      } catch (error) {
+        logger.error('Set subject member enabled error', { err: error.message, code: error.code });
+        return reply.code(500).send({ error: 'Failed to update subject member' });
       }
     }
   );

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,6 +1,9 @@
 const User = require('../models/User');
 const Group = require('../models/Group');
 const Role = require('../models/Role');
+const Subject = require('../models/Subject');
+const Assignment = require('../models/Assignment');
+const UserGroup = require('../models/UserGroup');
 const PasswordResetToken = require('../models/PasswordResetToken');
 const { sendPasswordSetupEmail } = require('../services/email');
 const {
@@ -8,6 +11,7 @@ const {
   parseBody,
   createUserSchema,
   updateUserSchema,
+  updateUserGroupSchema,
   changePasswordSchema,
   importUserRowSchema,
   validateUUID,
@@ -22,7 +26,9 @@ const MAX_IMPORT_SIZE = Number.isNaN(_parsed) ? 2000 : _parsed;
 async function usersRoutes(fastify, _options) {
   const isDev = config.app.nodeEnv === 'development';
 
-  // Get all users (admin/assignment_manager only) — supports ?role=, ?status=, ?groupId= filters
+  // Get all users (admin/assignment_manager only) — supports ?role=, ?status=,
+  // ?subjectId=, ?assignmentId= and ?groupId= (uuid or 'none') filters.
+  // Assignment managers only see users enrolled in subjects they manage.
   fastify.get(
     '/users',
     {
@@ -38,7 +44,7 @@ async function usersRoutes(fastify, _options) {
     },
     async (request, reply) => {
       try {
-        const { role, status, groupId } = request.query || {};
+        const { role, status, subjectId, assignmentId, groupId } = request.query || {};
 
         const VALID_STATUSES = ['active', 'inactive', 'pending'];
         if (status !== undefined && !VALID_STATUSES.includes(status)) {
@@ -47,12 +53,60 @@ async function usersRoutes(fastify, _options) {
         if (role !== undefined && !ROLE_VALUES.includes(role)) {
           return reply.code(400).send({ error: 'Invalid role filter' });
         }
+        if (subjectId !== undefined && !validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Invalid subjectId filter' });
+        }
+        if (assignmentId !== undefined && !validateUUID(assignmentId)) {
+          return reply.code(400).send({ error: 'Invalid assignmentId filter' });
+        }
         if (groupId !== undefined && groupId !== 'none' && !validateUUID(groupId)) {
           return reply.code(400).send({ error: 'Invalid groupId filter' });
         }
+        if (groupId === 'none' && assignmentId === undefined) {
+          return reply.code(400).send({ error: 'assignmentId is required when filtering ungrouped users' });
+        }
 
-        const users = await User.findAll({ role, status, groupId });
-        return reply.send({ users });
+        const filters = { role, status, subjectId, assignmentId, groupId };
+        // AM scoping: assignment managers only see users in subjects they manage
+        if (request.user?.role === 'assignment_manager') {
+          filters.managedBy = request.user.id;
+        }
+
+        const users = await User.findAll(filters);
+
+        // Attach subject enrolments and group memberships in two batch queries
+        const userIds = users.map((u) => u.id);
+        let subjectRows = [];
+        let membershipRows = [];
+        if (userIds.length > 0) {
+          [subjectRows, membershipRows] = await Promise.all([
+            Subject.findForUsers(userIds),
+            UserGroup.findMembershipsForUsers(userIds),
+          ]);
+        }
+        const subjectsByUser = new Map();
+        for (const row of subjectRows) {
+          const { user_id: uid, ...subject } = row;
+          if (!subjectsByUser.has(uid)) {
+            subjectsByUser.set(uid, []);
+          }
+          subjectsByUser.get(uid).push(subject);
+        }
+        const membershipsByUser = new Map();
+        for (const row of membershipRows) {
+          const { user_id: uid, ...membership } = row;
+          if (!membershipsByUser.has(uid)) {
+            membershipsByUser.set(uid, []);
+          }
+          membershipsByUser.get(uid).push(membership);
+        }
+        const enriched = users.map((u) => ({
+          ...u,
+          subjects: subjectsByUser.get(u.id) || [],
+          memberships: membershipsByUser.get(u.id) || [],
+        }));
+
+        return reply.send({ users: enriched });
       } catch (error) {
         logger.error('Get users error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve users' });
@@ -90,9 +144,13 @@ async function usersRoutes(fastify, _options) {
           return reply.code(404).send({ error: 'User not found' });
         }
 
-        // Remove password hash from response
+        // Remove password hash from response and enrich with hierarchy data
         const { password_hash: _password_hash, ...userWithoutPassword } = user;
-        return reply.send({ user: userWithoutPassword });
+        const [subjects, memberships] = await Promise.all([
+          Subject.findForUser(userId),
+          UserGroup.findMembershipsForUser(userId),
+        ]);
+        return reply.send({ user: { ...userWithoutPassword, subjects, memberships } });
       } catch (error) {
         logger.error('Get user error', { err: error.message, code: error.code });
         return reply.code(500).send({ error: 'Failed to retrieve user' });
@@ -123,7 +181,18 @@ async function usersRoutes(fastify, _options) {
           return reply.code(400).send({ error: validationError });
         }
 
-        const { username, email, firstName, lastName, studentId, groupId, role } = body;
+        const {
+          username,
+          email,
+          firstName,
+          lastName,
+          studentId,
+          role,
+          subjectIds,
+          assignmentId,
+          groupId,
+          assignmentIds,
+        } = body;
 
         // Only admins can create admin or assignment_manager users
         if ((role === 'admin' || role === 'assignment_manager') && request.user.role !== 'admin') {
@@ -141,7 +210,7 @@ async function usersRoutes(fastify, _options) {
           return reply.code(409).send({ error: 'Email already exists' });
         }
 
-        // Get role ID by name lookup (needed before group check to know effective role)
+        // Get role ID by name lookup (needed to know the effective role)
         const effectiveRole = role || 'user';
         const roleRecord = await Role.findByName(effectiveRole);
         if (!roleRecord) {
@@ -149,10 +218,9 @@ async function usersRoutes(fastify, _options) {
         }
         const roleId = roleRecord.id;
 
-        // studentId and groupId only apply to regular users
+        // studentId and subject/group placement only apply to regular users
         const isUserRole = effectiveRole === 'user';
         const effectiveStudentId = isUserRole ? studentId : undefined;
-        const effectiveGroupId = isUserRole ? groupId : undefined;
 
         // Check studentId uniqueness
         if (effectiveStudentId) {
@@ -162,15 +230,59 @@ async function usersRoutes(fastify, _options) {
           }
         }
 
-        // If a group is specified, verify it exists and has capacity
-        if (effectiveGroupId) {
-          const group = await Group.findById(effectiveGroupId);
-          if (!group) {
-            return reply.code(404).send({ error: 'Group not found' });
+        // Regular users must be enrolled in at least one subject; optional
+        // immediate group placement requires assignmentId within those subjects.
+        if (isUserRole) {
+          if (!Array.isArray(subjectIds) || subjectIds.length === 0) {
+            return reply.code(400).send({ error: 'Subject is required' });
           }
-          if (group.max_members !== null && group.member_count >= group.max_members) {
-            return reply.code(400).send({ error: 'Group is full' });
+          for (const sid of subjectIds) {
+            const subject = await Subject.findById(sid);
+            if (!subject) {
+              return reply.code(404).send({ error: 'Subject not found' });
+            }
+            // AMs may only enrol users into subjects containing an assignment
+            // they manage (same rule as POST /users/import).
+            if (request.user?.role === 'assignment_manager') {
+              const manages = await Assignment.managesAnyInSubject(request.user.id, sid);
+              if (!manages) {
+                return reply.code(403).send({ error: 'Forbidden: You do not manage any assignment in this subject' });
+              }
+            }
           }
+          if (groupId && !assignmentId) {
+            return reply.code(400).send({ error: 'assignmentId is required when groupId is provided' });
+          }
+          if (assignmentId) {
+            const assignment = await Assignment.findById(assignmentId);
+            if (!assignment) {
+              return reply.code(404).send({ error: 'Assignment not found' });
+            }
+            if (!subjectIds.includes(assignment.subject_id)) {
+              return reply.code(400).send({ error: 'Assignment does not belong to the selected subjects' });
+            }
+          }
+          if (groupId) {
+            const group = await Group.findById(groupId);
+            if (!group) {
+              return reply.code(404).send({ error: 'Group not found' });
+            }
+            if (group.assignment_id !== assignmentId) {
+              return reply.code(400).send({ error: 'Group does not belong to the selected assignment' });
+            }
+          }
+        }
+
+        // Assignment managers may be given assignments to manage at creation time
+        let managedAssignmentIds = [];
+        if (effectiveRole === 'assignment_manager' && Array.isArray(assignmentIds) && assignmentIds.length > 0) {
+          for (const aid of assignmentIds) {
+            const assignment = await Assignment.findById(aid);
+            if (!assignment) {
+              return reply.code(404).send({ error: 'Assignment not found' });
+            }
+          }
+          managedAssignmentIds = assignmentIds;
         }
 
         // Always create user as pending — password must be set via the email link
@@ -181,9 +293,26 @@ async function usersRoutes(fastify, _options) {
           firstName,
           lastName,
           studentId: effectiveStudentId,
-          groupId: effectiveGroupId,
           roleId,
         });
+
+        let placementWarning;
+        if (isUserRole) {
+          for (const sid of subjectIds) {
+            await Subject.addUsers(sid, [newUser.id]);
+          }
+          if (groupId) {
+            try {
+              await UserGroup.assignUserToGroup(newUser.id, groupId, { replace: true });
+            } catch (placementError) {
+              // Don't fail the request — the user was created and enrolled successfully
+              logger.error('Group placement failed after user creation', { err: placementError.message });
+              placementWarning = `User created but group placement failed: ${placementError.message}`;
+            }
+          }
+        } else if (managedAssignmentIds.length > 0) {
+          await Assignment.addManagers(newUser.id, managedAssignmentIds);
+        }
 
         // Only admins can suppress the setup email; assignment managers always trigger it
         const shouldSendEmail = request.user?.role === 'admin' ? body.sendSetupEmail !== false : true;
@@ -198,7 +327,7 @@ async function usersRoutes(fastify, _options) {
           }
         }
 
-        return reply.code(201).send({
+        const response = {
           message: 'User created successfully',
           user: {
             id: newUser.id,
@@ -207,7 +336,11 @@ async function usersRoutes(fastify, _options) {
             status: newUser.status,
             studentId: newUser.student_id,
           },
-        });
+        };
+        if (placementWarning) {
+          response.warning = placementWarning;
+        }
+        return reply.code(201).send(response);
       } catch (error) {
         if (error.code === '23505') {
           if (error.constraint?.includes('student_id')) {
@@ -227,17 +360,14 @@ async function usersRoutes(fastify, _options) {
     }
   );
 
-  // Update user's group assignment (admin/assignment_manager only)
+  // Update user's group placement for one assignment (admin, or an assignment
+  // manager who manages that assignment). groupId null removes the placement.
   fastify.put(
     '/users/:id/group',
     {
       preHandler: async (request, reply) => {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
-        }
-        const allowed = await fastify.checkRole(request, reply, ['admin', 'assignment_manager']);
-        if (!allowed) {
-          return reply;
         }
       },
     },
@@ -247,14 +377,10 @@ async function usersRoutes(fastify, _options) {
         if (!validateUUID(userId)) {
           return reply.code(400).send({ error: 'Invalid ID format' });
         }
-        const { groupId } = request.body;
 
-        if (groupId === undefined) {
-          return reply.code(400).send({ error: 'groupId is required' });
-        }
-
-        if (groupId !== null && !validateUUID(groupId)) {
-          return reply.code(400).send({ error: 'Invalid groupId format' });
+        const { data: body, error: validationError } = parseBody(updateUserGroupSchema, request.body);
+        if (validationError) {
+          return reply.code(400).send({ error: validationError });
         }
 
         // Verify user exists
@@ -263,19 +389,53 @@ async function usersRoutes(fastify, _options) {
           return reply.code(404).send({ error: 'User not found' });
         }
 
-        // If groupId is not null, assign inside a transaction with row-level lock (H2)
-        if (groupId !== null) {
-          await Group.assignUserToGroup(userId, groupId);
-        } else {
-          await User.updateGroup(userId, null);
+        // Role guard, then assignment-scoped guard (admin always passes both)
+        const allowed = await fastify.requireAssignmentManager(request, reply);
+        if (!allowed) {
+          return reply;
         }
+        const managesOk = await fastify.assertManagesAssignment(request, reply, body.assignmentId);
+        if (!managesOk) {
+          return reply;
+        }
+
+        const assignment = await Assignment.findById(body.assignmentId);
+        if (!assignment) {
+          return reply.code(404).send({ error: 'Assignment not found' });
+        }
+
+        if (body.groupId === null) {
+          await UserGroup.remove(userId, body.assignmentId);
+          return reply.send({
+            message: 'User removed from group',
+            user: {
+              id: user.id,
+              username: user.username,
+              assignmentId: body.assignmentId,
+              groupId: null,
+            },
+          });
+        }
+
+        const group = await Group.findById(body.groupId);
+        if (!group) {
+          return reply.code(404).send({ error: 'Group not found' });
+        }
+        if (group.assignment_id !== body.assignmentId) {
+          return reply.code(400).send({ error: 'Group does not belong to the selected assignment' });
+        }
+
+        // Atomic placement — enforces subject membership (403), capacity (409)
+        // and existence (404) under a row-level lock on the group.
+        await UserGroup.assignUserToGroup(userId, body.groupId, { replace: true });
 
         return reply.send({
           message: 'User group updated successfully',
           user: {
             id: user.id,
             username: user.username,
-            groupId: groupId,
+            assignmentId: body.assignmentId,
+            groupId: body.groupId,
           },
         });
       } catch (error) {
@@ -332,7 +492,7 @@ async function usersRoutes(fastify, _options) {
           return reply.code(400).send({ error: validationError });
         }
 
-        const { email, firstName, lastName, studentId, role, enabled, username, groupId } = body;
+        const { email, firstName, lastName, studentId, role, enabled, username } = body;
 
         // Reuse the user already fetched in preHandler (M3)
         const user = request.targetUser;
@@ -365,10 +525,6 @@ async function usersRoutes(fastify, _options) {
         }
 
         if (isAdmin) {
-          // Only include groupId for regular users
-          if (user.role_name === 'user' && groupId !== undefined) {
-            updates.groupId = groupId;
-          }
           // Resolve role name to roleId if provided and changed
           if (role !== undefined && role !== user.role_name) {
             const roleRecord = await Role.findByName(role);
@@ -561,8 +717,11 @@ async function usersRoutes(fastify, _options) {
     },
     async (request, reply) => {
       try {
-        const { users: usersToImport, conflictAction = 'skip', sendSetupEmail = false } = request.body || {};
+        const { users: usersToImport, conflictAction = 'skip', sendSetupEmail = false, subjectId } = request.body || {};
 
+        if (!subjectId || !validateUUID(subjectId)) {
+          return reply.code(400).send({ error: 'Subject is required' });
+        }
         if (conflictAction !== 'skip' && conflictAction !== 'overwrite') {
           return reply.code(400).send({ error: "Invalid 'conflictAction'. Allowed values are 'skip' or 'overwrite'." });
         }
@@ -578,6 +737,20 @@ async function usersRoutes(fastify, _options) {
           return reply.code(400).send({ error: `Import exceeds maximum of ${MAX_IMPORT_SIZE} rows` });
         }
 
+        const subject = await Subject.findById(subjectId);
+        if (!subject) {
+          return reply.code(404).send({ error: 'Subject not found' });
+        }
+
+        // Assignment managers may only import into subjects containing an
+        // assignment they manage
+        if (request.user.role === 'assignment_manager') {
+          const manages = await Assignment.managesAnyInSubject(request.user.id, subjectId);
+          if (!manages) {
+            return reply.code(403).send({ error: 'Forbidden: You do not manage any assignment in this subject' });
+          }
+        }
+
         const roleRecord = await Role.findByName('user');
         if (!roleRecord) {
           return reply.code(500).send({ error: 'User role not found' });
@@ -586,6 +759,7 @@ async function usersRoutes(fastify, _options) {
         let imported = 0;
         let skipped = 0;
         const errors = [];
+        const enrolledUserIds = [];
 
         // First pass: parse all rows and collect unique keys for batch lookup
         const parsedRows = [];
@@ -690,6 +864,7 @@ async function usersRoutes(fastify, _options) {
                   studentIdMap.set(studentId, updatedEntry);
                 }
               }
+              enrolledUserIds.push(existing.id);
               imported++;
               continue;
             }
@@ -733,6 +908,7 @@ async function usersRoutes(fastify, _options) {
             if (studentId) {
               studentIdMap.set(studentId, newEntry);
             }
+            enrolledUserIds.push(newUser.id);
 
             if (sendSetupEmail) {
               try {
@@ -749,6 +925,11 @@ async function usersRoutes(fastify, _options) {
             const reason = rowError.code === '23505' ? 'Duplicate entry' : 'Processing failed';
             errors.push({ row: rowNum, identifier: rowLabel, reason });
           }
+        }
+
+        // Enrol every created/overwritten user in the target subject in one call
+        if (enrolledUserIds.length > 0) {
+          await Subject.addUsers(subjectId, enrolledUserIds);
         }
 
         errors.sort((a, b) => a.row - b.row);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -26,9 +26,8 @@ const MAX_IMPORT_SIZE = Number.isNaN(_parsed) ? 2000 : _parsed;
 async function usersRoutes(fastify, _options) {
   const isDev = config.app.nodeEnv === 'development';
 
-  // Get all users (admin/assignment_manager only) — supports ?role=, ?status=,
-  // ?subjectId=, ?assignmentId= and ?groupId= (uuid or 'none') filters.
-  // Assignment managers only see users enrolled in subjects they manage.
+  // Get all users (admin only) — supports ?role=, ?status=, ?subjectId=,
+  // ?assignmentId= and ?groupId= (uuid or 'none') filters.
   fastify.get(
     '/users',
     {
@@ -36,7 +35,7 @@ async function usersRoutes(fastify, _options) {
         if (!request.user) {
           return reply.code(401).send({ error: 'Unauthorized' });
         }
-        const allowed = await fastify.checkRole(request, reply, ['admin', 'assignment_manager']);
+        const allowed = await fastify.requireAdmin(request, reply);
         if (!allowed) {
           return reply;
         }
@@ -66,11 +65,9 @@ async function usersRoutes(fastify, _options) {
           return reply.code(400).send({ error: 'assignmentId is required when filtering ungrouped users' });
         }
 
+        // GET /users is admin-only since the AM authorization tightening — the
+        // User model's managedBy filter is retained but no longer set here.
         const filters = { role, status, subjectId, assignmentId, groupId };
-        // AM scoping: assignment managers only see users in subjects they manage
-        if (request.user?.role === 'assignment_manager') {
-          filters.managedBy = request.user.id;
-        }
 
         const users = await User.findAll(filters);
 
@@ -517,6 +514,29 @@ async function usersRoutes(fastify, _options) {
 
         const isAdmin = request.user.role === 'admin';
         const isAssignmentManager = request.user.role === 'assignment_manager';
+        const isSelfEdit = request.user.id === userId;
+
+        // Assignment managers may only edit users enrolled (any enabled state)
+        // in a subject containing an assignment they manage; self-edit stays allowed
+        if (isAssignmentManager && !isSelfEdit) {
+          const targetSubjects = await Subject.findForUser(userId, { includeDisabled: true });
+          let inScope = false;
+          for (const subject of targetSubjects) {
+            if (await Assignment.managesAnyInSubject(request.user.id, subject.id)) {
+              inScope = true;
+              break;
+            }
+          }
+          if (!inScope) {
+            return reply.code(403).send({ error: 'Forbidden: user is not in a subject you manage' });
+          }
+        }
+
+        // Only admins may enable or disable accounts — explicit reject for everyone else
+        if (enabled !== undefined && !isAdmin) {
+          return reply.code(403).send({ error: 'Only admins can enable or disable accounts' });
+        }
+
         const updates = { email, firstName, lastName };
 
         // Only include studentId for regular users
@@ -535,9 +555,8 @@ async function usersRoutes(fastify, _options) {
           }
         }
 
-        // Admins and assignment managers can enable/disable users; sync status accordingly
-        // (assignment managers cannot edit admin users — enforced in preHandler)
-        if ((isAdmin || isAssignmentManager) && enabled !== undefined) {
+        // Admins can enable/disable users; sync status accordingly
+        if (isAdmin && enabled !== undefined) {
           updates.enabled = enabled;
           if (enabled === false) {
             updates.status = 'inactive';
@@ -961,6 +980,23 @@ async function usersRoutes(fastify, _options) {
         await PasswordResetToken.deleteExpired();
 
         const { userIds } = request.body || {};
+        const isAssignmentManager = request.user.role === 'assignment_manager';
+
+        // AM scoping: users enrolled (any enabled state) in a subject containing
+        // an assignment the caller manages
+        let managedSubjectIds;
+        if (isAssignmentManager) {
+          const managed = await Assignment.findManagedBy(request.user.id);
+          managedSubjectIds = new Set(managed.map((a) => a.subject_id));
+        }
+        const idsInManagedSubjects = async (users) => {
+          if (users.length === 0) {
+            return new Set();
+          }
+          const rows = await Subject.findForUsers(users.map((u) => u.id));
+          return new Set(rows.filter((r) => managedSubjectIds.has(r.id)).map((r) => r.user_id));
+        };
+
         // If userIds provided, send only to those; otherwise send to all pending users
         let targets;
         if (Array.isArray(userIds) && userIds.length > 0) {
@@ -972,10 +1008,22 @@ async function usersRoutes(fastify, _options) {
             return reply.code(400).send({ error: 'One or more user IDs have an invalid format' });
           }
           const found = await User.findByIds(userIds);
+          if (isAssignmentManager) {
+            // Every explicit target must be in scope — reject before any email is sent
+            const inScope = await idsInManagedSubjects(found);
+            if (found.some((u) => !inScope.has(u.id))) {
+              return reply.code(403).send({ error: 'Forbidden: user is not in a subject you manage' });
+            }
+          }
           targets = found.filter((u) => u.status === 'pending');
         } else {
           const all = await User.findAll({ status: 'pending' });
-          targets = all;
+          if (isAssignmentManager) {
+            const inScope = await idsInManagedSubjects(all);
+            targets = all.filter((u) => inScope.has(u.id));
+          } else {
+            targets = all;
+          }
         }
 
         let sent = 0;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -9,6 +9,8 @@ const { logger } = require('./utils/logger');
 const authRoutes = require('./routes/auth');
 const usersRoutes = require('./routes/users');
 const groupsRoutes = require('./routes/groups');
+const subjectsRoutes = require('./routes/subjects');
+const assignmentsRoutes = require('./routes/assignments');
 const configRoutes = require('./routes/config');
 
 // Import plugins
@@ -133,6 +135,28 @@ async function buildServer({ logger: disableLogger } = {}) {
             update: 'PUT /api/groups/:id (admin)',
             delete: 'DELETE /api/groups/:id (admin)',
           },
+          subjects: {
+            list: 'GET /api/subjects',
+            get: 'GET /api/subjects/:id',
+            create: 'POST /api/subjects (admin)',
+            update: 'PUT /api/subjects/:id (admin)',
+            delete: 'DELETE /api/subjects/:id (admin)',
+            listUsers: 'GET /api/subjects/:id/users (admin/assignment_manager)',
+            addUsers: 'POST /api/subjects/:id/users (admin)',
+            removeUser: 'DELETE /api/subjects/:id/users/:userId (admin)',
+          },
+          assignments: {
+            list: 'GET /api/assignments',
+            get: 'GET /api/assignments/:id',
+            create: 'POST /api/assignments (admin)',
+            update: 'PUT /api/assignments/:id (admin)',
+            delete: 'DELETE /api/assignments/:id (admin)',
+            listGroups: 'GET /api/assignments/:id/groups',
+            listManagers: 'GET /api/assignments/:id/managers (admin)',
+            setManagers: 'PUT /api/assignments/:id/managers (admin)',
+            exportMappings: 'GET /api/assignments/:id/export-mappings (admin/manager)',
+            importMappings: 'POST /api/assignments/:id/import-mappings (admin/manager)',
+          },
         },
       };
     }
@@ -142,6 +166,8 @@ async function buildServer({ logger: disableLogger } = {}) {
   await fastify.register(authRoutes, { prefix: '/api' });
   await fastify.register(usersRoutes, { prefix: '/api' });
   await fastify.register(groupsRoutes, { prefix: '/api' });
+  await fastify.register(subjectsRoutes, { prefix: '/api' });
+  await fastify.register(assignmentsRoutes, { prefix: '/api' });
   await fastify.register(configRoutes, { prefix: '/api' });
 
   return fastify;

--- a/backend/src/utils/schemas.js
+++ b/backend/src/utils/schemas.js
@@ -85,6 +85,11 @@ const groupNameSchema = sanitizedString.pipe(
   z.string().min(1, 'Group name is required').max(100, 'Group name must be at most 100 characters')
 );
 
+const subjectNameSchema = nameSchema('Subject name');
+const assignmentNameSchema = nameSchema('Assignment name');
+
+const uuidArraySchema = z.array(z.string().uuid('Invalid ID format'));
+
 // ── Endpoint schemas ─────────────────────────────────────────────────────────
 
 const ROLE_VALUES = /** @type {const} */ (['admin', 'assignment_manager', 'user']);
@@ -109,7 +114,13 @@ const createUserSchema = z.object({
   lastName: nameSchema('Last name'),
   studentId: studentIdSchema,
   role: z.enum(ROLE_VALUES).optional(),
+  // role 'user': subjects to enrol in (required — enforced in the route),
+  // plus optional immediate group placement (assignment ∈ subjectIds).
+  subjectIds: uuidArraySchema.optional(),
+  assignmentId: z.string().uuid().optional().nullable(),
   groupId: z.string().uuid().optional().nullable(),
+  // role 'assignment_manager': assignments the new AM will manage.
+  assignmentIds: uuidArraySchema.optional(),
   sendSetupEmail: z.boolean().optional(),
 });
 
@@ -121,7 +132,6 @@ const updateUserSchema = z.object({
   role: z.enum(ROLE_VALUES).optional(),
   enabled: z.boolean().optional(),
   username: usernameSchema.optional(),
-  groupId: z.string().uuid().optional().nullable(),
 });
 
 const changePasswordSchema = z.object({
@@ -165,9 +175,40 @@ const importGroupMappingRowSchema = z.object({
 });
 
 const createGroupSchema = z.object({
+  assignmentId: z.string().uuid('Invalid assignment ID'),
   name: groupNameSchema,
   enabled: z.boolean().optional(),
   maxMembers: z.number().int().positive().optional().nullable(),
+});
+
+const createSubjectSchema = z.object({
+  name: subjectNameSchema,
+});
+
+const updateSubjectSchema = z.object({
+  name: subjectNameSchema,
+});
+
+const createAssignmentSchema = z.object({
+  subjectId: z.string().uuid('Invalid subject ID'),
+  name: assignmentNameSchema,
+});
+
+const updateAssignmentSchema = z.object({
+  name: assignmentNameSchema,
+});
+
+const addSubjectUsersSchema = z.object({
+  userIds: uuidArraySchema.min(1, 'At least one user is required').max(2000, 'At most 2000 users per request'),
+});
+
+const setAssignmentManagersSchema = z.object({
+  userIds: uuidArraySchema.max(2000, 'At most 2000 users per request'),
+});
+
+const updateUserGroupSchema = z.object({
+  assignmentId: z.string().uuid('Invalid assignment ID'),
+  groupId: z.string().uuid('Invalid group ID').nullable(),
 });
 
 const updateGroupSchema = z.object({
@@ -182,6 +223,14 @@ const bulkCreateGroupItemSchema = z.object({
   name: groupNameSchema,
   enabled: z.boolean().optional(),
   maxMembers: z.number().int().positive().optional().nullable(),
+});
+
+const bulkCreateGroupsSchema = z.object({
+  assignmentId: z.string().uuid('Invalid assignment ID'),
+  groups: z
+    .array(bulkCreateGroupItemSchema)
+    .min(1, 'At least one group is required')
+    .max(BULK_CREATE_MAX, `At most ${BULK_CREATE_MAX} groups per request`),
 });
 
 const updateConfigSchema = z.object({
@@ -225,4 +274,12 @@ module.exports = {
   updateGroupSchema,
   forgotPasswordSchema,
   setPasswordSchema,
+  createSubjectSchema,
+  updateSubjectSchema,
+  createAssignmentSchema,
+  updateAssignmentSchema,
+  addSubjectUsersSchema,
+  setAssignmentManagersSchema,
+  updateUserGroupSchema,
+  bulkCreateGroupsSchema,
 };

--- a/backend/src/utils/schemas.js
+++ b/backend/src/utils/schemas.js
@@ -202,6 +202,10 @@ const addSubjectUsersSchema = z.object({
   userIds: uuidArraySchema.min(1, 'At least one user is required').max(2000, 'At most 2000 users per request'),
 });
 
+const setMemberEnabledSchema = z.object({
+  enabled: z.boolean(),
+});
+
 const setAssignmentManagersSchema = z.object({
   userIds: uuidArraySchema.max(2000, 'At most 2000 users per request'),
 });
@@ -279,6 +283,7 @@ module.exports = {
   createAssignmentSchema,
   updateAssignmentSchema,
   addSubjectUsersSchema,
+  setMemberEnabledSchema,
   setAssignmentManagersSchema,
   updateUserGroupSchema,
   bulkCreateGroupsSchema,

--- a/backend/tests/integration/assignments.test.js
+++ b/backend/tests/integration/assignments.test.js
@@ -1,0 +1,789 @@
+'use strict';
+
+const { buildTestServer, closeTestServer } = require('./helpers/server');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  getPool,
+} = require('./helpers/db');
+
+let app;
+let adminToken;
+let amToken;
+let userToken;
+let am1;
+let user1;
+let subject;
+
+beforeAll(async () => {
+  app = await buildTestServer();
+});
+
+afterAll(async () => {
+  await closeTestServer(app);
+});
+
+beforeEach(async () => {
+  await cleanDatabase();
+  adminToken = await loginAs(app, 'admin', 'AdminPass123!');
+
+  am1 = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  amToken = await loginAs(app, 'am1', 'TestPass123!');
+
+  user1 = await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  userToken = await loginAs(app, 'user1', 'TestPass123!');
+
+  subject = await createSubject({ name: 'BaseSubject' });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/assignments
+// ---------------------------------------------------------------------------
+describe('GET /api/assignments', () => {
+  it('returns 401 without token', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/assignments' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('admin lists all assignments', async () => {
+    await createAssignment({ subjectId: subject.id, name: 'A1' });
+    await createAssignment({ subjectId: subject.id, name: 'A2' });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.assignments).toHaveLength(2);
+    expect(body.assignments[0].subject_name).toBe('BaseSubject');
+  });
+
+  it('filters by subjectId', async () => {
+    const other = await createSubject({ name: 'OtherSubject' });
+    await createAssignment({ subjectId: subject.id, name: 'InBase' });
+    await createAssignment({ subjectId: other.id, name: 'InOther' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments?subjectId=${subject.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).assignments.map((a) => a.name);
+    expect(names).toEqual(['InBase']);
+  });
+
+  it('returns 400 for invalid subjectId filter', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments?subjectId=not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('AM sees managed assignments plus assignments of own subjects', async () => {
+    const managed = await createAssignment({ subjectId: subject.id, name: 'ManagedA' });
+    await createAssignment({ subjectId: subject.id, name: 'UnmanagedA' });
+    const memberSubject = await createSubject({ name: 'AMMemberSubject' });
+    await createAssignment({ subjectId: memberSubject.id, name: 'MemberSubjectA' });
+    await assignManager(am1.id, managed.id);
+    await addUserToSubject(am1.id, memberSubject.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).assignments.map((a) => a.name);
+    expect(names).toContain('ManagedA');
+    expect(names).toContain('MemberSubjectA');
+    expect(names).not.toContain('UnmanagedA');
+  });
+
+  it('regular user sees only assignments of subjects they belong to', async () => {
+    await createAssignment({ subjectId: subject.id, name: 'MineA' });
+    const other = await createSubject({ name: 'NotMineSubject' });
+    await createAssignment({ subjectId: other.id, name: 'NotMineA' });
+    await addUserToSubject(user1.id, subject.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).assignments.map((a) => a.name);
+    expect(names).toEqual(['MineA']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/assignments/:id
+// ---------------------------------------------------------------------------
+describe('GET /api/assignments/:id', () => {
+  it('admin gets an assignment', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'DetailA' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.assignment.name).toBe('DetailA');
+    expect(body.assignment.subject_id).toBe(subject.id);
+  });
+
+  it('subject member can view the assignment', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'MemberA' });
+    await addUserToSubject(user1.id, subject.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('managing AM can view the assignment', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'AMViewA' });
+    await assignManager(am1.id, a.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('outsider user gets 403', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'PrivateA' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 for invalid UUID and 404 for unknown id', async () => {
+    const bad = await app.inject({
+      method: 'GET',
+      url: '/api/assignments/not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(bad.statusCode).toBe(400);
+    const missing = await app.inject({
+      method: 'GET',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/assignments
+// ---------------------------------------------------------------------------
+describe('POST /api/assignments', () => {
+  it('admin creates an assignment', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { subjectId: subject.id, name: 'NewAssignment' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.assignment.name).toBe('NewAssignment');
+    expect(body.assignment.subject_id).toBe(subject.id);
+  });
+
+  it('returns 409 for a duplicate name within the same subject (case-insensitive)', async () => {
+    await createAssignment({ subjectId: subject.id, name: 'DupA' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { subjectId: subject.id, name: 'dupa' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('allows the same name in a DIFFERENT subject', async () => {
+    await createAssignment({ subjectId: subject.id, name: 'SharedName' });
+    const other = await createSubject({ name: 'SecondSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { subjectId: other.id, name: 'SharedName' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('returns 404 when the subject does not exist', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { subjectId: '00000000-0000-0000-0000-000000000000', name: 'Orphan' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/assignments',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'NoSubject' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 for AM and regular user', async () => {
+    for (const token of [amToken, userToken]) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/assignments',
+        headers: { authorization: `Bearer ${token}` },
+        payload: { subjectId: subject.id, name: 'Forbidden' },
+      });
+      expect(res.statusCode).toBe(403);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/assignments/:id
+// ---------------------------------------------------------------------------
+describe('PUT /api/assignments/:id', () => {
+  it('admin renames an assignment', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'OldA' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'NewA' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).assignment.name).toBe('NewA');
+  });
+
+  it('returns 409 when renaming to an existing name in the subject', async () => {
+    await createAssignment({ subjectId: subject.id, name: 'TakenA' });
+    const a = await createAssignment({ subjectId: subject.id, name: 'RenameA' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'TakenA' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('returns 404 / 400 for unknown id / invalid uuid', async () => {
+    const missing = await app.inject({
+      method: 'PUT',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'Ghost' },
+    });
+    expect(missing.statusCode).toBe(404);
+    const bad = await app.inject({
+      method: 'PUT',
+      url: '/api/assignments/not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'Bad' },
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
+  it('returns 403 for AM', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'AMPutA' });
+    await assignManager(am1.id, a.id);
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { name: 'Hacked' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/assignments/:id
+// ---------------------------------------------------------------------------
+describe('DELETE /api/assignments/:id', () => {
+  it('admin deletes an assignment; groups and memberships cascade, users survive', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'CascadeA' });
+    const g = await createGroup({ assignmentId: a.id, name: 'G1' });
+    await addUserToSubject(user1.id, subject.id);
+    await addUserToGroup(user1.id, g.id, a.id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const db = getPool();
+    const groups = await db.query('SELECT COUNT(*)::int AS c FROM groups WHERE assignment_id = $1', [a.id]);
+    expect(groups.rows[0].c).toBe(0);
+    const memberships = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE assignment_id = $1', [a.id]);
+    expect(memberships.rows[0].c).toBe(0);
+    const users = await db.query('SELECT COUNT(*)::int AS c FROM users WHERE id = $1', [user1.id]);
+    expect(users.rows[0].c).toBe(1);
+    // Subject enrolment is untouched
+    const enrolment = await db.query('SELECT COUNT(*)::int AS c FROM user_subjects WHERE user_id = $1', [user1.id]);
+    expect(enrolment.rows[0].c).toBe(1);
+  });
+
+  it('returns 404 for unknown assignment and 403 for non-admin', async () => {
+    const missing = await app.inject({
+      method: 'DELETE',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(missing.statusCode).toBe(404);
+
+    const a = await createAssignment({ subjectId: subject.id, name: 'ProtectedA' });
+    await assignManager(am1.id, a.id);
+    const amRes = await app.inject({
+      method: 'DELETE',
+      url: `/api/assignments/${a.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(amRes.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/assignments/:id/groups
+// ---------------------------------------------------------------------------
+describe('GET /api/assignments/:id/groups', () => {
+  it('lists groups of the assignment with member counts', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'GroupsA' });
+    const g = await createGroup({ assignmentId: a.id, name: 'Alpha' });
+    await createGroup({ assignmentId: a.id, name: 'Beta', enabled: false });
+    await addUserToSubject(user1.id, subject.id);
+    await addUserToGroup(user1.id, g.id, a.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/groups`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.groups).toHaveLength(2);
+    const alpha = body.groups.find((x) => x.name === 'Alpha');
+    expect(alpha.member_count).toBe(1);
+  });
+
+  it('?enabled=true returns only enabled groups', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'EnabledFilterA' });
+    await createGroup({ assignmentId: a.id, name: 'On', enabled: true });
+    await createGroup({ assignmentId: a.id, name: 'Off', enabled: false });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/groups?enabled=true`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).groups.map((g) => g.name);
+    expect(names).toEqual(['On']);
+  });
+
+  it('subject member can list; outsider gets 403', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'ScopedGroupsA' });
+    await addUserToSubject(user1.id, subject.id);
+    const memberRes = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/groups`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(memberRes.statusCode).toBe(200);
+
+    const outsider = await createUser({ username: 'outsider', email: 'outsider@test.com' });
+    const outsiderToken = await loginAs(app, outsider.username, 'TestPass123!');
+    const outsiderRes = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/groups`,
+      headers: { authorization: `Bearer ${outsiderToken}` },
+    });
+    expect(outsiderRes.statusCode).toBe(403);
+  });
+
+  it('returns 404 for unknown assignment', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000/groups',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET/PUT /api/assignments/:id/managers
+// ---------------------------------------------------------------------------
+describe('GET/PUT /api/assignments/:id/managers', () => {
+  it('admin sets and reads managers; replace semantics; empty clears', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'ManagersA' });
+    const am2 = await createUser({ username: 'am2', email: 'am2@test.com', role: 'assignment_manager' });
+
+    // Set [am1]
+    const set1 = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [am1.id] },
+    });
+    expect(set1.statusCode).toBe(200);
+    expect(JSON.parse(set1.body).managers.map((m) => m.username)).toEqual(['am1']);
+
+    // Replace with [am2] — am1 must be gone
+    const set2 = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [am2.id] },
+    });
+    expect(set2.statusCode).toBe(200);
+    expect(JSON.parse(set2.body).managers.map((m) => m.username)).toEqual(['am2']);
+
+    const get = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(get.statusCode).toBe(200);
+    expect(JSON.parse(get.body).managers.map((m) => m.username)).toEqual(['am2']);
+
+    // Empty clears
+    const clear = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [] },
+    });
+    expect(clear.statusCode).toBe(200);
+    expect(JSON.parse(clear.body).managers).toEqual([]);
+  });
+
+  it('PUT rejects userIds whose role is not assignment_manager', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'BadManagerA' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/assignment_manager role/i);
+  });
+
+  it('PUT rejects unknown userIds', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'GhostManagerA' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: ['00000000-0000-0000-0000-000000000000'] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/do not exist/i);
+  });
+
+  it('GET and PUT are admin-only (403 for AM)', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'AdminOnlyManagersA' });
+    await assignManager(am1.id, a.id);
+    const get = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(get.statusCode).toBe(403);
+    const put = await app.inject({
+      method: 'PUT',
+      url: `/api/assignments/${a.id}/managers`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { userIds: [] },
+    });
+    expect(put.statusCode).toBe(403);
+  });
+
+  it('returns 404 for unknown assignment', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000/managers',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [] },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/assignments/:id/export-mappings
+// ---------------------------------------------------------------------------
+describe('GET /api/assignments/:id/export-mappings', () => {
+  it('exports email/groupName pairs for the assignment only', async () => {
+    const a1 = await createAssignment({ subjectId: subject.id, name: 'ExportA1' });
+    const a2 = await createAssignment({ subjectId: subject.id, name: 'ExportA2' });
+    const g1 = await createGroup({ assignmentId: a1.id, name: 'TeamOne' });
+    const g2 = await createGroup({ assignmentId: a2.id, name: 'TeamTwo' });
+    const u2 = await createUser({ username: 'exporter2', email: 'exporter2@test.com' });
+    await addUserToSubject(user1.id, subject.id);
+    await addUserToSubject(u2.id, subject.id);
+    await addUserToGroup(user1.id, g1.id, a1.id);
+    await addUserToGroup(u2.id, g2.id, a2.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a1.id}/export-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.mappings).toEqual([{ email: 'user1@test.com', groupName: 'TeamOne' }]);
+  });
+
+  it('managing AM can export; non-managing AM gets 403; user gets 403', async () => {
+    const a = await createAssignment({ subjectId: subject.id, name: 'ExportScopeA' });
+    await assignManager(am1.id, a.id);
+    const ok = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/export-mappings`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(JSON.parse(ok.body).mappings).toEqual([]);
+
+    const am2 = await createUser({ username: 'am2', email: 'am2@test.com', role: 'assignment_manager' });
+    const am2Token = await loginAs(app, am2.username, 'TestPass123!');
+    const forbidden = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/export-mappings`,
+      headers: { authorization: `Bearer ${am2Token}` },
+    });
+    expect(forbidden.statusCode).toBe(403);
+
+    const userRes = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${a.id}/export-mappings`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(userRes.statusCode).toBe(403);
+  });
+
+  it('returns 404 for unknown assignment', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/assignments/00000000-0000-0000-0000-000000000000/export-mappings',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/assignments/:id/import-mappings
+// ---------------------------------------------------------------------------
+describe('POST /api/assignments/:id/import-mappings', () => {
+  let assignment;
+  let group;
+
+  beforeEach(async () => {
+    assignment = await createAssignment({ subjectId: subject.id, name: 'ImportA' });
+    group = await createGroup({ assignmentId: assignment.id, name: 'ImportGroup' });
+  });
+
+  it('admin imports a mapping for a subject member', async () => {
+    await addUserToSubject(user1.id, subject.id);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(1);
+    expect(body.skipped).toEqual([]);
+    expect(body.errors).toEqual([]);
+
+    const db = getPool();
+    const rows = await db.query('SELECT group_id FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      user1.id,
+      assignment.id,
+    ]);
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].group_id).toBe(group.id);
+  });
+
+  it('replaces an existing membership for the assignment', async () => {
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'SecondGroup' });
+    await addUserToSubject(user1.id, subject.id);
+    await addUserToGroup(user1.id, group.id, assignment.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'SecondGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).imported).toBe(1);
+
+    const db = getPool();
+    const rows = await db.query('SELECT group_id FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      user1.id,
+      assignment.id,
+    ]);
+    expect(rows.rows[0].group_id).toBe(g2.id);
+  });
+
+  it('skips unknown email', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'ghost@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.skipped[0].reason).toBe('User not found');
+  });
+
+  it('skips unknown group', async () => {
+    await addUserToSubject(user1.id, subject.id);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'GhostGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).skipped[0].reason).toBe('Group not found');
+  });
+
+  it('skips a user who is not a member of the subject', async () => {
+    // user1 exists but is NOT enrolled in the subject
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.skipped[0].reason).toBe('User is not a member of this subject');
+  });
+
+  it('skips admin accounts', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'admin@gap.local', groupName: 'ImportGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.skipped[0].reason).toMatch(/admin/i);
+  });
+
+  it('skips a mapping into a full group', async () => {
+    const full = await createGroup({ assignmentId: assignment.id, name: 'FullGroup', maxMembers: 1 });
+    const filler = await createUser({ username: 'filler', email: 'filler@test.com' });
+    await addUserToSubject(filler.id, subject.id);
+    await addUserToSubject(user1.id, subject.id);
+    await addUserToGroup(filler.id, full.id, assignment.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'FullGroup' }] },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.skipped[0].reason).toBe('Group is full');
+  });
+
+  it('rows with action=skip are echoed into skipped', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        rows: [{ email: 'skipme@test.com', groupName: 'ImportGroup', action: 'skip', skipReason: 'Duplicate entry' }],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.skipped).toHaveLength(1);
+    expect(body.skipped[0].reason).toBe('Duplicate entry');
+  });
+
+  it('returns 400 for empty rows', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { rows: [] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('managing AM can import; non-managing AM gets 403', async () => {
+    await assignManager(am1.id, assignment.id);
+    await addUserToSubject(user1.id, subject.id);
+    const ok = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(JSON.parse(ok.body).imported).toBe(1);
+
+    const am2 = await createUser({ username: 'am2', email: 'am2@test.com', role: 'assignment_manager' });
+    const am2Token = await loginAs(app, am2.username, 'TestPass123!');
+    const forbidden = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${am2Token}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('returns 403 for regular user', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/assignments/${assignment.id}/import-mappings`,
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { rows: [{ email: 'user1@test.com', groupName: 'ImportGroup' }] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/tests/integration/auth.test.js
+++ b/backend/tests/integration/auth.test.js
@@ -1,11 +1,26 @@
 'use strict';
 
 const { buildTestServer, closeTestServer } = require('./helpers/server');
-const { cleanDatabase, createUser, loginAs, getPool } = require('./helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  getPool,
+} = require('./helpers/db');
 const config = require('../../src/config/index');
 
 let app;
 let adminToken;
+
+function decodeJwtPayload(token) {
+  return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+}
 
 beforeAll(async () => {
   app = await buildTestServer();
@@ -37,6 +52,61 @@ describe('POST /api/auth/login', () => {
     expect(body.token).toBeDefined();
     expect(body.user.username).toBe('admin');
     expect(body.user.role).toBe('admin');
+  });
+
+  it('login payload includes subjects/memberships/managedAssignments and no group claims', async () => {
+    const subject = await createSubject({ name: 'LoginSubject' });
+    const assignment = await createAssignment({ subjectId: subject.id, name: 'A1' });
+    const group = await createGroup({ assignmentId: assignment.id, name: 'LoginGroup' });
+    const u = await createUser({ username: 'loginuser', email: 'loginuser@test.com' });
+    await addUserToSubject(u.id, subject.id);
+    await addUserToGroup(u.id, group.id, assignment.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'loginuser', password: 'TestPass123!' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+
+    expect(body.user.subjects).toEqual([{ id: subject.id, name: 'LoginSubject' }]);
+    expect(body.user.memberships).toHaveLength(1);
+    expect(body.user.memberships[0]).toMatchObject({
+      assignment_id: assignment.id,
+      group_id: group.id,
+      group_name: 'LoginGroup',
+      subject_id: subject.id,
+    });
+    expect(body.user.managedAssignments).toEqual([]);
+    expect(body.user).not.toHaveProperty('groupId');
+    expect(body.user).not.toHaveProperty('groupName');
+
+    // JWT carries identity claims only — no group/hierarchy data
+    const claims = decodeJwtPayload(body.token);
+    expect(claims).toMatchObject({ id: u.id, username: 'loginuser', role: 'user' });
+    expect(claims).not.toHaveProperty('groupId');
+    expect(claims).not.toHaveProperty('groupName');
+    expect(claims).not.toHaveProperty('subjects');
+    expect(claims).not.toHaveProperty('memberships');
+  });
+
+  it('assignment manager login includes managedAssignments', async () => {
+    const subject = await createSubject({ name: 'AMSubject' });
+    const assignment = await createAssignment({ subjectId: subject.id, name: 'ManagedA' });
+    const am = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+    await assignManager(am.id, assignment.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'am1', password: 'TestPass123!' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.managedAssignments).toHaveLength(1);
+    expect(body.user.managedAssignments[0].id).toBe(assignment.id);
+    expect(body.user.managedAssignments[0].subject_id).toBe(subject.id);
   });
 
   it('returns 401 for wrong password', async () => {
@@ -79,8 +149,9 @@ describe('POST /api/auth/login', () => {
   });
 
   it('returns 401 for pending user (no password set)', async () => {
+    const subject = await createSubject({ name: 'PendingSubject' });
     // Create user via API so they're pending
-    await app.inject({
+    const createRes = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
@@ -89,9 +160,11 @@ describe('POST /api/auth/login', () => {
         email: 'pending@test.com',
         firstName: 'P',
         lastName: 'User',
+        subjectIds: [subject.id],
         sendSetupEmail: false,
       },
     });
+    expect(createRes.statusCode).toBe(201);
     const res = await app.inject({
       method: 'POST',
       url: '/api/auth/login',
@@ -204,6 +277,30 @@ describe('GET /api/auth/me', () => {
     expect(body.user).not.toHaveProperty('password_hash');
   });
 
+  it('includes subjects/memberships/managedAssignments and no group claims', async () => {
+    const subject = await createSubject({ name: 'MeSubject' });
+    const assignment = await createAssignment({ subjectId: subject.id, name: 'A1' });
+    const group = await createGroup({ assignmentId: assignment.id, name: 'MeGroup' });
+    const u = await createUser({ username: 'meuser', email: 'meuser@test.com' });
+    await addUserToSubject(u.id, subject.id);
+    await addUserToGroup(u.id, group.id, assignment.id);
+    const token = await loginAs(app, 'meuser', 'TestPass123!');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.subjects).toEqual([{ id: subject.id, name: 'MeSubject' }]);
+    expect(body.user.memberships).toHaveLength(1);
+    expect(body.user.memberships[0].group_id).toBe(group.id);
+    expect(body.user.managedAssignments).toEqual([]);
+    expect(body.user).not.toHaveProperty('groupId');
+    expect(body.user).not.toHaveProperty('groupName');
+  });
+
   it('returns 401 without token', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/auth/me' });
     expect(res.statusCode).toBe(401);
@@ -284,6 +381,7 @@ describe('POST /api/auth/forgot-password', () => {
   });
 
   it('creates a setup-type token (not reset) for a pending user', async () => {
+    const subject = await createSubject({ name: 'ForgotSubject' });
     // Create a pending user via the API (sendSetupEmail:false → no token yet, status pending)
     const createRes = await app.inject({
       method: 'POST',
@@ -294,6 +392,7 @@ describe('POST /api/auth/forgot-password', () => {
         email: 'pendingforgot@test.com',
         firstName: 'Pending',
         lastName: 'Forgot',
+        subjectIds: [subject.id],
         sendSetupEmail: false,
       },
     });
@@ -339,14 +438,7 @@ describe('POST /api/auth/set-password', () => {
   });
 
   it('full e2e: register → set-password → login', async () => {
-    // Enable registration
-    await app.inject({
-      method: 'PUT',
-      url: '/api/config/registration_enabled',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { value: 'true' },
-    });
-
+    // Registration is enabled via REGISTRATION_ENABLED=true in setupEnv.js
     // Register a pending user
     const regRes = await app.inject({
       method: 'POST',

--- a/backend/tests/integration/config.test.js
+++ b/backend/tests/integration/config.test.js
@@ -1,12 +1,23 @@
 'use strict';
 
 const { buildTestServer, closeTestServer } = require('./helpers/server');
-const { cleanDatabase, createUser, createGroup, loginAs } = require('./helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  loginAs,
+} = require('./helpers/db');
 
 let app;
 let adminToken;
 let amToken;
 let userToken;
+let am1;
+let subject;
+let assignment;
 
 beforeAll(async () => {
   app = await buildTestServer();
@@ -20,10 +31,14 @@ beforeEach(async () => {
   await cleanDatabase();
   adminToken = await loginAs(app, 'admin', 'AdminPass123!');
 
-  await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  subject = await createSubject({ name: 'ConfigSubject' });
+  assignment = await createAssignment({ subjectId: subject.id, name: 'A1' });
+
+  am1 = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
   amToken = await loginAs(app, 'am1', 'TestPass123!');
 
-  await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  const user1 = await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  await addUserToSubject(user1.id, subject.id);
   userToken = await loginAs(app, 'user1', 'TestPass123!');
 });
 
@@ -204,7 +219,7 @@ describe('PUT /api/config/:key', () => {
 // ---------------------------------------------------------------------------
 describe('group_join_locked enforcement', () => {
   it('prevents regular users from joining when locked', async () => {
-    const g = await createGroup({ name: 'LockTestGroup', enabled: true });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'LockTestGroup', enabled: true });
 
     await app.inject({
       method: 'PUT',
@@ -223,7 +238,9 @@ describe('group_join_locked enforcement', () => {
   });
 
   it('allows assignment_manager to join group even when locked', async () => {
-    const g = await createGroup({ name: 'AMCanJoin', enabled: true });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'AMCanJoin', enabled: true });
+    // Joining still requires subject membership — the lock bypass is what is under test
+    await addUserToSubject(am1.id, subject.id);
 
     await app.inject({
       method: 'PUT',
@@ -242,7 +259,15 @@ describe('group_join_locked enforcement', () => {
   });
 
   it('allows admin to join group even when locked', async () => {
-    const g = await createGroup({ name: 'AdminCanJoin', enabled: true });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'AdminCanJoin', enabled: true });
+    // Joining requires subject membership even for admins; enrol the admin first
+    const loginRes = await app.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'admin', password: 'AdminPass123!' },
+    });
+    const adminId = JSON.parse(loginRes.body).user.id;
+    await addUserToSubject(adminId, subject.id);
 
     await app.inject({
       method: 'PUT',
@@ -256,8 +281,7 @@ describe('group_join_locked enforcement', () => {
       url: `/api/groups/${g.id}/join`,
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    // Admin bypasses the lock — cleanDatabase resets admin's group_id to NULL
-    // (via ON DELETE SET NULL), so admin can always join a fresh group.
+    // Admin bypasses the lock (cleanDatabase clears user_groups between tests)
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).error).toBeUndefined();
   });

--- a/backend/tests/integration/groups.test.js
+++ b/backend/tests/integration/groups.test.js
@@ -1,12 +1,29 @@
 'use strict';
 
 const { buildTestServer, closeTestServer } = require('./helpers/server');
-const { cleanDatabase, createUser, createGroup, loginAs } = require('./helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  getPool,
+} = require('./helpers/db');
 
 let app;
 let adminToken;
-let amToken;
-let userToken;
+let amToken; // manages `assignment`
+let am2Token; // manages nothing
+let userToken; // member of `subject`
+let am1;
+let am2;
+let user1;
+let subject;
+let assignment;
 
 beforeAll(async () => {
   app = await buildTestServer();
@@ -20,61 +37,27 @@ beforeEach(async () => {
   await cleanDatabase();
   adminToken = await loginAs(app, 'admin', 'AdminPass123!');
 
-  await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  subject = await createSubject({ name: 'BaseSubject' });
+  assignment = await createAssignment({ subjectId: subject.id, name: 'A1' });
+
+  am1 = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  await assignManager(am1.id, assignment.id);
   amToken = await loginAs(app, 'am1', 'TestPass123!');
 
-  await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  am2 = await createUser({ username: 'am2', email: 'am2@test.com', role: 'assignment_manager' });
+  am2Token = await loginAs(app, 'am2', 'TestPass123!');
+
+  user1 = await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  await addUserToSubject(user1.id, subject.id);
   userToken = await loginAs(app, 'user1', 'TestPass123!');
-});
-
-// ---------------------------------------------------------------------------
-// GET /api/groups
-// ---------------------------------------------------------------------------
-describe('GET /api/groups', () => {
-  it('authenticated user can list groups', async () => {
-    await createGroup({ name: 'Alpha' });
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups',
-      headers: { authorization: `Bearer ${userToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(Array.isArray(body.groups)).toBe(true);
-    expect(body.groups.some((g) => g.name === 'Alpha')).toBe(true);
-  });
-
-  it('returns 401 without token', async () => {
-    const res = await app.inject({ method: 'GET', url: '/api/groups' });
-    expect(res.statusCode).toBe(401);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// GET /api/groups/enabled
-// ---------------------------------------------------------------------------
-describe('GET /api/groups/enabled', () => {
-  it('returns only enabled groups', async () => {
-    await createGroup({ name: 'EnabledGroup', enabled: true });
-    await createGroup({ name: 'DisabledGroup', enabled: false });
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups/enabled',
-      headers: { authorization: `Bearer ${userToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.groups.every((g) => g.enabled === true)).toBe(true);
-    expect(body.groups.some((g) => g.name === 'DisabledGroup')).toBe(false);
-  });
 });
 
 // ---------------------------------------------------------------------------
 // GET /api/groups/:id
 // ---------------------------------------------------------------------------
 describe('GET /api/groups/:id', () => {
-  it('returns group with member list', async () => {
-    const g = await createGroup({ name: 'DetailGroup' });
+  it('subject member gets group with hierarchy info and member list', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'DetailGroup' });
     const res = await app.inject({
       method: 'GET',
       url: `/api/groups/${g.id}`,
@@ -83,7 +66,43 @@ describe('GET /api/groups/:id', () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.group.name).toBe('DetailGroup');
+    expect(body.group.assignmentId).toBe(assignment.id);
+    expect(body.group.subjectId).toBe(subject.id);
     expect(Array.isArray(body.members)).toBe(true);
+  });
+
+  it('admin and managing AM can view the group', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'StaffGroup' });
+    for (const token of [adminToken, amToken]) {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/groups/${g.id}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(res.statusCode).toBe(200);
+    }
+  });
+
+  it('non-member user gets 403', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'PrivateGroup' });
+    await createUser({ username: 'outsider', email: 'outsider@test.com' });
+    const outsiderToken = await loginAs(app, 'outsider', 'TestPass123!');
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${outsiderToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('non-managing AM (not a subject member) gets 403', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'AMScopedGroup' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${am2Token}` },
+    });
+    expect(res.statusCode).toBe(403);
   });
 
   it('returns 404 for non-existent group', async () => {
@@ -109,70 +128,111 @@ describe('GET /api/groups/:id', () => {
 // POST /api/groups
 // ---------------------------------------------------------------------------
 describe('POST /api/groups', () => {
-  it('admin creates a group', async () => {
+  it('admin creates a group in an assignment', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'NewGroup' },
+      payload: { assignmentId: assignment.id, name: 'NewGroup' },
     });
     expect(res.statusCode).toBe(201);
     const body = JSON.parse(res.body);
     expect(body.group.name).toBe('NewGroup');
     expect(body.group.enabled).toBe(true);
+    expect(body.group.assignmentId).toBe(assignment.id);
   });
 
-  it('admin creates group with maxMembers', async () => {
+  it('admin creates group with maxMembers and disabled state', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'LimitedGroup', maxMembers: 5 },
+      payload: { assignmentId: assignment.id, name: 'LimitedGroup', maxMembers: 5, enabled: false },
     });
     expect(res.statusCode).toBe(201);
-    expect(JSON.parse(res.body).group.maxMembers).toBe(5);
+    const body = JSON.parse(res.body);
+    expect(body.group.maxMembers).toBe(5);
+    expect(body.group.enabled).toBe(false);
   });
 
-  it('admin creates disabled group', async () => {
+  it('returns 409 for duplicate group name within the assignment', async () => {
+    await createGroup({ assignmentId: assignment.id, name: 'DupGroup' });
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'DisabledAtCreate', enabled: false },
-    });
-    expect(res.statusCode).toBe(201);
-    expect(JSON.parse(res.body).group.enabled).toBe(false);
-  });
-
-  it('returns 409 for duplicate group name', async () => {
-    await createGroup({ name: 'DupGroup' });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'DupGroup' },
+      payload: { assignmentId: assignment.id, name: 'DupGroup' },
     });
     expect(res.statusCode).toBe(409);
   });
 
-  it('assignment_manager cannot create groups', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups',
-      headers: { authorization: `Bearer ${amToken}` },
-      payload: { name: 'AMGroup' },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-
-  it('returns 400 for missing name', async () => {
+  it('allows the same group name in a different assignment', async () => {
+    await createGroup({ assignmentId: assignment.id, name: 'SharedName' });
+    const a2 = await createAssignment({ subjectId: subject.id, name: 'A2' });
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: {},
+      payload: { assignmentId: a2.id, name: 'SharedName' },
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('managing AM can create a group in their assignment', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { assignmentId: assignment.id, name: 'AMGroup' },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('AM cannot create a group in an assignment they do not manage', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${am2Token}` },
+      payload: { assignmentId: assignment.id, name: 'ForbiddenGroup' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('regular user cannot create groups', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { assignmentId: assignment.id, name: 'UserGroup' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 for missing name or assignmentId', async () => {
+    const noName = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: assignment.id },
+    });
+    expect(noName.statusCode).toBe(400);
+    const noAssignment = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'NoAssignment' },
+    });
+    expect(noAssignment.statusCode).toBe(400);
+  });
+
+  it('returns 404 for unknown assignment', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/groups',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: '00000000-0000-0000-0000-000000000000', name: 'Orphan' },
+    });
+    expect(res.statusCode).toBe(404);
   });
 });
 
@@ -185,19 +245,21 @@ describe('POST /api/groups/bulk', () => {
       method: 'POST',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: [{ name: 'Bulk1' }, { name: 'Bulk2', maxMembers: 10 }, { name: 'Bulk3', enabled: false }],
+      payload: {
+        assignmentId: assignment.id,
+        groups: [{ name: 'Bulk1' }, { name: 'Bulk2', maxMembers: 10 }, { name: 'Bulk3', enabled: false }],
+      },
     });
     expect(res.statusCode).toBe(201);
-    const body = JSON.parse(res.body);
-    expect(body.groups).toHaveLength(3);
+    expect(JSON.parse(res.body).groups).toHaveLength(3);
   });
 
-  it('returns 400 for empty array', async () => {
+  it('returns 400 for empty groups array', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: [],
+      payload: { assignmentId: assignment.id, groups: [] },
     });
     expect(res.statusCode).toBe(400);
   });
@@ -207,21 +269,39 @@ describe('POST /api/groups/bulk', () => {
       method: 'POST',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: [{ name: 'DupBulk' }, { name: 'DupBulk' }],
+      payload: { assignmentId: assignment.id, groups: [{ name: 'DupBulk' }, { name: 'dupbulk' }] },
     });
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/duplicate/i);
   });
 
   it('returns 409 when a name conflicts with an existing group', async () => {
-    await createGroup({ name: 'ExistingGroup' });
+    await createGroup({ assignmentId: assignment.id, name: 'ExistingGroup' });
     const res = await app.inject({
       method: 'POST',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: [{ name: 'ExistingGroup' }, { name: 'NewOne' }],
+      payload: { assignmentId: assignment.id, groups: [{ name: 'ExistingGroup' }, { name: 'NewOne' }] },
     });
     expect(res.statusCode).toBe(409);
+  });
+
+  it('managing AM can bulk create; unmanaged AM gets 403', async () => {
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { assignmentId: assignment.id, groups: [{ name: 'AMBulk1' }] },
+    });
+    expect(ok.statusCode).toBe(201);
+
+    const forbidden = await app.inject({
+      method: 'POST',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${am2Token}` },
+      payload: { assignmentId: assignment.id, groups: [{ name: 'AMBulk2' }] },
+    });
+    expect(forbidden.statusCode).toBe(403);
   });
 
   it('regular user cannot bulk create groups', async () => {
@@ -229,7 +309,7 @@ describe('POST /api/groups/bulk', () => {
       method: 'POST',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${userToken}` },
-      payload: [{ name: 'UserGroup' }],
+      payload: { assignmentId: assignment.id, groups: [{ name: 'UserBulk' }] },
     });
     expect(res.statusCode).toBe(403);
   });
@@ -239,41 +319,38 @@ describe('POST /api/groups/bulk', () => {
 // PUT /api/groups/:id
 // ---------------------------------------------------------------------------
 describe('PUT /api/groups/:id', () => {
-  it('admin updates group name', async () => {
-    const g = await createGroup({ name: 'OldName' });
+  it('admin updates group name and enabled state', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'OldName' });
     const res = await app.inject({
       method: 'PUT',
       url: `/api/groups/${g.id}`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'NewName', enabled: true },
+      payload: { name: 'NewName', enabled: false },
     });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).group.name).toBe('NewName');
+    const body = JSON.parse(res.body);
+    expect(body.group.name).toBe('NewName');
+    expect(body.group.enabled).toBe(false);
   });
 
-  it('admin disables a group', async () => {
-    const g = await createGroup({ name: 'Disableable' });
+  it('returns 409 when renaming to an existing name in the assignment', async () => {
+    await createGroup({ assignmentId: assignment.id, name: 'TakenName' });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'RenameMe' });
     const res = await app.inject({
       method: 'PUT',
       url: `/api/groups/${g.id}`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'Disableable', enabled: false },
+      payload: { name: 'TakenName' },
     });
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).group.enabled).toBe(false);
+    expect(res.statusCode).toBe(409);
   });
 
   it('returns 400 when maxMembers is less than current member count', async () => {
-    const g = await createGroup({ name: 'ShrinkGroup', maxMembers: 5 });
-    // Add 3 members directly
+    const g = await createGroup({ assignmentId: assignment.id, name: 'ShrinkGroup', maxMembers: 5 });
     for (let i = 0; i < 3; i++) {
       const u = await createUser({ username: `shrink${i}`, email: `shrink${i}@test.com` });
-      await app.inject({
-        method: 'PUT',
-        url: `/api/users/${u.id}/group`,
-        headers: { authorization: `Bearer ${adminToken}` },
-        payload: { groupId: g.id },
-      });
+      await addUserToSubject(u.id, subject.id);
+      await addUserToGroup(u.id, g.id, assignment.id);
     }
     const res = await app.inject({
       method: 'PUT',
@@ -283,6 +360,23 @@ describe('PUT /api/groups/:id', () => {
     });
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/members/i);
+  });
+
+  it('setting maxMembers exactly equal to current member count succeeds', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'BoundaryGroup', maxMembers: 10 });
+    for (let i = 0; i < 3; i++) {
+      const u = await createUser({ username: `bnd${i}`, email: `bnd${i}@test.com` });
+      await addUserToSubject(u.id, subject.id);
+      await addUserToGroup(u.id, g.id, assignment.id);
+    }
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'BoundaryGroup', enabled: true, maxMembers: 3 },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).group.max_members).toBe(3);
   });
 
   it('returns 404 for non-existent group', async () => {
@@ -295,15 +389,23 @@ describe('PUT /api/groups/:id', () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it('assignment_manager cannot update groups', async () => {
-    const g = await createGroup({ name: 'AMUpdateTarget' });
-    const res = await app.inject({
+  it('managing AM can update; unmanaged AM gets 403', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'AMUpdateTarget' });
+    const ok = await app.inject({
       method: 'PUT',
       url: `/api/groups/${g.id}`,
       headers: { authorization: `Bearer ${amToken}` },
+      payload: { name: 'AMUpdated', enabled: true },
+    });
+    expect(ok.statusCode).toBe(200);
+
+    const forbidden = await app.inject({
+      method: 'PUT',
+      url: `/api/groups/${g.id}`,
+      headers: { authorization: `Bearer ${am2Token}` },
       payload: { name: 'Hacked', enabled: true },
     });
-    expect(res.statusCode).toBe(403);
+    expect(forbidden.statusCode).toBe(403);
   });
 });
 
@@ -311,14 +413,41 @@ describe('PUT /api/groups/:id', () => {
 // DELETE /api/groups/:id
 // ---------------------------------------------------------------------------
 describe('DELETE /api/groups/:id', () => {
-  it('admin deletes a group', async () => {
-    const g = await createGroup({ name: 'DeleteMe' });
+  it('admin deletes a group; memberships cascade but users survive', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'DeleteMe' });
+    await addUserToGroup(user1.id, g.id, assignment.id);
+
     const res = await app.inject({
       method: 'DELETE',
       url: `/api/groups/${g.id}`,
       headers: { authorization: `Bearer ${adminToken}` },
     });
     expect(res.statusCode).toBe(200);
+
+    const db = getPool();
+    const memberships = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE group_id = $1', [g.id]);
+    expect(memberships.rows[0].c).toBe(0);
+    const users = await db.query('SELECT COUNT(*)::int AS c FROM users WHERE id = $1', [user1.id]);
+    expect(users.rows[0].c).toBe(1);
+  });
+
+  it('managing AM can delete; unmanaged AM gets 403', async () => {
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'AMDel1' });
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'AMDel2' });
+
+    const forbidden = await app.inject({
+      method: 'DELETE',
+      url: `/api/groups/${g1.id}`,
+      headers: { authorization: `Bearer ${am2Token}` },
+    });
+    expect(forbidden.statusCode).toBe(403);
+
+    const ok = await app.inject({
+      method: 'DELETE',
+      url: `/api/groups/${g2.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(ok.statusCode).toBe(200);
   });
 
   it('returns 404 for non-existent group', async () => {
@@ -331,7 +460,7 @@ describe('DELETE /api/groups/:id', () => {
   });
 
   it('regular user cannot delete groups', async () => {
-    const g = await createGroup({ name: 'Protected' });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'Protected' });
     const res = await app.inject({
       method: 'DELETE',
       url: `/api/groups/${g.id}`,
@@ -346,8 +475,8 @@ describe('DELETE /api/groups/:id', () => {
 // ---------------------------------------------------------------------------
 describe('DELETE /api/groups/bulk', () => {
   it('admin bulk deletes groups', async () => {
-    const g1 = await createGroup({ name: 'BulkDel1' });
-    const g2 = await createGroup({ name: 'BulkDel2' });
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'BulkDel1' });
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'BulkDel2' });
     const res = await app.inject({
       method: 'DELETE',
       url: '/api/groups/bulk',
@@ -358,24 +487,64 @@ describe('DELETE /api/groups/bulk', () => {
     expect(JSON.parse(res.body).deleted).toBe(2);
   });
 
-  it('returns 400 for empty ids', async () => {
-    const res = await app.inject({
+  it('returns 400 for empty ids and invalid UUIDs', async () => {
+    const empty = await app.inject({
       method: 'DELETE',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: { ids: [] },
     });
-    expect(res.statusCode).toBe(400);
-  });
-
-  it('returns 400 for invalid UUIDs', async () => {
-    const res = await app.inject({
+    expect(empty.statusCode).toBe(400);
+    const invalid = await app.inject({
       method: 'DELETE',
       url: '/api/groups/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: { ids: ['not-valid'] },
     });
-    expect(res.statusCode).toBe(400);
+    expect(invalid.statusCode).toBe(400);
+  });
+
+  it('managing AM can bulk delete groups of their assignment', async () => {
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'AMBulkDel1' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { ids: [g1.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).deleted).toBe(1);
+  });
+
+  it('AM bulk delete including a group of an unmanaged assignment returns 403', async () => {
+    const a2 = await createAssignment({ subjectId: subject.id, name: 'A2' });
+    const managed = await createGroup({ assignmentId: assignment.id, name: 'ManagedG' });
+    const unmanaged = await createGroup({ assignmentId: a2.id, name: 'UnmanagedG' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { ids: [managed.id, unmanaged.id] },
+    });
+    expect(res.statusCode).toBe(403);
+
+    // Nothing was deleted
+    const db = getPool();
+    const remaining = await db.query('SELECT COUNT(*)::int AS c FROM groups WHERE id = ANY($1)', [
+      [managed.id, unmanaged.id],
+    ]);
+    expect(remaining.rows[0].c).toBe(2);
+  });
+
+  it('regular user cannot bulk delete groups', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'UserBulkDel' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/groups/bulk',
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { ids: [g.id] },
+    });
+    expect(res.statusCode).toBe(403);
   });
 });
 
@@ -383,8 +552,8 @@ describe('DELETE /api/groups/bulk', () => {
 // POST /api/groups/:id/join
 // ---------------------------------------------------------------------------
 describe('POST /api/groups/:id/join', () => {
-  it('user joins an enabled group', async () => {
-    const g = await createGroup({ name: 'Joinable', enabled: true });
+  it('subject member joins an enabled group', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'Joinable' });
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
@@ -394,8 +563,36 @@ describe('POST /api/groups/:id/join', () => {
     expect(JSON.parse(res.body).groupId).toBe(g.id);
   });
 
+  it('non-subject-member joining returns 403', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'MembersOnly' });
+    await createUser({ username: 'stranger', email: 'stranger@test.com' });
+    const strangerToken = await loginAs(app, 'stranger', 'TestPass123!');
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${strangerToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/not a member of this subject/i);
+  });
+
+  it('a user disabled after login cannot join (stale JWT) — 403 Account is disabled', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'NoDisabledJoin' });
+    // user1 logs in first, then is disabled; the JWT remains valid
+    await getPool().query('UPDATE users SET enabled = false WHERE id = $1', [user1.id]);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Account is disabled');
+    const { rows } = await getPool().query('SELECT 1 FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(rows).toHaveLength(0);
+  });
+
   it('returns 400 for disabled group', async () => {
-    const g = await createGroup({ name: 'Disabled', enabled: false });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'Disabled', enabled: false });
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
@@ -405,37 +602,61 @@ describe('POST /api/groups/:id/join', () => {
     expect(JSON.parse(res.body).error).toMatch(/disabled/i);
   });
 
-  it('returns 400 when user is already in a group', async () => {
-    const g1 = await createGroup({ name: 'FirstGroup' });
-    const g2 = await createGroup({ name: 'SecondGroup' });
-    // Join first group
-    await app.inject({
+  it('returns 409 when already in a group for the same assignment', async () => {
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'FirstGroup' });
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'SecondGroup' });
+    const join1 = await app.inject({
       method: 'POST',
       url: `/api/groups/${g1.id}/join`,
       headers: { authorization: `Bearer ${userToken}` },
     });
-    // Try to join second group
+    expect(join1.statusCode).toBe(200);
+
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g2.id}/join`,
       headers: { authorization: `Bearer ${userToken}` },
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body).error).toMatch(/already in a group/i);
   });
 
+  it('same user can join groups in two different assignments of the subject', async () => {
+    const a2 = await createAssignment({ subjectId: subject.id, name: 'A2' });
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'A1Group' });
+    const g2 = await createGroup({ assignmentId: a2.id, name: 'A2Group' });
+
+    const join1 = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g1.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(join1.statusCode).toBe(200);
+
+    const join2 = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g2.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(join2.statusCode).toBe(200);
+
+    const db = getPool();
+    const rows = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(rows.rows[0].c).toBe(2);
+  });
+
   it('returns 409 when group is at capacity', async () => {
-    const g = await createGroup({ name: 'FullGroup', maxMembers: 1 });
-    // First user fills the group
-    await createUser({ username: 'filler', email: 'filler@test.com' });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'FullGroup', maxMembers: 1 });
+    const filler = await createUser({ username: 'filler', email: 'filler@test.com' });
+    await addUserToSubject(filler.id, subject.id);
     const fToken = await loginAs(app, 'filler', 'TestPass123!');
-    await app.inject({
+    const fill = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
       headers: { authorization: `Bearer ${fToken}` },
     });
+    expect(fill.statusCode).toBe(200);
 
-    // user1 tries to join full group
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
@@ -454,10 +675,42 @@ describe('POST /api/groups/:id/join', () => {
     expect(res.statusCode).toBe(404);
   });
 
-  it('returns 401 without token', async () => {
-    const g = await createGroup({ name: 'NoAuthGroup' });
-    const res = await app.inject({ method: 'POST', url: `/api/groups/${g.id}/join` });
-    expect(res.statusCode).toBe(401);
+  it('returns 401 without token and 400 for invalid UUID', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'NoAuthGroup' });
+    const noAuth = await app.inject({ method: 'POST', url: `/api/groups/${g.id}/join` });
+    expect(noAuth.statusCode).toBe(401);
+    const badId = await app.inject({
+      method: 'POST',
+      url: '/api/groups/not-a-uuid/join',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(badId.statusCode).toBe(400);
+  });
+
+  it('group_join_locked blocks regular users but not an AM who is a subject member', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'LockedGroup' });
+    await addUserToSubject(am1.id, subject.id);
+    await app.inject({
+      method: 'PUT',
+      url: '/api/config/group_join_locked',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { value: 'true' },
+    });
+
+    const userRes = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(userRes.statusCode).toBe(403);
+    expect(JSON.parse(userRes.body).error).toMatch(/locked/i);
+
+    const amRes = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g.id}/join`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(amRes.statusCode).toBe(200);
   });
 });
 
@@ -466,7 +719,7 @@ describe('POST /api/groups/:id/join', () => {
 // ---------------------------------------------------------------------------
 describe('POST /api/groups/:id/leave', () => {
   it('user leaves their group', async () => {
-    const g = await createGroup({ name: 'LeaveGroup', enabled: true });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'LeaveGroup' });
     await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
@@ -479,10 +732,14 @@ describe('POST /api/groups/:id/leave', () => {
       headers: { authorization: `Bearer ${userToken}` },
     });
     expect(res.statusCode).toBe(200);
+
+    const db = getPool();
+    const rows = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(rows.rows[0].c).toBe(0);
   });
 
   it('returns 400 when user is not a member of this group', async () => {
-    const g = await createGroup({ name: 'NotMemberGroup' });
+    const g = await createGroup({ assignmentId: assignment.id, name: 'NotMemberGroup' });
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/leave`,
@@ -491,216 +748,41 @@ describe('POST /api/groups/:id/leave', () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/not a member/i);
   });
-});
 
-// ---------------------------------------------------------------------------
-// POST /api/groups/import-mappings
-// ---------------------------------------------------------------------------
-describe('POST /api/groups/import-mappings', () => {
-  it('admin imports user-group mappings', async () => {
-    const g = await createGroup({ name: 'MappingGroup', enabled: true });
-    await createUser({ username: 'mapuser', email: 'mapuser@test.com' });
+  it('a user disabled after login cannot leave (stale JWT) — 403 Account is disabled', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'NoDisabledLeave' });
+    await addUserToGroup(user1.id, g.id, assignment.id);
+    await getPool().query('UPDATE users SET enabled = false WHERE id = $1', [user1.id]);
     const res = await app.inject({
       method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        rows: [{ email: 'mapuser@test.com', groupName: 'MappingGroup' }],
-      },
+      url: `/api/groups/${g.id}/leave`,
+      headers: { authorization: `Bearer ${userToken}` },
     });
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).imported).toBe(1);
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Account is disabled');
+    const { rows } = await getPool().query('SELECT 1 FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(rows).toHaveLength(1);
   });
 
-  it('skips row when user not found', async () => {
-    await createGroup({ name: 'SkipGroup', enabled: true });
+  it('returns 400 when the user is in a different group of the same assignment', async () => {
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'ActualGroup' });
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'WrongGroup' });
+    await addUserToGroup(user1.id, g1.id, assignment.id);
     const res = await app.inject({
       method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { rows: [{ email: 'ghost@test.com', groupName: 'SkipGroup' }] },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(0);
-    expect(body.skipped.some((s) => s.reason === 'User not found')).toBe(true);
-  });
-
-  it('skips row when group not found', async () => {
-    await createUser({ username: 'orphan', email: 'orphan@test.com' });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { rows: [{ email: 'orphan@test.com', groupName: 'GhostGroup' }] },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).skipped.some((s) => s.reason === 'Group not found')).toBe(true);
-  });
-
-  it('skips admin users in mappings', async () => {
-    const g = await createGroup({ name: 'AdminMap' });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { rows: [{ email: 'admin@gap.local', groupName: g.name }] },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(0);
-    expect(body.skipped[0].reason).toMatch(/admin/i);
-  });
-
-  it('returns 400 for empty rows', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { rows: [] },
+      url: `/api/groups/${g2.id}/leave`,
+      headers: { authorization: `Bearer ${userToken}` },
     });
     expect(res.statusCode).toBe(400);
   });
 
-  it('regular user cannot import mappings', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${userToken}` },
-      payload: { rows: [{ email: 'a@test.com', groupName: 'G' }] },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// GET /api/groups/export-mappings
-// ---------------------------------------------------------------------------
-describe('GET /api/groups/export-mappings', () => {
-  it('admin exports user-group mappings', async () => {
-    const g = await createGroup({ name: 'ExportGroup', enabled: true });
-    const u = await createUser({ username: 'exportuser', email: 'export@test.com' });
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups/export-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(Array.isArray(body.mappings)).toBe(true);
-    expect(body.mappings.some((m) => m.email === 'export@test.com' && m.groupName === 'ExportGroup')).toBe(true);
-  });
-
-  it('assignment_manager can export mappings', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups/export-mappings',
-      headers: { authorization: `Bearer ${amToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-  });
-
-  it('returns empty array when no mappings exist', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups/export-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.mappings).toEqual([]);
-  });
-
-  it('regular user cannot export mappings', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/groups/export-mappings',
-      headers: { authorization: `Bearer ${userToken}` },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/groups/:id/join — disabled user
-// ---------------------------------------------------------------------------
-describe('POST /api/groups/:id/join — disabled user', () => {
-  it('disabled user attempting to join returns 403', async () => {
-    const g = await createGroup({ name: 'DisabledJoinGroup', enabled: true });
-    // Create user as enabled, get token, then disable the account
-    const u = await createUser({ username: 'disableduser', email: 'disabled@test.com' });
-    const disabledToken = await loginAs(app, 'disableduser', 'TestPass123!');
-
-    // Disable the user via admin
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { email: u.email, firstName: 'Dis', lastName: 'Abled', enabled: false },
-    });
-
-    const res = await app.inject({
-      method: 'POST',
-      url: `/api/groups/${g.id}/join`,
-      headers: { authorization: `Bearer ${disabledToken}` },
-    });
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toMatch(/disabled/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/groups/:id/leave — disabled user and locked system
-// ---------------------------------------------------------------------------
-describe('POST /api/groups/:id/leave — disabled user and locked system', () => {
-  it('disabled user attempting to leave returns 403', async () => {
-    const g = await createGroup({ name: 'DisabledLeaveGroup', enabled: true });
-    // Create user as enabled, join group, then disable
-    const u = await createUser({ username: 'disleave', email: 'disleave@test.com' });
-    const tempToken = await loginAs(app, 'disleave', 'TestPass123!');
-
-    // Join the group while enabled
-    await app.inject({
-      method: 'POST',
-      url: `/api/groups/${g.id}/join`,
-      headers: { authorization: `Bearer ${tempToken}` },
-    });
-
-    // Disable the user via admin
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { email: u.email, firstName: 'Dis', lastName: 'Leave', enabled: false },
-    });
-
-    // Try to leave while disabled (token still valid but account disabled)
-    const res = await app.inject({
-      method: 'POST',
-      url: `/api/groups/${g.id}/leave`,
-      headers: { authorization: `Bearer ${tempToken}` },
-    });
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toMatch(/disabled/i);
-  });
-
   it('user attempting to leave when group_join_locked=true returns 403', async () => {
-    const g = await createGroup({ name: 'LockedLeaveGroup', enabled: true });
-
-    // Join the group first
+    const g = await createGroup({ assignmentId: assignment.id, name: 'LockedLeaveGroup' });
     await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/join`,
       headers: { authorization: `Bearer ${userToken}` },
     });
-
-    // Lock group joining
     await app.inject({
       method: 'PUT',
       url: '/api/config/group_join_locked',
@@ -708,7 +790,6 @@ describe('POST /api/groups/:id/leave — disabled user and locked system', () =>
       payload: { value: 'true' },
     });
 
-    // Try to leave while locked
     const res = await app.inject({
       method: 'POST',
       url: `/api/groups/${g.id}/leave`,
@@ -716,118 +797,6 @@ describe('POST /api/groups/:id/leave — disabled user and locked system', () =>
     });
     expect(res.statusCode).toBe(403);
     expect(JSON.parse(res.body).error).toMatch(/locked/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// RBAC: AM on admin-only group endpoints
-// ---------------------------------------------------------------------------
-describe('RBAC: AM on admin-only group endpoints', () => {
-  it('DELETE /api/groups/:id with AM token returns 403', async () => {
-    const g = await createGroup({ name: 'AMDeleteTarget' });
-    const res = await app.inject({
-      method: 'DELETE',
-      url: `/api/groups/${g.id}`,
-      headers: { authorization: `Bearer ${amToken}` },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-
-  it('POST /api/groups/bulk with AM token returns 403', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/bulk',
-      headers: { authorization: `Bearer ${amToken}` },
-      payload: [{ name: 'AMBulkGroup' }],
-    });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/groups/:id — maxMembers boundary
-// ---------------------------------------------------------------------------
-describe('PUT /api/groups/:id — maxMembers boundary', () => {
-  it('setting maxMembers exactly equal to current member count succeeds', async () => {
-    const g = await createGroup({ name: 'BoundaryGroup', maxMembers: 10 });
-    // Add exactly 3 members
-    for (let i = 0; i < 3; i++) {
-      const u = await createUser({ username: `bnd${i}`, email: `bnd${i}@test.com` });
-      await app.inject({
-        method: 'PUT',
-        url: `/api/users/${u.id}/group`,
-        headers: { authorization: `Bearer ${adminToken}` },
-        payload: { groupId: g.id },
-      });
-    }
-    // Set maxMembers = 3 (exactly the current count)
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/groups/${g.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { name: 'BoundaryGroup', enabled: true, maxMembers: 3 },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).group.max_members).toBe(3);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/groups/import-mappings — full group error path
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// POST /api/groups/import-mappings — skip-action rows
-// ---------------------------------------------------------------------------
-describe('POST /api/groups/import-mappings — skip-action rows', () => {
-  it('rows with action=skip appear in the skipped response', async () => {
-    await createGroup({ name: 'SkipActionGroup', enabled: true });
-    await createUser({ username: 'skipuser', email: 'skipuser@test.com' });
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        rows: [
-          { email: 'skipuser@test.com', groupName: 'SkipActionGroup' },
-          { email: 'skipped@test.com', groupName: 'SkipActionGroup', action: 'skip', skipReason: 'Duplicate entry' },
-        ],
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(1);
-    expect(body.skipped.some((s) => s.email === 'skipped@test.com' && s.reason === 'Duplicate entry')).toBe(true);
-  });
-
-  it('skip-action row with no skipReason defaults to "Skipped"', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        rows: [{ email: 'noop@test.com', groupName: 'AnyGroup', action: 'skip' }],
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.skipped).toHaveLength(1);
-    expect(body.skipped[0].reason).toBe('Skipped');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/groups/:id/join and /leave — invalid UUID in path
-// ---------------------------------------------------------------------------
-describe('POST /api/groups/:id/join and /leave — invalid UUID', () => {
-  it('join with invalid UUID returns 400', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/not-a-uuid/join',
-      headers: { authorization: `Bearer ${userToken}` },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
   });
 
   it('leave with invalid UUID returns 400', async () => {
@@ -837,185 +806,46 @@ describe('POST /api/groups/:id/join and /leave — invalid UUID', () => {
       headers: { authorization: `Bearer ${userToken}` },
     });
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
   });
 });
 
-describe('POST /api/groups/import-mappings — full group error path', () => {
-  it('importing a user mapping to a full group records an error', async () => {
-    const g = await createGroup({ name: 'FullImportGroup', maxMembers: 1 });
-    // Fill the group with one member
-    const filler = await createUser({ username: 'filler', email: 'filler@test.com' });
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${filler.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-
-    // Try to import another user into the full group
-    await createUser({ username: 'overflow', email: 'overflow@test.com' });
+// ---------------------------------------------------------------------------
+// PUT /api/users/:id/group — universal subject-membership rule & replace
+// ---------------------------------------------------------------------------
+describe('PUT /api/users/:id/group — placement rules', () => {
+  it('admin placing a non-subject-member returns 403 (universal rule)', async () => {
+    const g = await createGroup({ assignmentId: assignment.id, name: 'RuleGroup' });
+    const outsider = await createUser({ username: 'outsider', email: 'outsider@test.com' });
     const res = await app.inject({
-      method: 'POST',
-      url: '/api/groups/import-mappings',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        rows: [{ email: 'overflow@test.com', groupName: 'FullImportGroup' }],
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(0);
-    expect(body.errors.length).toBe(1);
-    expect(body.errors[0].error).toMatch(/full/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DELETE /api/groups/:id — ON DELETE SET NULL cascade on members
-// ---------------------------------------------------------------------------
-describe('DELETE /api/groups/:id — member detachment (ON DELETE SET NULL)', () => {
-  it('detaches members (group_id null) instead of deleting them when the group is deleted', async () => {
-    const g = await createGroup({ name: 'CascadeGroup' });
-    const m1 = await createUser({ username: 'cascade1', email: 'cascade1@test.com' });
-    const m2 = await createUser({ username: 'cascade2', email: 'cascade2@test.com' });
-
-    // Assign both members to the group
-    for (const m of [m1, m2]) {
-      const assignRes = await app.inject({
-        method: 'PUT',
-        url: `/api/users/${m.id}/group`,
-        headers: { authorization: `Bearer ${adminToken}` },
-        payload: { groupId: g.id },
-      });
-      expect(assignRes.statusCode).toBe(200);
-    }
-
-    // Delete the group
-    const delRes = await app.inject({
-      method: 'DELETE',
-      url: `/api/groups/${g.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(delRes.statusCode).toBe(200);
-
-    // Each member must still exist with group_id now null
-    for (const m of [m1, m2]) {
-      const getRes = await app.inject({
-        method: 'GET',
-        url: `/api/users/${m.id}`,
-        headers: { authorization: `Bearer ${adminToken}` },
-      });
-      expect(getRes.statusCode).toBe(200);
-      expect(JSON.parse(getRes.body).user.group_id).toBeNull();
-    }
-
-    // Both detached members should now appear under groupId=none
-    const noneRes = await app.inject({
-      method: 'GET',
-      url: '/api/users?groupId=none',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(noneRes.statusCode).toBe(200);
-    const ungrouped = JSON.parse(noneRes.body).users;
-    expect(ungrouped.some((u) => u.username === 'cascade1')).toBe(true);
-    expect(ungrouped.some((u) => u.username === 'cascade2')).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DELETE /api/groups/bulk — ON DELETE SET NULL cascade on members
-// ---------------------------------------------------------------------------
-describe('DELETE /api/groups/bulk — member detachment (ON DELETE SET NULL)', () => {
-  it('bulk delete detaches members of every deleted group rather than deleting them', async () => {
-    const g1 = await createGroup({ name: 'BulkCascade1' });
-    const g2 = await createGroup({ name: 'BulkCascade2' });
-    const m1 = await createUser({ username: 'bulkcasc1', email: 'bulkcasc1@test.com' });
-    const m2 = await createUser({ username: 'bulkcasc2', email: 'bulkcasc2@test.com' });
-
-    await app.inject({
       method: 'PUT',
-      url: `/api/users/${m1.id}/group`,
+      url: `/api/users/${outsider.id}/group`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g1.id },
+      payload: { assignmentId: assignment.id, groupId: g.id },
     });
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${m2.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g2.id },
-    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/not a member of this subject/i);
+  });
+
+  it('admin reassigns a user to another group in the same assignment (replace)', async () => {
+    const g1 = await createGroup({ assignmentId: assignment.id, name: 'FromGroup' });
+    const g2 = await createGroup({ assignmentId: assignment.id, name: 'ToGroup' });
+    await addUserToGroup(user1.id, g1.id, assignment.id);
 
     const res = await app.inject({
-      method: 'DELETE',
-      url: '/api/groups/bulk',
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { ids: [g1.id, g2.id] },
+      payload: { assignmentId: assignment.id, groupId: g2.id },
     });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).deleted).toBe(2);
+    expect(JSON.parse(res.body).user.groupId).toBe(g2.id);
 
-    for (const m of [m1, m2]) {
-      const getRes = await app.inject({
-        method: 'GET',
-        url: `/api/users/${m.id}`,
-        headers: { authorization: `Bearer ${adminToken}` },
-      });
-      expect(getRes.statusCode).toBe(200);
-      expect(JSON.parse(getRes.body).user.group_id).toBeNull();
-    }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DELETE /api/groups/:id — scoped deletion / member_count consistency
-// ---------------------------------------------------------------------------
-describe('DELETE /api/groups/:id — scoped deletion preserves other groups', () => {
-  it('deleting a different empty group leaves the populated group and its memberCount intact', async () => {
-    const populated = await createGroup({ name: 'PopulatedGroup' });
-    const empty = await createGroup({ name: 'EmptyGroup' });
-    const member = await createUser({ username: 'scopedmember', email: 'scoped@test.com' });
-
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${member.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: populated.id },
-    });
-
-    // Delete the unrelated empty group
-    const delEmpty = await app.inject({
-      method: 'DELETE',
-      url: `/api/groups/${empty.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(delEmpty.statusCode).toBe(200);
-
-    // The populated group is untouched and still reports its single member
-    const getPopulated = await app.inject({
-      method: 'GET',
-      url: `/api/groups/${populated.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(getPopulated.statusCode).toBe(200);
-    const populatedBody = JSON.parse(getPopulated.body);
-    expect(populatedBody.group.memberCount).toBe(1);
-    expect(populatedBody.members).toHaveLength(1);
-
-    // Now delete the populated group; member is detached, not deleted
-    const delPopulated = await app.inject({
-      method: 'DELETE',
-      url: `/api/groups/${populated.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(delPopulated.statusCode).toBe(200);
-
-    const getMember = await app.inject({
-      method: 'GET',
-      url: `/api/users/${member.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(getMember.statusCode).toBe(200);
-    expect(JSON.parse(getMember.body).user.group_id).toBeNull();
+    const db = getPool();
+    const rows = await db.query('SELECT group_id FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      user1.id,
+      assignment.id,
+    ]);
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].group_id).toBe(g2.id);
   });
 });

--- a/backend/tests/integration/groups.test.js
+++ b/backend/tests/integration/groups.test.js
@@ -573,7 +573,7 @@ describe('POST /api/groups/:id/join', () => {
       headers: { authorization: `Bearer ${strangerToken}` },
     });
     expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toMatch(/not a member of this subject/i);
+    expect(JSON.parse(res.body).error).toMatch(/not an active member of this subject/i);
   });
 
   it('a user disabled after login cannot join (stale JWT) — 403 Account is disabled', async () => {
@@ -823,7 +823,7 @@ describe('PUT /api/users/:id/group — placement rules', () => {
       payload: { assignmentId: assignment.id, groupId: g.id },
     });
     expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toMatch(/not a member of this subject/i);
+    expect(JSON.parse(res.body).error).toMatch(/not an active member of this subject/i);
   });
 
   it('admin reassigns a user to another group in the same assignment (replace)', async () => {

--- a/backend/tests/integration/helpers/db.js
+++ b/backend/tests/integration/helpers/db.js
@@ -2,7 +2,8 @@
 
 /**
  * Database helpers for integration tests.
- * Provides truncation utilities to keep tests isolated.
+ * Provides truncation utilities and direct-INSERT factories for the
+ * subject → assignment → group hierarchy to keep tests isolated.
  */
 
 const { Pool } = require('pg');
@@ -26,16 +27,20 @@ function getPool() {
 }
 
 /**
- * Truncates test data tables, preserving seed data (roles, admin user).
+ * Deletes test data in FK-safe order, preserving seed data (roles, admin user).
  * Call in beforeEach to guarantee a clean state between tests.
  */
 async function cleanDatabase() {
   const db = getPool();
-  // Order matters: users references groups and roles
   await db.query(`
     DELETE FROM password_reset_tokens WHERE TRUE;
+    DELETE FROM user_groups WHERE TRUE;
+    DELETE FROM assignment_managers WHERE TRUE;
+    DELETE FROM user_subjects WHERE TRUE;
     DELETE FROM users WHERE username != 'admin';
     DELETE FROM groups WHERE TRUE;
+    DELETE FROM assignments WHERE TRUE;
+    DELETE FROM subjects WHERE TRUE;
     DELETE FROM config WHERE TRUE;
   `);
 }
@@ -69,15 +74,72 @@ async function createUser({
 }
 
 /**
- * Create a group directly in the DB.
+ * Create a subject directly in the DB.
  */
-async function createGroup({ name, enabled = true, maxMembers = null }) {
+async function createSubject({ name }) {
   const db = getPool();
-  const { rows } = await db.query('INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *', [
+  const { rows } = await db.query('INSERT INTO subjects (name) VALUES ($1) RETURNING *', [name]);
+  return rows[0];
+}
+
+/**
+ * Create an assignment directly in the DB.
+ */
+async function createAssignment({ subjectId, name }) {
+  const db = getPool();
+  const { rows } = await db.query('INSERT INTO assignments (subject_id, name) VALUES ($1, $2) RETURNING *', [
+    subjectId,
     name,
-    enabled,
-    maxMembers,
   ]);
+  return rows[0];
+}
+
+/**
+ * Create a group directly in the DB (requires a parent assignment).
+ */
+async function createGroup({ assignmentId, name, enabled = true, maxMembers = null }) {
+  const db = getPool();
+  const { rows } = await db.query(
+    'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+    [assignmentId, name, enabled, maxMembers]
+  );
+  return rows[0];
+}
+
+/**
+ * Enrol a user in a subject directly in the DB.
+ */
+async function addUserToSubject(userId, subjectId) {
+  const db = getPool();
+  const { rows } = await db.query('INSERT INTO user_subjects (user_id, subject_id) VALUES ($1, $2) RETURNING *', [
+    userId,
+    subjectId,
+  ]);
+  return rows[0];
+}
+
+/**
+ * Make a user the manager of an assignment directly in the DB.
+ */
+async function assignManager(userId, assignmentId) {
+  const db = getPool();
+  const { rows } = await db.query(
+    'INSERT INTO assignment_managers (user_id, assignment_id) VALUES ($1, $2) RETURNING *',
+    [userId, assignmentId]
+  );
+  return rows[0];
+}
+
+/**
+ * Place a user in a group for an assignment directly in the DB
+ * (bypasses the application-layer subject-membership/capacity checks).
+ */
+async function addUserToGroup(userId, groupId, assignmentId) {
+  const db = getPool();
+  const { rows } = await db.query(
+    'INSERT INTO user_groups (user_id, group_id, assignment_id) VALUES ($1, $2, $3) RETURNING *',
+    [userId, groupId, assignmentId]
+  );
   return rows[0];
 }
 
@@ -101,4 +163,16 @@ async function closePool() {
   }
 }
 
-module.exports = { cleanDatabase, createUser, createGroup, loginAs, closePool, getPool };
+module.exports = {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  closePool,
+  getPool,
+};

--- a/backend/tests/integration/helpers/db.js
+++ b/backend/tests/integration/helpers/db.js
@@ -107,14 +107,15 @@ async function createGroup({ assignmentId, name, enabled = true, maxMembers = nu
 }
 
 /**
- * Enrol a user in a subject directly in the DB.
+ * Enrol a user in a subject directly in the DB (enabled = false creates a
+ * suspended membership).
  */
-async function addUserToSubject(userId, subjectId) {
+async function addUserToSubject(userId, subjectId, enabled = true) {
   const db = getPool();
-  const { rows } = await db.query('INSERT INTO user_subjects (user_id, subject_id) VALUES ($1, $2) RETURNING *', [
-    userId,
-    subjectId,
-  ]);
+  const { rows } = await db.query(
+    'INSERT INTO user_subjects (user_id, subject_id, enabled) VALUES ($1, $2, $3) RETURNING *',
+    [userId, subjectId, enabled]
+  );
   return rows[0];
 }
 

--- a/backend/tests/integration/subjects.test.js
+++ b/backend/tests/integration/subjects.test.js
@@ -1,0 +1,637 @@
+'use strict';
+
+const { buildTestServer, closeTestServer } = require('./helpers/server');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  getPool,
+} = require('./helpers/db');
+
+let app;
+let adminToken;
+let amToken;
+let userToken;
+let am1;
+let user1;
+
+beforeAll(async () => {
+  app = await buildTestServer();
+});
+
+afterAll(async () => {
+  await closeTestServer(app);
+});
+
+beforeEach(async () => {
+  await cleanDatabase();
+  adminToken = await loginAs(app, 'admin', 'AdminPass123!');
+
+  am1 = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  amToken = await loginAs(app, 'am1', 'TestPass123!');
+
+  user1 = await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  userToken = await loginAs(app, 'user1', 'TestPass123!');
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/subjects
+// ---------------------------------------------------------------------------
+describe('GET /api/subjects', () => {
+  it('returns 401 without token', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/subjects' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('admin sees all subjects with counts', async () => {
+    const s1 = await createSubject({ name: 'COMP10001' });
+    await createSubject({ name: 'COMP20002' });
+    await createAssignment({ subjectId: s1.id, name: 'A1' });
+    await addUserToSubject(user1.id, s1.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.subjects).toHaveLength(2);
+    const comp1 = body.subjects.find((s) => s.name === 'COMP10001');
+    expect(comp1.assignment_count).toBe(1);
+    expect(comp1.member_count).toBe(1);
+  });
+
+  it('assignment manager sees only subjects with managed assignments or own membership', async () => {
+    const managed = await createSubject({ name: 'ManagedSubject' });
+    const memberOf = await createSubject({ name: 'MemberSubject' });
+    await createSubject({ name: 'UnrelatedSubject' });
+    const a1 = await createAssignment({ subjectId: managed.id, name: 'A1' });
+    await assignManager(am1.id, a1.id);
+    await addUserToSubject(am1.id, memberOf.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).subjects.map((s) => s.name);
+    expect(names).toContain('ManagedSubject');
+    expect(names).toContain('MemberSubject');
+    expect(names).not.toContain('UnrelatedSubject');
+  });
+
+  it('regular user sees only subjects they are a member of', async () => {
+    const mine = await createSubject({ name: 'MySubject' });
+    await createSubject({ name: 'OtherSubject' });
+    await addUserToSubject(user1.id, mine.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = JSON.parse(res.body).subjects.map((s) => s.name);
+    expect(names).toEqual(['MySubject']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/subjects/:id
+// ---------------------------------------------------------------------------
+describe('GET /api/subjects/:id', () => {
+  it('admin gets subject with its assignments', async () => {
+    const s = await createSubject({ name: 'DetailSubject' });
+    await createAssignment({ subjectId: s.id, name: 'A1' });
+    await createAssignment({ subjectId: s.id, name: 'A2' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.subject.name).toBe('DetailSubject');
+    expect(body.assignments).toHaveLength(2);
+    expect(body.assignments.map((a) => a.name).sort()).toEqual(['A1', 'A2']);
+  });
+
+  it('subject member can view the subject', async () => {
+    const s = await createSubject({ name: 'MemberViewSubject' });
+    await addUserToSubject(user1.id, s.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('non-member user gets 403', async () => {
+    const s = await createSubject({ name: 'PrivateSubject' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('AM managing an assignment in the subject can view it', async () => {
+    const s = await createSubject({ name: 'AMViewSubject' });
+    const a = await createAssignment({ subjectId: s.id, name: 'A1' });
+    await assignManager(am1.id, a.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('AM with no managed assignment in the subject gets 403', async () => {
+    const s = await createSubject({ name: 'AMNoAccessSubject' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects/not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for non-existent subject', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/subjects
+// ---------------------------------------------------------------------------
+describe('POST /api/subjects', () => {
+  it('admin creates a subject', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'NewSubject' },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.subject.name).toBe('NewSubject');
+    expect(body.subject.id).toBeDefined();
+  });
+
+  it('returns 409 for duplicate name', async () => {
+    await createSubject({ name: 'DupSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'DupSubject' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('duplicate check is case-insensitive', async () => {
+    await createSubject({ name: 'CaseSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'casesubject' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('returns 400 for missing name', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 for assignment manager', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { name: 'AMSubject' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 403 for regular user', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects',
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { name: 'UserSubject' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await app.inject({ method: 'POST', url: '/api/subjects', payload: { name: 'NoAuth' } });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/subjects/:id
+// ---------------------------------------------------------------------------
+describe('PUT /api/subjects/:id', () => {
+  it('admin renames a subject', async () => {
+    const s = await createSubject({ name: 'OldSubjectName' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'NewSubjectName' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).subject.name).toBe('NewSubjectName');
+  });
+
+  it('renaming to an existing name (case-insensitive) returns 409', async () => {
+    await createSubject({ name: 'TakenName' });
+    const s = await createSubject({ name: 'RenameMe' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'takenname' },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('updating with the unchanged name succeeds', async () => {
+    const s = await createSubject({ name: 'SameName' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'SameName' },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/subjects/not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'X' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const s = await createSubject({ name: 'BadBodySubject' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for non-existent subject', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/subjects/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { name: 'Ghost' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 for assignment manager', async () => {
+    const s = await createSubject({ name: 'AMUpdateSubject' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { name: 'Hacked' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/subjects/:id
+// ---------------------------------------------------------------------------
+describe('DELETE /api/subjects/:id', () => {
+  it('admin deletes a subject', async () => {
+    const s = await createSubject({ name: 'DeleteMe' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('cascades assignments, groups and memberships but NOT users', async () => {
+    const s = await createSubject({ name: 'CascadeSubject' });
+    const a = await createAssignment({ subjectId: s.id, name: 'A1' });
+    const g = await createGroup({ assignmentId: a.id, name: 'G1' });
+    await addUserToSubject(user1.id, s.id);
+    await addUserToGroup(user1.id, g.id, a.id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const db = getPool();
+    const assignments = await db.query('SELECT COUNT(*)::int AS c FROM assignments WHERE subject_id = $1', [s.id]);
+    expect(assignments.rows[0].c).toBe(0);
+    const groups = await db.query('SELECT COUNT(*)::int AS c FROM groups WHERE id = $1', [g.id]);
+    expect(groups.rows[0].c).toBe(0);
+    const userGroups = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(userGroups.rows[0].c).toBe(0);
+    const userSubjects = await db.query('SELECT COUNT(*)::int AS c FROM user_subjects WHERE subject_id = $1', [s.id]);
+    expect(userSubjects.rows[0].c).toBe(0);
+    // The user itself survives
+    const users = await db.query('SELECT COUNT(*)::int AS c FROM users WHERE id = $1', [user1.id]);
+    expect(users.rows[0].c).toBe(1);
+  });
+
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/subjects/not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for non-existent subject', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/subjects/00000000-0000-0000-0000-000000000000',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 for regular user', async () => {
+    const s = await createSubject({ name: 'ProtectedSubject' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/subjects/:id/users
+// ---------------------------------------------------------------------------
+describe('GET /api/subjects/:id/users', () => {
+  it('admin lists subject members', async () => {
+    const s = await createSubject({ name: 'MembersSubject' });
+    await addUserToSubject(user1.id, s.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].username).toBe('user1');
+  });
+
+  it('AM managing an assignment in the subject can list members', async () => {
+    const s = await createSubject({ name: 'AMMembersSubject' });
+    const a = await createAssignment({ subjectId: s.id, name: 'A1' });
+    await assignManager(am1.id, a.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('AM not managing in the subject gets 403', async () => {
+    const s = await createSubject({ name: 'ForeignSubject' });
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('regular user (even a member) gets 403', async () => {
+    const s = await createSubject({ name: 'MemberButNoList' });
+    await addUserToSubject(user1.id, s.id);
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 404 for non-existent subject', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/subjects/00000000-0000-0000-0000-000000000000/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/subjects/:id/users
+// ---------------------------------------------------------------------------
+describe('POST /api/subjects/:id/users', () => {
+  it('admin adds users to a subject', async () => {
+    const s = await createSubject({ name: 'AddUsersSubject' });
+    const u2 = await createUser({ username: 'user2', email: 'user2@test.com' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id, u2.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).added).toBe(2);
+
+    const listRes = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const usernames = JSON.parse(listRes.body).users.map((u) => u.username);
+    expect(usernames.sort()).toEqual(['user1', 'user2']);
+  });
+
+  it('re-adding an existing member is idempotent (added 0)', async () => {
+    const s = await createSubject({ name: 'IdempotentSubject' });
+    await addUserToSubject(user1.id, s.id);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).added).toBe(0);
+  });
+
+  it('returns 400 when a user does not exist', async () => {
+    const s = await createSubject({ name: 'GhostUserSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: ['00000000-0000-0000-0000-000000000000'] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/do not exist/i);
+  });
+
+  it('returns 400 for empty userIds', async () => {
+    const s = await createSubject({ name: 'EmptyIdsSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for non-existent subject', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/subjects/00000000-0000-0000-0000-000000000000/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 for assignment manager', async () => {
+    const s = await createSubject({ name: 'AMAddSubject' });
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/subjects/${s.id}/users`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/subjects/:id/users/:userId
+// ---------------------------------------------------------------------------
+describe('DELETE /api/subjects/:id/users/:userId', () => {
+  it('admin removes a member; group memberships within the subject are deleted', async () => {
+    const s1 = await createSubject({ name: 'RemovalSubject' });
+    const s2 = await createSubject({ name: 'KeptSubject' });
+    const a1 = await createAssignment({ subjectId: s1.id, name: 'A1' });
+    const a2 = await createAssignment({ subjectId: s2.id, name: 'A2' });
+    const g1 = await createGroup({ assignmentId: a1.id, name: 'G1' });
+    const g2 = await createGroup({ assignmentId: a2.id, name: 'G2' });
+    await addUserToSubject(user1.id, s1.id);
+    await addUserToSubject(user1.id, s2.id);
+    await addUserToGroup(user1.id, g1.id, a1.id);
+    await addUserToGroup(user1.id, g2.id, a2.id);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const db = getPool();
+    // Membership in s1's assignment group removed…
+    const inS1 = await db.query(
+      'SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1 AND assignment_id = $2',
+      [user1.id, a1.id]
+    );
+    expect(inS1.rows[0].c).toBe(0);
+    // …but the membership in the other subject's assignment survives
+    const inS2 = await db.query(
+      'SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1 AND assignment_id = $2',
+      [user1.id, a2.id]
+    );
+    expect(inS2.rows[0].c).toBe(1);
+    // Subject enrolment removed
+    const enrolled = await db.query(
+      'SELECT COUNT(*)::int AS c FROM user_subjects WHERE user_id = $1 AND subject_id = $2',
+      [user1.id, s1.id]
+    );
+    expect(enrolled.rows[0].c).toBe(0);
+  });
+
+  it('returns 404 when the user is not a member', async () => {
+    const s = await createSubject({ name: 'NotMemberSubject' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toMatch(/not a member/i);
+  });
+
+  it('returns 400 for invalid user UUID', async () => {
+    const s = await createSubject({ name: 'BadUserIdSubject' });
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}/users/not-a-uuid`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 403 for assignment manager', async () => {
+    const s = await createSubject({ name: 'AMRemoveSubject' });
+    await addUserToSubject(user1.id, s.id);
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/subjects/${s.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/tests/integration/subjects.test.js
+++ b/backend/tests/integration/subjects.test.js
@@ -560,6 +560,239 @@ describe('POST /api/subjects/:id/users', () => {
 });
 
 // ---------------------------------------------------------------------------
+// PUT /api/subjects/:id/users/:userId — per-subject membership suspension
+// ---------------------------------------------------------------------------
+describe('PUT /api/subjects/:id/users/:userId', () => {
+  let s1;
+  let s2;
+  let a1;
+  let a2;
+  let g1;
+  let g2;
+
+  beforeEach(async () => {
+    s1 = await createSubject({ name: 'SuspendSubject' });
+    s2 = await createSubject({ name: 'OtherSubject' });
+    a1 = await createAssignment({ subjectId: s1.id, name: 'A1' });
+    a2 = await createAssignment({ subjectId: s2.id, name: 'A2' });
+    g1 = await createGroup({ assignmentId: a1.id, name: 'G1' });
+    g2 = await createGroup({ assignmentId: a2.id, name: 'G2' });
+    await assignManager(am1.id, a1.id);
+    await addUserToSubject(user1.id, s1.id);
+    await addUserToSubject(user1.id, s2.id);
+    await addUserToGroup(user1.id, g1.id, a1.id);
+    await addUserToGroup(user1.id, g2.id, a2.id);
+  });
+
+  it('managing AM suspends a member end-to-end; re-enable restores the subject but not the group', async () => {
+    // AM suspends user1 in the managed subject
+    const suspendRes = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { enabled: false },
+    });
+    expect(suspendRes.statusCode).toBe(200);
+    expect(JSON.parse(suspendRes.body)).toEqual({ message: 'Member suspended', membershipEnabled: false });
+
+    const db = getPool();
+    // Group membership within the suspended subject is deleted…
+    const inS1 = await db.query(
+      'SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1 AND assignment_id = $2',
+      [user1.id, a1.id]
+    );
+    expect(inS1.rows[0].c).toBe(0);
+    // …but the membership in the other subject survives
+    const inS2 = await db.query(
+      'SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1 AND assignment_id = $2',
+      [user1.id, a2.id]
+    );
+    expect(inS2.rows[0].c).toBe(1);
+    // The enrolment row itself survives, flagged as disabled
+    const enrolment = await db.query('SELECT enabled FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
+      user1.id,
+      s1.id,
+    ]);
+    expect(enrolment.rows).toHaveLength(1);
+    expect(enrolment.rows[0].enabled).toBe(false);
+
+    // The member's own session no longer lists the suspended subject
+    const meRes = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    const meSubjects = JSON.parse(meRes.body).user.subjects.map((s) => s.name);
+    expect(meSubjects).not.toContain('SuspendSubject');
+    expect(meSubjects).toContain('OtherSubject');
+
+    // Self-join into a group of the suspended subject is rejected
+    const joinRes = await app.inject({
+      method: 'POST',
+      url: `/api/groups/${g1.id}/join`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(joinRes.statusCode).toBe(403);
+    expect(JSON.parse(joinRes.body).error).toMatch(/not an active member/i);
+
+    // Re-enable restores subject visibility, but the user stays ungrouped
+    const enableRes = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { enabled: true },
+    });
+    expect(enableRes.statusCode).toBe(200);
+    expect(JSON.parse(enableRes.body)).toEqual({ message: 'Member enabled', membershipEnabled: true });
+
+    const meAfter = await app.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    const afterBody = JSON.parse(meAfter.body).user;
+    expect(afterBody.subjects.map((s) => s.name)).toContain('SuspendSubject');
+    expect(afterBody.memberships.filter((m) => m.assignment_id === a1.id)).toHaveLength(0);
+  });
+
+  it('admin can suspend and re-enable a member', async () => {
+    const suspendRes = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+    expect(suspendRes.statusCode).toBe(200);
+    expect(JSON.parse(suspendRes.body).membershipEnabled).toBe(false);
+
+    const enableRes = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: true },
+    });
+    expect(enableRes.statusCode).toBe(200);
+    expect(JSON.parse(enableRes.body).membershipEnabled).toBe(true);
+  });
+
+  it('suspended member gets 403 on GET /subjects/:id', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/subjects/${s1.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('admin placing a suspended member into a group returns 403', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: a1.id, groupId: g1.id },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/not an active member/i);
+  });
+
+  it('returns 401 without token and 403 for a regular user', async () => {
+    const noToken = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      payload: { enabled: false },
+    });
+    expect(noToken.statusCode).toBe(401);
+
+    const forbidden = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { enabled: false },
+    });
+    expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('AM not managing any assignment in the subject gets 403', async () => {
+    // user1 is enrolled in s2, but am1 manages no assignment there
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s2.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { enabled: false },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 400 for invalid UUIDs and invalid body', async () => {
+    const badSubject = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/not-a-uuid/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+    expect(badSubject.statusCode).toBe(400);
+
+    const badUser = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/not-a-uuid`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+    expect(badUser.statusCode).toBe(400);
+
+    const missingEnabled = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(missingEnabled.statusCode).toBe(400);
+
+    const nonBoolean = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: 'false' },
+    });
+    expect(nonBoolean.statusCode).toBe(400);
+  });
+
+  it('returns 404 for a non-existent subject and for a non-member user', async () => {
+    const ghostSubject = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/00000000-0000-0000-0000-000000000000/users/${user1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+    expect(ghostSubject.statusCode).toBe(404);
+
+    const notMember = await createUser({ username: 'notmember', email: 'notmember@test.com' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/subjects/${s1.id}/users/${notMember.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { enabled: false },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toBe('User is not a member of this subject');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // DELETE /api/subjects/:id/users/:userId
 // ---------------------------------------------------------------------------
 describe('DELETE /api/subjects/:id/users/:userId', () => {

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -1,12 +1,29 @@
 'use strict';
 
 const { buildTestServer, closeTestServer } = require('./helpers/server');
-const { cleanDatabase, createUser, createGroup, loginAs, getPool } = require('./helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createGroup,
+  addUserToSubject,
+  assignManager,
+  addUserToGroup,
+  loginAs,
+  getPool,
+} = require('./helpers/db');
 
 let app;
 let adminToken;
-let amToken; // assignment_manager token
+let amToken; // manages assignment1 (in subject1)
 let userToken;
+let am1;
+let user1;
+let subject1;
+let subject2;
+let assignment1;
+let assignment2;
 
 beforeAll(async () => {
   app = await buildTestServer();
@@ -20,11 +37,17 @@ beforeEach(async () => {
   await cleanDatabase();
   adminToken = await loginAs(app, 'admin', 'AdminPass123!');
 
-  // Seed a fresh assignment_manager and regular user for each test
-  await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  subject1 = await createSubject({ name: 'Subject1' });
+  subject2 = await createSubject({ name: 'Subject2' });
+  assignment1 = await createAssignment({ subjectId: subject1.id, name: 'A1' });
+  assignment2 = await createAssignment({ subjectId: subject2.id, name: 'A2' });
+
+  am1 = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+  await assignManager(am1.id, assignment1.id);
   amToken = await loginAs(app, 'am1', 'TestPass123!');
 
-  await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  user1 = await createUser({ username: 'user1', email: 'user1@test.com', role: 'user' });
+  await addUserToSubject(user1.id, subject1.id);
   userToken = await loginAs(app, 'user1', 'TestPass123!');
 });
 
@@ -32,7 +55,10 @@ beforeEach(async () => {
 // GET /api/users
 // ---------------------------------------------------------------------------
 describe('GET /api/users', () => {
-  it('admin can list all users', async () => {
+  it('admin can list all users with subjects and memberships enrichment', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'EnrichGroup' });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
+
     const res = await app.inject({
       method: 'GET',
       url: '/api/users',
@@ -41,82 +67,162 @@ describe('GET /api/users', () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(Array.isArray(body.users)).toBe(true);
-    expect(body.users.length).toBeGreaterThanOrEqual(1);
+
+    const u1 = body.users.find((u) => u.username === 'user1');
+    expect(u1.subjects.map((s) => s.name)).toEqual(['Subject1']);
+    expect(u1.memberships).toHaveLength(1);
+    expect(u1.memberships[0].group_id).toBe(g.id);
+    expect(u1.memberships[0].assignment_id).toBe(assignment1.id);
+    expect(u1.memberships[0].group_name).toBe('EnrichGroup');
+
+    const admin = body.users.find((u) => u.username === 'admin');
+    expect(admin.subjects).toEqual([]);
+    expect(admin.memberships).toEqual([]);
   });
 
-  it('assignment_manager can list users', async () => {
+  it('AM sees only users in subjects containing their managed assignments', async () => {
+    const s2only = await createUser({ username: 's2only', email: 's2only@test.com' });
+    await addUserToSubject(s2only.id, subject2.id);
+
     const res = await app.inject({
       method: 'GET',
       url: '/api/users',
       headers: { authorization: `Bearer ${amToken}` },
     });
     expect(res.statusCode).toBe(200);
+    const usernames = JSON.parse(res.body).users.map((u) => u.username);
+    expect(usernames).toContain('user1');
+    expect(usernames).not.toContain('s2only');
+
+    // Admin sees both
+    const adminRes = await app.inject({
+      method: 'GET',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    const allUsernames = JSON.parse(adminRes.body).users.map((u) => u.username);
+    expect(allUsernames).toContain('user1');
+    expect(allUsernames).toContain('s2only');
   });
 
-  it('regular user cannot list all users', async () => {
-    const res = await app.inject({
+  it('regular user cannot list users and 401 without token', async () => {
+    const forbidden = await app.inject({
       method: 'GET',
       url: '/api/users',
       headers: { authorization: `Bearer ${userToken}` },
     });
-    expect(res.statusCode).toBe(403);
+    expect(forbidden.statusCode).toBe(403);
+    const noToken = await app.inject({ method: 'GET', url: '/api/users' });
+    expect(noToken.statusCode).toBe(401);
   });
 
-  it('returns 401 without token', async () => {
-    const res = await app.inject({ method: 'GET', url: '/api/users' });
-    expect(res.statusCode).toBe(401);
-  });
-
-  it('filters by role', async () => {
-    const res = await app.inject({
+  it('filters by role and status; rejects invalid values', async () => {
+    const byRole = await app.inject({
       method: 'GET',
       url: '/api/users?role=admin',
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.users.every((u) => u.role_name === 'admin')).toBe(true);
-  });
+    expect(byRole.statusCode).toBe(200);
+    expect(JSON.parse(byRole.body).users.every((u) => u.role_name === 'admin')).toBe(true);
 
-  it('returns 400 for invalid role filter', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/users?role=superadmin',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(400);
-  });
-
-  it('filters by status=active', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/users?status=active',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.users.every((u) => u.status === 'active')).toBe(true);
-  });
-
-  it('filters by combined role + status', async () => {
-    const res = await app.inject({
+    const byStatus = await app.inject({
       method: 'GET',
       url: '/api/users?role=user&status=active',
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.users.every((u) => u.role_name === 'user' && u.status === 'active')).toBe(true);
-    expect(body.users.length).toBeGreaterThan(0);
-  });
+    expect(byStatus.statusCode).toBe(200);
+    const users = JSON.parse(byStatus.body).users;
+    expect(users.length).toBeGreaterThan(0);
+    expect(users.every((u) => u.role_name === 'user' && u.status === 'active')).toBe(true);
 
-  it('returns 400 for invalid status filter', async () => {
-    const res = await app.inject({
+    const badRole = await app.inject({
+      method: 'GET',
+      url: '/api/users?role=superadmin',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(badRole.statusCode).toBe(400);
+    const badStatus = await app.inject({
       method: 'GET',
       url: '/api/users?status=unknown',
       headers: { authorization: `Bearer ${adminToken}` },
     });
+    expect(badStatus.statusCode).toBe(400);
+  });
+
+  it('filters by subjectId', async () => {
+    const s2user = await createUser({ username: 's2user', email: 's2user@test.com' });
+    await addUserToSubject(s2user.id, subject2.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/users?subjectId=${subject1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const usernames = JSON.parse(res.body).users.map((u) => u.username);
+    expect(usernames).toEqual(['user1']);
+
+    const bad = await app.inject({
+      method: 'GET',
+      url: '/api/users?subjectId=not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
+  it('filters by groupId=<uuid>', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'FilterGroup' });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
+    const ungrouped = await createUser({ username: 'ungrouped', email: 'ungrouped@test.com' });
+    await addUserToSubject(ungrouped.id, subject1.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/users?groupId=${g.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const usernames = JSON.parse(res.body).users.map((u) => u.username);
+    expect(usernames).toEqual(['user1']);
+
+    const bad = await app.inject({
+      method: 'GET',
+      url: '/api/users?groupId=not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(bad.statusCode).toBe(400);
+  });
+
+  it('groupId=none with assignmentId returns enrolled-but-ungrouped users', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'SomeGroup' });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
+    const ungrouped = await createUser({ username: 'ungrouped', email: 'ungrouped@test.com' });
+    await addUserToSubject(ungrouped.id, subject1.id);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/users?groupId=none&assignmentId=${assignment1.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const usernames = JSON.parse(res.body).users.map((u) => u.username);
+    expect(usernames).toContain('ungrouped');
+    expect(usernames).not.toContain('user1');
+  });
+
+  it('groupId=none without assignmentId returns 400', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/users?groupId=none',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
     expect(res.statusCode).toBe(400);
+    const badAssignment = await app.inject({
+      method: 'GET',
+      url: '/api/users?groupId=none&assignmentId=not-a-uuid',
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(badAssignment.statusCode).toBe(400);
   });
 });
 
@@ -124,36 +230,31 @@ describe('GET /api/users', () => {
 // GET /api/users/:id
 // ---------------------------------------------------------------------------
 describe('GET /api/users/:id', () => {
-  it('admin can get any user', async () => {
-    const u = await createUser({ username: 'target', email: 'target@test.com' });
+  it('admin can get any user, enriched with subjects and memberships', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'ProfileGroup' });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
     const res = await app.inject({
       method: 'GET',
-      url: `/api/users/${u.id}`,
+      url: `/api/users/${user1.id}`,
       headers: { authorization: `Bearer ${adminToken}` },
     });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).user.username).toBe('target');
+    const body = JSON.parse(res.body);
+    expect(body.user.username).toBe('user1');
+    expect(body.user.subjects.map((s) => s.name)).toEqual(['Subject1']);
+    expect(body.user.memberships).toHaveLength(1);
+    expect(body.user.memberships[0].group_name).toBe('ProfileGroup');
+    expect(body.user).not.toHaveProperty('password_hash');
   });
 
-  it('user can get their own profile', async () => {
-    // Get the user1 id
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const users = JSON.parse(listRes.body).users;
-    const user1 = users.find((u) => u.username === 'user1');
-
-    const res = await app.inject({
+  it('user can get their own profile but not another user', async () => {
+    const own = await app.inject({
       method: 'GET',
       url: `/api/users/${user1.id}`,
       headers: { authorization: `Bearer ${userToken}` },
     });
-    expect(res.statusCode).toBe(200);
-  });
+    expect(own.statusCode).toBe(200);
 
-  it('user cannot get another user profile', async () => {
     const other = await createUser({ username: 'other', email: 'other@test.com' });
     const res = await app.inject({
       method: 'GET',
@@ -163,33 +264,19 @@ describe('GET /api/users/:id', () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it('returns 404 for non-existent user', async () => {
-    const res = await app.inject({
+  it('returns 404 for non-existent user and 400 for invalid UUID', async () => {
+    const missing = await app.inject({
       method: 'GET',
       url: '/api/users/00000000-0000-0000-0000-000000000000',
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it('returns 400 for invalid UUID', async () => {
-    const res = await app.inject({
+    expect(missing.statusCode).toBe(404);
+    const bad = await app.inject({
       method: 'GET',
       url: '/api/users/not-a-uuid',
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(400);
-  });
-
-  it('password_hash is not exposed in response', async () => {
-    const u = await createUser({ username: 'safe', email: 'safe@test.com' });
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const body = JSON.parse(res.body);
-    expect(body.user).not.toHaveProperty('password_hash');
+    expect(bad.statusCode).toBe(400);
   });
 });
 
@@ -197,7 +284,7 @@ describe('GET /api/users/:id', () => {
 // POST /api/users
 // ---------------------------------------------------------------------------
 describe('POST /api/users', () => {
-  it('admin creates user with role=user', async () => {
+  it('admin creates user with subjectIds; user is pending and enrolled', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users',
@@ -207,6 +294,7 @@ describe('POST /api/users', () => {
         email: 'new@test.com',
         firstName: 'New',
         lastName: 'User',
+        subjectIds: [subject1.id],
         sendSetupEmail: false,
       },
     });
@@ -214,9 +302,220 @@ describe('POST /api/users', () => {
     const body = JSON.parse(res.body);
     expect(body.user.username).toBe('newuser');
     expect(body.user.status).toBe('pending');
+
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${body.user.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(getRes.body).user.subjects.map((s) => s.id)).toEqual([subject1.id]);
   });
 
-  it('admin creates assignment_manager', async () => {
+  it('role user without subjectIds returns 400 "Subject is required"', async () => {
+    for (const subjectIds of [undefined, []]) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/users',
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: {
+          username: 'nosubject',
+          email: 'nosubject@test.com',
+          firstName: 'No',
+          lastName: 'Subject',
+          subjectIds,
+          sendSetupEmail: false,
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toBe('Subject is required');
+    }
+  });
+
+  it('AM cannot create a user in a subject they do not manage (403)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: {
+        username: 'scoped1',
+        email: 'scoped1@test.com',
+        firstName: 'Scoped',
+        lastName: 'User',
+        subjectIds: [subject2.id],
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Forbidden: You do not manage any assignment in this subject');
+  });
+
+  it('AM can create a user in a subject they manage', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: {
+        username: 'scoped2',
+        email: 'scoped2@test.com',
+        firstName: 'Scoped',
+        lastName: 'User',
+        subjectIds: [subject1.id],
+      },
+    });
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('returns 404 for unknown subject in subjectIds', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'ghostsubject',
+        email: 'ghostsubject@test.com',
+        firstName: 'G',
+        lastName: 'S',
+        subjectIds: ['00000000-0000-0000-0000-000000000000'],
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('creates user with immediate group placement', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'PlacementGroup' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'placed',
+        email: 'placed@test.com',
+        firstName: 'P',
+        lastName: 'L',
+        subjectIds: [subject1.id],
+        assignmentId: assignment1.id,
+        groupId: g.id,
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.warning).toBeUndefined();
+
+    const db = getPool();
+    const rows = await db.query('SELECT group_id FROM user_groups WHERE user_id = $1', [body.user.id]);
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].group_id).toBe(g.id);
+  });
+
+  it('groupId without assignmentId returns 400', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'NoAssignmentGroup' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'noassignment',
+        email: 'noassignment@test.com',
+        firstName: 'N',
+        lastName: 'A',
+        subjectIds: [subject1.id],
+        groupId: g.id,
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/assignmentId is required/i);
+  });
+
+  it('assignment not in selected subjects returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'wrongsubject',
+        email: 'wrongsubject@test.com',
+        firstName: 'W',
+        lastName: 'S',
+        subjectIds: [subject1.id],
+        assignmentId: assignment2.id,
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/does not belong to the selected subjects/i);
+  });
+
+  it('group not in the selected assignment returns 400', async () => {
+    const g2 = await createGroup({ assignmentId: assignment2.id, name: 'OtherAssignmentGroup' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'wronggroup',
+        email: 'wronggroup@test.com',
+        firstName: 'W',
+        lastName: 'G',
+        subjectIds: [subject1.id],
+        assignmentId: assignment1.id,
+        groupId: g2.id,
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/does not belong to the selected assignment/i);
+  });
+
+  it('returns 404 when placement group does not exist', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'withghostgroup',
+        email: 'withghostgroup@test.com',
+        firstName: 'W',
+        lastName: 'G',
+        subjectIds: [subject1.id],
+        assignmentId: assignment1.id,
+        groupId: '00000000-0000-0000-0000-000000000000',
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('placement into a full group still creates the user with a warning', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'FullGroup', maxMembers: 1 });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username: 'overflow',
+        email: 'overflow@test.com',
+        firstName: 'O',
+        lastName: 'F',
+        subjectIds: [subject1.id],
+        assignmentId: assignment1.id,
+        groupId: g.id,
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.warning).toMatch(/full/i);
+
+    const db = getPool();
+    const rows = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1', [body.user.id]);
+    expect(rows.rows[0].c).toBe(0);
+  });
+
+  it('admin creates assignment_manager with managed assignmentIds', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users',
@@ -227,27 +526,55 @@ describe('POST /api/users', () => {
         firstName: 'AM',
         lastName: 'User',
         role: 'assignment_manager',
+        assignmentIds: [assignment1.id, assignment2.id],
         sendSetupEmail: false,
       },
     });
     expect(res.statusCode).toBe(201);
+    const newAmId = JSON.parse(res.body).user.id;
+
+    const managers = await app.inject({
+      method: 'GET',
+      url: `/api/assignments/${assignment2.id}/managers`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(managers.body).managers.map((m) => m.id)).toContain(newAmId);
   });
 
-  it('assignment_manager cannot create admin user', async () => {
+  it('AM cannot create admin or assignment_manager users', async () => {
+    for (const role of ['admin', 'assignment_manager']) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/users',
+        headers: { authorization: `Bearer ${amToken}` },
+        payload: {
+          username: `bad-${role}`,
+          email: `bad-${role}@test.com`,
+          firstName: 'B',
+          lastName: 'A',
+          role,
+          sendSetupEmail: false,
+        },
+      });
+      expect(res.statusCode).toBe(403);
+    }
+  });
+
+  it('AM can create a regular user', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${amToken}` },
       payload: {
-        username: 'badAdmin',
-        email: 'bad@test.com',
-        firstName: 'B',
-        lastName: 'A',
-        role: 'admin',
+        username: 'amcreated',
+        email: 'amcreated@test.com',
+        firstName: 'AM',
+        lastName: 'Created',
+        subjectIds: [subject1.id],
         sendSetupEmail: false,
       },
     });
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(201);
   });
 
   it('regular user cannot create users', async () => {
@@ -255,90 +582,46 @@ describe('POST /api/users', () => {
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${userToken}` },
-      payload: { username: 'x', email: 'x@test.com', firstName: 'X', lastName: 'Y', sendSetupEmail: false },
+      payload: {
+        username: 'x',
+        email: 'x@test.com',
+        firstName: 'X',
+        lastName: 'Y',
+        subjectIds: [subject1.id],
+        sendSetupEmail: false,
+      },
     });
     expect(res.statusCode).toBe(403);
   });
 
-  it('returns 409 for duplicate username', async () => {
-    await createUser({ username: 'dup', email: 'dup@test.com' });
-    const res = await app.inject({
+  it('returns 409 for duplicate username, email and studentId', async () => {
+    await createUser({ username: 'dup', email: 'dup@test.com', studentId: 'S123' });
+    const base = { firstName: 'D', lastName: 'U', subjectIds: [subject1.id], sendSetupEmail: false };
+
+    const dupUsername = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { username: 'dup', email: 'other@test.com', firstName: 'D', lastName: 'U', sendSetupEmail: false },
+      payload: { ...base, username: 'dup', email: 'unique1@test.com' },
     });
-    expect(res.statusCode).toBe(409);
-  });
+    expect(dupUsername.statusCode).toBe(409);
 
-  it('returns 409 for duplicate email', async () => {
-    await createUser({ username: 'uniqueuser', email: 'shared@test.com' });
-    const res = await app.inject({
+    const dupEmail = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'anotheruser',
-        email: 'shared@test.com',
-        firstName: 'A',
-        lastName: 'B',
-        sendSetupEmail: false,
-      },
+      payload: { ...base, username: 'unique1', email: 'dup@test.com' },
     });
-    expect(res.statusCode).toBe(409);
-  });
+    expect(dupEmail.statusCode).toBe(409);
 
-  it('returns 404 when specified group does not exist', async () => {
-    const res = await app.inject({
+    const dupStudentId = await app.inject({
       method: 'POST',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'withgroup',
-        email: 'withgroup@test.com',
-        firstName: 'W',
-        lastName: 'G',
-        groupId: '00000000-0000-0000-0000-000000000000',
-        sendSetupEmail: false,
-      },
+      payload: { ...base, username: 'unique2', email: 'unique2@test.com', studentId: 'S123' },
     });
-    expect(res.statusCode).toBe(404);
-  });
-
-  it('returns 400 when group is full', async () => {
-    const group = await createGroup({ name: 'FullGroup', maxMembers: 1 });
-    await createUser({ username: 'member1', email: 'member1@test.com' });
-
-    // Assign member1 to group
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const member1 = JSON.parse(listRes.body).users.find((u) => u.username === 'member1');
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${member1.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: group.id },
-    });
-
-    // Now try to create another user in the same full group
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'member2',
-        email: 'member2@test.com',
-        firstName: 'M',
-        lastName: '2',
-        groupId: group.id,
-        sendSetupEmail: false,
-      },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/full/i);
+    expect(dupStudentId.statusCode).toBe(409);
+    expect(JSON.parse(dupStudentId.body).error).toMatch(/student id/i);
   });
 });
 
@@ -404,13 +687,6 @@ describe('PUT /api/users/:id', () => {
   });
 
   it('user can edit their own non-role fields', async () => {
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
-
     const res = await app.inject({
       method: 'PUT',
       url: `/api/users/${user1.id}`,
@@ -419,6 +695,18 @@ describe('PUT /api/users/:id', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).user.email).toBe('user1updated@test.com');
+  });
+
+  it('regular user editing another user returns 403', async () => {
+    const other = await createUser({ username: 'editvictim', email: 'editvictim@test.com' });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${other.id}`,
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: { email: 'hijacked@test.com', firstName: 'H', lastName: 'J' },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/your own profile/i);
   });
 
   it('prevents username change', async () => {
@@ -432,64 +720,161 @@ describe('PUT /api/users/:id', () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/username/i);
   });
+
+  it('AM cannot escalate a user role; admin can change roles', async () => {
+    const u = await createUser({ username: 'rolechange', email: 'rolechange@test.com' });
+
+    const amRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: u.email, firstName: 'No', lastName: 'Change', role: 'admin' },
+    });
+    expect(amRes.statusCode).toBe(200);
+    let getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(getRes.body).user.role_name).toBe('user');
+
+    const adminRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { email: u.email, firstName: 'Role', lastName: 'Change', role: 'assignment_manager' },
+    });
+    expect(adminRes.statusCode).toBe(200);
+    getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(getRes.body).user.role_name).toBe('assignment_manager');
+  });
 });
 
 // ---------------------------------------------------------------------------
 // PUT /api/users/:id/group
 // ---------------------------------------------------------------------------
 describe('PUT /api/users/:id/group', () => {
-  it('admin assigns user to group', async () => {
-    const u = await createUser({ username: 'groupable', email: 'groupable@test.com' });
-    const g = await createGroup({ name: 'TestGroup' });
+  it('admin assigns a subject member to a group', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'TestGroup' });
     const res = await app.inject({
       method: 'PUT',
-      url: `/api/users/${u.id}/group`,
+      url: `/api/users/${user1.id}/group`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
+      payload: { assignmentId: assignment1.id, groupId: g.id },
     });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).user.groupId).toBe(g.id);
+    const body = JSON.parse(res.body);
+    expect(body.user.groupId).toBe(g.id);
+    expect(body.user.assignmentId).toBe(assignment1.id);
   });
 
-  it('admin removes user from group by setting groupId to null', async () => {
-    const u = await createUser({ username: 'removable', email: 'removable@test.com' });
-    const g = await createGroup({ name: 'RemovableGroup' });
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
+  it('admin removes user from group with groupId null', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'RemovableGroup' });
+    await addUserToGroup(user1.id, g.id, assignment1.id);
     const res = await app.inject({
       method: 'PUT',
-      url: `/api/users/${u.id}/group`,
+      url: `/api/users/${user1.id}/group`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: null },
+      payload: { assignmentId: assignment1.id, groupId: null },
     });
     expect(res.statusCode).toBe(200);
+    const db = getPool();
+    const rows = await db.query('SELECT COUNT(*)::int AS c FROM user_groups WHERE user_id = $1', [user1.id]);
+    expect(rows.rows[0].c).toBe(0);
   });
 
-  it('returns 400 when groupId is missing from body', async () => {
-    const u = await createUser({ username: 'nogroup', email: 'nogroup@test.com' });
+  it('managing AM can place users; unmanaged AM gets 403', async () => {
+    const g1 = await createGroup({ assignmentId: assignment1.id, name: 'AMGroup1' });
+    const ok = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { assignmentId: assignment1.id, groupId: g1.id },
+    });
+    expect(ok.statusCode).toBe(200);
+
+    // am1 does not manage assignment2
+    const g2 = await createGroup({ assignmentId: assignment2.id, name: 'AMGroup2' });
+    const forbidden = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { assignmentId: assignment2.id, groupId: g2.id },
+    });
+    expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('returns 400 when body is missing assignmentId or groupId', async () => {
+    for (const payload of [{}, { groupId: null }, { assignmentId: assignment1.id }]) {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/api/users/${user1.id}/group`,
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload,
+      });
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it('returns 400 when the group belongs to a different assignment', async () => {
+    const g2 = await createGroup({ assignmentId: assignment2.id, name: 'MismatchGroup' });
     const res = await app.inject({
       method: 'PUT',
-      url: `/api/users/${u.id}/group`,
+      url: `/api/users/${user1.id}/group`,
       headers: { authorization: `Bearer ${adminToken}` },
-      payload: {},
+      payload: { assignmentId: assignment1.id, groupId: g2.id },
     });
     expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/does not belong/i);
   });
 
-  it('regular user cannot update group assignment', async () => {
-    const u = await createUser({ username: 'victim', email: 'victim@test.com' });
-    const g = await createGroup({ name: 'VictimGroup' });
+  it('returns 404 for non-existent group or assignment', async () => {
+    const missingGroup = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: assignment1.id, groupId: '00000000-0000-0000-0000-000000000000' },
+    });
+    expect(missingGroup.statusCode).toBe(404);
+
+    const missingAssignment = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${user1.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: '00000000-0000-0000-0000-000000000000', groupId: null },
+    });
+    expect(missingAssignment.statusCode).toBe(404);
+  });
+
+  it('regular user cannot update group placements', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'VictimGroup' });
     const res = await app.inject({
       method: 'PUT',
-      url: `/api/users/${u.id}/group`,
+      url: `/api/users/${user1.id}/group`,
       headers: { authorization: `Bearer ${userToken}` },
-      payload: { groupId: g.id },
+      payload: { assignmentId: assignment1.id, groupId: g.id },
     });
     expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 409 when the target group is full', async () => {
+    const g = await createGroup({ assignmentId: assignment1.id, name: 'TxnFullGroup', maxMembers: 1 });
+    const second = await createUser({ username: 'txnsecond', email: 'txnsecond@test.com' });
+    await addUserToSubject(second.id, subject1.id);
+    await addUserToGroup(user1.id, g.id, assignment1.id);
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${second.id}/group`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { assignmentId: assignment1.id, groupId: g.id },
+    });
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toMatch(/full/i);
   });
 });
 
@@ -498,14 +883,6 @@ describe('PUT /api/users/:id/group', () => {
 // ---------------------------------------------------------------------------
 describe('PUT /api/users/:id/password', () => {
   it('user can change their own password', async () => {
-    // Get user1 id
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
-
     const res = await app.inject({
       method: 'PUT',
       url: `/api/users/${user1.id}/password`,
@@ -516,13 +893,6 @@ describe('PUT /api/users/:id/password', () => {
   });
 
   it('returns 401 for wrong current password', async () => {
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
-
     const res = await app.inject({
       method: 'PUT',
       url: `/api/users/${user1.id}/password`,
@@ -533,13 +903,6 @@ describe('PUT /api/users/:id/password', () => {
   });
 
   it('returns 400 for too-short new password', async () => {
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
-
     const res = await app.inject({
       method: 'PUT',
       url: `/api/users/${user1.id}/password`,
@@ -549,22 +912,30 @@ describe('PUT /api/users/:id/password', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it('user cannot change another user password', async () => {
+  it('user cannot change another user password (admin included)', async () => {
     const other = await createUser({ username: 'otherpass', email: 'otherpass@test.com' });
-    const res = await app.inject({
+    const asUser = await app.inject({
       method: 'PUT',
       url: `/api/users/${other.id}/password`,
       headers: { authorization: `Bearer ${userToken}` },
       payload: { currentPassword: 'TestPass123!', newPassword: 'NewPass456!' },
     });
-    expect(res.statusCode).toBe(403);
+    expect(asUser.statusCode).toBe(403);
+
+    const asAdmin = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${other.id}/password`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { currentPassword: 'TestPass123!', newPassword: 'NewPass456!' },
+    });
+    expect(asAdmin.statusCode).toBe(403);
   });
 });
 
 // ---------------------------------------------------------------------------
-// DELETE /api/users/:id
+// DELETE /api/users/:id and /api/users/bulk
 // ---------------------------------------------------------------------------
-describe('DELETE /api/users/:id', () => {
+describe('DELETE /api/users', () => {
   it('admin deletes a user', async () => {
     const u = await createUser({ username: 'deleteme', email: 'deleteme@test.com' });
     const res = await app.inject({
@@ -575,47 +946,60 @@ describe('DELETE /api/users/:id', () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it('returns 404 for non-existent user', async () => {
-    const res = await app.inject({
+  it('deleting a user cascades reset tokens', async () => {
+    const PasswordResetToken = require('../../src/models/PasswordResetToken');
+    const u = await createUser({ username: 'tokenowner', email: 'tokenowner@test.com' });
+    await PasswordResetToken.create(u.id, 'reset', 1);
+
+    const db = getPool();
+    const before = await db.query('SELECT COUNT(*)::int AS c FROM password_reset_tokens WHERE user_id = $1', [u.id]);
+    expect(before.rows[0].c).toBe(1);
+
+    const delRes = await app.inject({
+      method: 'DELETE',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(delRes.statusCode).toBe(200);
+
+    const after = await db.query('SELECT COUNT(*)::int AS c FROM password_reset_tokens WHERE user_id = $1', [u.id]);
+    expect(after.rows[0].c).toBe(0);
+  });
+
+  it('returns 404 for non-existent user; admin cannot delete self; AM/user get 403', async () => {
+    const missing = await app.inject({
       method: 'DELETE',
       url: '/api/users/00000000-0000-0000-0000-000000000000',
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(404);
-  });
+    expect(missing.statusCode).toBe(404);
 
-  it('admin cannot delete their own account', async () => {
     const listRes = await app.inject({
       method: 'GET',
       url: '/api/users?role=admin',
       headers: { authorization: `Bearer ${adminToken}` },
     });
     const adminUser = JSON.parse(listRes.body).users.find((u) => u.username === 'admin');
-    const res = await app.inject({
+    const self = await app.inject({
       method: 'DELETE',
       url: `/api/users/${adminUser.id}`,
       headers: { authorization: `Bearer ${adminToken}` },
     });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/own account/i);
-  });
+    expect(self.statusCode).toBe(400);
+    expect(JSON.parse(self.body).error).toMatch(/own account/i);
 
-  it('regular user cannot delete users', async () => {
     const u = await createUser({ username: 'protected', email: 'protected@test.com' });
-    const res = await app.inject({
-      method: 'DELETE',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${userToken}` },
-    });
-    expect(res.statusCode).toBe(403);
+    for (const token of [amToken, userToken]) {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: `/api/users/${u.id}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(res.statusCode).toBe(403);
+    }
   });
-});
 
-// ---------------------------------------------------------------------------
-// DELETE /api/users/bulk
-// ---------------------------------------------------------------------------
-describe('DELETE /api/users/bulk', () => {
-  it('admin bulk deletes users', async () => {
+  it('admin bulk deletes users; validation errors covered', async () => {
     const u1 = await createUser({ username: 'bulk1', email: 'bulk1@test.com' });
     const u2 = await createUser({ username: 'bulk2', email: 'bulk2@test.com' });
     const res = await app.inject({
@@ -626,42 +1010,36 @@ describe('DELETE /api/users/bulk', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).deleted).toBe(2);
-  });
 
-  it('returns 400 for empty ids array', async () => {
-    const res = await app.inject({
+    const empty = await app.inject({
       method: 'DELETE',
       url: '/api/users/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: { ids: [] },
     });
-    expect(res.statusCode).toBe(400);
-  });
+    expect(empty.statusCode).toBe(400);
 
-  it('returns 400 when ids contain invalid UUIDs', async () => {
-    const res = await app.inject({
+    const invalid = await app.inject({
       method: 'DELETE',
       url: '/api/users/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: { ids: ['not-a-uuid'] },
     });
-    expect(res.statusCode).toBe(400);
-  });
+    expect(invalid.statusCode).toBe(400);
 
-  it('returns 400 when admin id is in the list', async () => {
     const listRes = await app.inject({
       method: 'GET',
       url: '/api/users?role=admin',
       headers: { authorization: `Bearer ${adminToken}` },
     });
     const adminUser = JSON.parse(listRes.body).users.find((u) => u.username === 'admin');
-    const res = await app.inject({
+    const withSelf = await app.inject({
       method: 'DELETE',
       url: '/api/users/bulk',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: { ids: [adminUser.id] },
     });
-    expect(res.statusCode).toBe(400);
+    expect(withSelf.statusCode).toBe(400);
   });
 });
 
@@ -669,7 +1047,38 @@ describe('DELETE /api/users/bulk', () => {
 // POST /api/users/import
 // ---------------------------------------------------------------------------
 describe('POST /api/users/import', () => {
-  it('admin imports new users', async () => {
+  it('requires a valid subjectId', async () => {
+    for (const subjectId of [undefined, 'not-a-uuid']) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/users/import',
+        headers: { authorization: `Bearer ${adminToken}` },
+        payload: {
+          users: [{ username: 'imp1', email: 'imp1@test.com', firstName: 'Imp', lastName: 'One' }],
+          subjectId,
+          sendSetupEmail: false,
+        },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).error).toBe('Subject is required');
+    }
+  });
+
+  it('returns 404 for unknown subject', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        users: [{ username: 'imp1', email: 'imp1@test.com', firstName: 'Imp', lastName: 'One' }],
+        subjectId: '00000000-0000-0000-0000-000000000000',
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('admin imports new users and they are enrolled in the subject', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users/import',
@@ -679,6 +1088,7 @@ describe('POST /api/users/import', () => {
           { username: 'imp1', email: 'imp1@test.com', firstName: 'Imp', lastName: 'One' },
           { username: 'imp2', email: 'imp2@test.com', firstName: 'Imp', lastName: 'Two' },
         ],
+        subjectId: subject1.id,
         conflictAction: 'skip',
         sendSetupEmail: false,
       },
@@ -688,6 +1098,15 @@ describe('POST /api/users/import', () => {
     expect(body.imported).toBe(2);
     expect(body.skipped).toBe(0);
     expect(body.errors).toHaveLength(0);
+
+    const db = getPool();
+    const rows = await db.query(
+      `SELECT COUNT(*)::int AS c FROM user_subjects us
+       JOIN users u ON u.id = us.user_id
+       WHERE us.subject_id = $1 AND u.username IN ('imp1', 'imp2')`,
+      [subject1.id]
+    );
+    expect(rows.rows[0].c).toBe(2);
   });
 
   it('skips existing users when conflictAction=skip', async () => {
@@ -698,6 +1117,7 @@ describe('POST /api/users/import', () => {
       headers: { authorization: `Bearer ${adminToken}` },
       payload: {
         users: [{ username: 'existing', email: 'existing@test.com', firstName: 'E', lastName: 'X' }],
+        subjectId: subject1.id,
         conflictAction: 'skip',
         sendSetupEmail: false,
       },
@@ -708,20 +1128,28 @@ describe('POST /api/users/import', () => {
     expect(body.imported).toBe(0);
   });
 
-  it('overwrites existing users when conflictAction=overwrite', async () => {
-    await createUser({ username: 'overwriteuser', email: 'overwrite@test.com', firstName: 'Old', lastName: 'Name' });
+  it('overwrites existing users when conflictAction=overwrite and enrols them', async () => {
+    const existing = await createUser({ username: 'overwriteuser', email: 'overwrite@test.com', firstName: 'Old' });
     const res = await app.inject({
       method: 'POST',
       url: '/api/users/import',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: {
         users: [{ username: 'overwriteuser', email: 'overwrite@test.com', firstName: 'New', lastName: 'Name' }],
+        subjectId: subject1.id,
         conflictAction: 'overwrite',
         sendSetupEmail: false,
       },
     });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).imported).toBe(1);
+
+    const db = getPool();
+    const rows = await db.query('SELECT COUNT(*)::int AS c FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
+      existing.id,
+      subject1.id,
+    ]);
+    expect(rows.rows[0].c).toBe(1);
   });
 
   it('cannot overwrite admin account via import', async () => {
@@ -731,341 +1159,80 @@ describe('POST /api/users/import', () => {
       headers: { authorization: `Bearer ${adminToken}` },
       payload: {
         users: [{ username: 'admin', email: 'admin@test.com', firstName: 'H', lastName: 'K' }],
+        subjectId: subject1.id,
         conflictAction: 'overwrite',
         sendSetupEmail: false,
       },
     });
     expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.errors[0].reason).toMatch(/admin/i);
+    expect(JSON.parse(res.body).errors[0].reason).toMatch(/admin/i);
   });
 
-  it('AM importing skips admin/AM accounts on overwrite', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/import',
-      headers: { authorization: `Bearer ${amToken}` },
-      payload: {
-        users: [
-          { username: 'admin', email: 'admin@test.com', firstName: 'H', lastName: 'K' },
-          { username: 'am1', email: 'am1@test.com', firstName: 'A', lastName: 'M' },
-          { username: 'newuser', email: 'new@test.com', firstName: 'New', lastName: 'User' },
-        ],
-        conflictAction: 'overwrite',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    const serializedErrors = body.errors.map((e) => JSON.stringify(e));
-    expect(body.imported).toBe(1);
-    expect(body.errors.length).toBeGreaterThanOrEqual(2);
-    expect(serializedErrors.some((error) => /admin/i.test(error))).toBe(true);
-    expect(serializedErrors.some((error) => /am1|assignment manager/i.test(error))).toBe(true);
-    expect(serializedErrors.some((error) => /newuser/i.test(error))).toBe(false);
-  });
-
-  it('returns 400 for empty users array', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/import',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { users: [], conflictAction: 'skip', sendSetupEmail: false },
-    });
-    expect(res.statusCode).toBe(400);
-  });
-
-  it('assignment_manager can import users', async () => {
-    const res = await app.inject({
+  it('AM managing an assignment in the subject can import; unmanaged subject returns 403', async () => {
+    const ok = await app.inject({
       method: 'POST',
       url: '/api/users/import',
       headers: { authorization: `Bearer ${amToken}` },
       payload: {
         users: [{ username: 'amimp1', email: 'amimp1@test.com', firstName: 'AM', lastName: 'Imp' }],
+        subjectId: subject1.id,
         conflictAction: 'skip',
         sendSetupEmail: false,
       },
     });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(1);
+    expect(ok.statusCode).toBe(200);
+    expect(JSON.parse(ok.body).imported).toBe(1);
+
+    const forbidden = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: {
+        users: [{ username: 'amimp2', email: 'amimp2@test.com', firstName: 'AM', lastName: 'Imp' }],
+        subjectId: subject2.id,
+        conflictAction: 'skip',
+        sendSetupEmail: false,
+      },
+    });
+    expect(forbidden.statusCode).toBe(403);
   });
 
-  it('regular user cannot import', async () => {
-    const res = await app.inject({
+  it('returns 400 for empty users array and invalid conflictAction; 403 for regular user', async () => {
+    const empty = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { users: [], subjectId: subject1.id, sendSetupEmail: false },
+    });
+    expect(empty.statusCode).toBe(400);
+
+    const badAction = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        users: [{ username: 'x', email: 'x@test.com', firstName: 'X', lastName: 'Y' }],
+        subjectId: subject1.id,
+        conflictAction: 'merge',
+        sendSetupEmail: false,
+      },
+    });
+    expect(badAction.statusCode).toBe(400);
+    expect(JSON.parse(badAction.body).error).toMatch(/conflictAction/i);
+
+    const forbidden = await app.inject({
       method: 'POST',
       url: '/api/users/import',
       headers: { authorization: `Bearer ${userToken}` },
       payload: {
         users: [{ username: 'x', email: 'x@test.com', firstName: 'X', lastName: 'Y' }],
-        conflictAction: 'skip',
+        subjectId: subject1.id,
         sendSetupEmail: false,
       },
     });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/users/send-setup-emails
-// ---------------------------------------------------------------------------
-describe('POST /api/users/send-setup-emails', () => {
-  it('admin can send setup emails to all pending users', async () => {
-    // Create pending users via the API (no password = pending)
-    const res1 = await app.inject({
-      method: 'POST',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'pending1',
-        email: 'pending1@test.com',
-        firstName: 'P',
-        lastName: 'One',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res1.statusCode).toBe(201);
-    const res2 = await app.inject({
-      method: 'POST',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'pending2',
-        email: 'pending2@test.com',
-        firstName: 'P',
-        lastName: 'Two',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res2.statusCode).toBe(201);
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {},
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.sent).toBeGreaterThanOrEqual(2);
+    expect(forbidden.statusCode).toBe(403);
   });
 
-  it('admin can send to specific userIds list', async () => {
-    const createRes = await app.inject({
-      method: 'POST',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'specific1',
-        email: 'specific1@test.com',
-        firstName: 'S',
-        lastName: 'One',
-        sendSetupEmail: false,
-      },
-    });
-    const userId = JSON.parse(createRes.body).user.id;
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { userIds: [userId] },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.sent).toBe(1);
-  });
-
-  it('returns 401 without token', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      payload: {},
-    });
-    expect(res.statusCode).toBe(401);
-  });
-
-  it('returns 403 for regular user', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${userToken}` },
-      payload: {},
-    });
-    expect(res.statusCode).toBe(403);
-  });
-
-  it('returns 400 when exceeding 500 userIds', async () => {
-    const fakeIds = Array.from({ length: 501 }, (_, i) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`);
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { userIds: fakeIds },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/500/);
-  });
-
-  it('returns 400 for invalid UUID in userIds', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { userIds: ['not-a-uuid'] },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/invalid/i);
-  });
-
-  it('silently skips non-pending users in userIds', async () => {
-    // user1 is active (created with password via createUser helper), not pending
-    const listRes = await app.inject({
-      method: 'GET',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    const user1 = JSON.parse(listRes.body).users.find((u) => u.username === 'user1');
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/send-setup-emails',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { userIds: [user1.id] },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    // user1 is active, not pending — should be filtered out
-    expect(body.sent).toBe(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id/group — AM RBAC
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id/group — AM RBAC', () => {
-  it('assignment_manager can assign a user to a group', async () => {
-    const u = await createUser({ username: 'amtarget', email: 'amtarget@test.com' });
-    const g = await createGroup({ name: 'AMAssignGroup' });
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}/group`,
-      headers: { authorization: `Bearer ${amToken}` },
-      payload: { groupId: g.id },
-    });
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).user.groupId).toBe(g.id);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id — AM role escalation prevention
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id — AM role escalation', () => {
-  it('assignment_manager cannot change a user role', async () => {
-    const u = await createUser({ username: 'norolechange', email: 'norolechange@test.com' });
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${amToken}` },
-      payload: { email: u.email, firstName: 'No', lastName: 'Change', role: 'admin' },
-    });
-    // AM cannot escalate role — the role field should be ignored (not applied)
-    expect(res.statusCode).toBe(200);
-
-    // Verify via a fresh GET that the role was NOT changed
-    const getRes = await app.inject({
-      method: 'GET',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(JSON.parse(getRes.body).user.role_name).toBe('user');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// RBAC: AM on admin-only endpoints (users)
-// ---------------------------------------------------------------------------
-describe('RBAC: AM on admin-only user endpoints', () => {
-  it('DELETE /api/users/:id with AM token returns 403', async () => {
-    const u = await createUser({ username: 'amdeletetarget', email: 'amdel@test.com' });
-    const res = await app.inject({
-      method: 'DELETE',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${amToken}` },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// GET /api/users?groupId= — filter by group
-// ---------------------------------------------------------------------------
-describe('GET /api/users?groupId=<uuid>', () => {
-  it('returns only users in the specified group', async () => {
-    const g = await createGroup({ name: 'FilterGroup' });
-    const inGroup = await createUser({ username: 'ingroup', email: 'ingroup@test.com' });
-    await createUser({ username: 'nogroup', email: 'nogroup@test.com' });
-
-    // Assign inGroup user to the group
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${inGroup.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/users?groupId=${g.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.users.every((u) => u.group_id === g.id)).toBe(true);
-    expect(body.users.some((u) => u.username === 'ingroup')).toBe(true);
-    expect(body.users.some((u) => u.username === 'nogroup')).toBe(false);
-  });
-
-  it('groupId=none returns only ungrouped users', async () => {
-    const g = await createGroup({ name: 'SomeGroup' });
-    const grouped = await createUser({ username: 'grouped', email: 'grouped@test.com' });
-    await createUser({ username: 'ungrouped', email: 'ungrouped@test.com' });
-
-    await app.inject({
-      method: 'PUT',
-      url: `/api/users/${grouped.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/users?groupId=none',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.users.every((u) => u.group_id === null)).toBe(true);
-    expect(body.users.some((u) => u.username === 'ungrouped')).toBe(true);
-    expect(body.users.some((u) => u.username === 'grouped')).toBe(false);
-  });
-
-  it('returns 400 for invalid groupId filter', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/users?groupId=not-a-uuid',
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/groupId/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/users/import — within-batch duplicate detection
-// ---------------------------------------------------------------------------
-describe('POST /api/users/import — within-batch duplicate email', () => {
   it('detects duplicate emails within the same batch', async () => {
     const res = await app.inject({
       method: 'POST',
@@ -1076,234 +1243,29 @@ describe('POST /api/users/import — within-batch duplicate email', () => {
           { username: 'dup1', email: 'same@test.com', firstName: 'Dup', lastName: 'One' },
           { username: 'dup2', email: 'same@test.com', firstName: 'Dup', lastName: 'Two' },
         ],
+        subjectId: subject1.id,
         conflictAction: 'skip',
         sendSetupEmail: false,
       },
     });
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
-    // First row imports, second row errors because email is already taken by the first
     expect(body.imported).toBe(1);
     expect(body.errors.length).toBe(1);
     expect(body.errors[0].reason).toMatch(/email/i);
   });
-});
 
-// ---------------------------------------------------------------------------
-// POST /api/users/import — invalid conflictAction
-// ---------------------------------------------------------------------------
-describe('POST /api/users/import — invalid conflictAction', () => {
-  it('returns 400 for an invalid conflictAction value', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/import',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        users: [{ username: 'x', email: 'x@test.com', firstName: 'X', lastName: 'Y' }],
-        conflictAction: 'merge',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toMatch(/conflictAction/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id — admin changes role from user to assignment_manager
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id — admin role change', () => {
-  it('admin changes role from user to assignment_manager and verifies via GET', async () => {
-    const u = await createUser({ username: 'rolechange', email: 'rolechange@test.com', role: 'user' });
-
-    const putRes = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { email: u.email, firstName: 'Role', lastName: 'Change', role: 'assignment_manager' },
-    });
-    expect(putRes.statusCode).toBe(200);
-
-    // Verify the role was actually updated
-    const getRes = await app.inject({
-      method: 'GET',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(getRes.statusCode).toBe(200);
-    expect(JSON.parse(getRes.body).user.role_name).toBe('assignment_manager');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id/password — admin cannot change another user's password
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id/password — admin cross-user', () => {
-  it('admin cannot change another user password (returns 403)', async () => {
-    const other = await createUser({ username: 'adminpassvictim', email: 'apv@test.com' });
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${other.id}/password`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { currentPassword: 'TestPass123!', newPassword: 'NewPass456!' },
-    });
-    expect(res.statusCode).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id/group — transactional capacity guard (409)
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id/group — transactional capacity guard', () => {
-  it('returns 409 when assigning a second user to a maxMembers=1 group', async () => {
-    const g = await createGroup({ name: 'TxnFullGroup', maxMembers: 1 });
-    const first = await createUser({ username: 'txnfirst', email: 'txnfirst@test.com' });
-    const second = await createUser({ username: 'txnsecond', email: 'txnsecond@test.com' });
-
-    // Fill the group via PUT (the same endpoint under test)
-    const fillRes = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${first.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-    expect(fillRes.statusCode).toBe(200);
-
-    // Second assignment must hit the row-locked transaction's full-group throw
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${second.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: g.id },
-    });
-    expect(res.statusCode).toBe(409);
-    expect(JSON.parse(res.body).error).toMatch(/full/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// PUT /api/users/:id/group — transactional not-found guard (404)
-// ---------------------------------------------------------------------------
-describe('PUT /api/users/:id/group — transactional not-found guard', () => {
-  it('returns 404 when groupId is a valid but non-existent UUID', async () => {
-    // Real user so the route-level user pre-check passes and the transaction runs
-    const u = await createUser({ username: 'txnnogroup', email: 'txnnogroup@test.com' });
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${u.id}/group`,
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: { groupId: '00000000-0000-0000-0000-000000000000' },
-    });
-    expect(res.statusCode).toBe(404);
-    expect(JSON.parse(res.body).error).toMatch(/group not found/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// DELETE /api/users/:id — password_reset_tokens cascade (ON DELETE CASCADE)
-// ---------------------------------------------------------------------------
-describe('DELETE /api/users/:id — reset token cascade', () => {
-  it('deletes outstanding password_reset_tokens when the user is deleted', async () => {
-    const PasswordResetToken = require('../../src/models/PasswordResetToken');
-    const u = await createUser({ username: 'tokenowner', email: 'tokenowner@test.com' });
-
-    // Create an outstanding reset token for the user
-    await PasswordResetToken.create(u.id, 'reset', 1);
-
-    const db = getPool();
-    const before = await db.query('SELECT COUNT(*)::int AS count FROM password_reset_tokens WHERE user_id = $1', [
-      u.id,
-    ]);
-    expect(before.rows[0].count).toBe(1);
-
-    // Delete the user via the API
-    const delRes = await app.inject({
-      method: 'DELETE',
-      url: `/api/users/${u.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(delRes.statusCode).toBe(200);
-
-    // The cascade must have removed the token row
-    const after = await db.query('SELECT COUNT(*)::int AS count FROM password_reset_tokens WHERE user_id = $1', [u.id]);
-    expect(after.rows[0].count).toBe(0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/users — duplicate studentId (409)
-// ---------------------------------------------------------------------------
-describe('POST /api/users — duplicate studentId', () => {
-  it('returns 409 when studentId is already taken by another user', async () => {
-    await createUser({ username: 'sidowner', email: 'sidowner@test.com', studentId: 'S123' });
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        username: 'sidclash',
-        email: 'sidclash@test.com',
-        firstName: 'Sid',
-        lastName: 'Clash',
-        studentId: 'S123',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res.statusCode).toBe(409);
-    expect(JSON.parse(res.body).error).toMatch(/student id/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/users/import — overwrite collides with another existing user's email
-// ---------------------------------------------------------------------------
-describe('POST /api/users/import — overwrite email owned by a different user', () => {
-  it('rejects the row when the new email already belongs to another existing user', async () => {
-    const userA = await createUser({ username: 'ovrA', email: 'a@test.com' });
-    await createUser({ username: 'ovrB', email: 'b@test.com' });
-
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/users/import',
-      headers: { authorization: `Bearer ${adminToken}` },
-      payload: {
-        users: [{ username: 'ovrA', email: 'b@test.com', firstName: 'A', lastName: 'Overwrite' }],
-        conflictAction: 'overwrite',
-        sendSetupEmail: false,
-      },
-    });
-    expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.imported).toBe(0);
-    expect(body.errors.length).toBe(1);
-    expect(body.errors[0].reason).toMatch(/email already in use/i);
-
-    // userA's email must be unchanged
-    const getRes = await app.inject({
-      method: 'GET',
-      url: `/api/users/${userA.id}`,
-      headers: { authorization: `Bearer ${adminToken}` },
-    });
-    expect(getRes.statusCode).toBe(200);
-    expect(JSON.parse(getRes.body).user.email).toBe('a@test.com');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// POST /api/users/import — within-batch duplicate studentId for new users
-// ---------------------------------------------------------------------------
-describe('POST /api/users/import — within-batch duplicate studentId', () => {
-  it('imports the first new-user row and errors the second sharing a studentId', async () => {
+  it('detects within-batch duplicate studentId', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users/import',
       headers: { authorization: `Bearer ${adminToken}` },
       payload: {
         users: [
-          { username: 'sidnew1', email: 'sidnew1@test.com', firstName: 'Sid', lastName: 'One', studentId: 'SBATCH1' },
-          { username: 'sidnew2', email: 'sidnew2@test.com', firstName: 'Sid', lastName: 'Two', studentId: 'SBATCH1' },
+          { username: 'sidnew1', email: 'sidnew1@test.com', firstName: 'S', lastName: 'One', studentId: 'SBATCH1' },
+          { username: 'sidnew2', email: 'sidnew2@test.com', firstName: 'S', lastName: 'Two', studentId: 'SBATCH1' },
         ],
+        subjectId: subject1.id,
         conflictAction: 'skip',
         sendSetupEmail: false,
       },
@@ -1314,21 +1276,126 @@ describe('POST /api/users/import — within-batch duplicate studentId', () => {
     expect(body.errors.length).toBe(1);
     expect(body.errors[0].reason).toMatch(/student id/i);
   });
+
+  it('rejects overwrite when the new email belongs to another existing user', async () => {
+    const userA = await createUser({ username: 'ovrA', email: 'a@test.com' });
+    await createUser({ username: 'ovrB', email: 'b@test.com' });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/import',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        users: [{ username: 'ovrA', email: 'b@test.com', firstName: 'A', lastName: 'Overwrite' }],
+        subjectId: subject1.id,
+        conflictAction: 'overwrite',
+        sendSetupEmail: false,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.imported).toBe(0);
+    expect(body.errors.length).toBe(1);
+    expect(body.errors[0].reason).toMatch(/email already in use/i);
+
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/users/${userA.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
+    expect(JSON.parse(getRes.body).user.email).toBe('a@test.com');
+  });
 });
 
 // ---------------------------------------------------------------------------
-// PUT /api/users/:id — regular user editing another user (403)
+// POST /api/users/send-setup-emails
 // ---------------------------------------------------------------------------
-describe('PUT /api/users/:id — horizontal privilege escalation guard', () => {
-  it('regular user editing another user returns 403', async () => {
-    const other = await createUser({ username: 'editvictim', email: 'editvictim@test.com' });
+describe('POST /api/users/send-setup-emails', () => {
+  async function createPendingUser(username, email) {
     const res = await app.inject({
-      method: 'PUT',
-      url: `/api/users/${other.id}`,
-      headers: { authorization: `Bearer ${userToken}` },
-      payload: { email: 'hijacked@test.com', firstName: 'H', lastName: 'J' },
+      method: 'POST',
+      url: '/api/users',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {
+        username,
+        email,
+        firstName: 'P',
+        lastName: 'User',
+        subjectIds: [subject1.id],
+        sendSetupEmail: false,
+      },
     });
-    expect(res.statusCode).toBe(403);
-    expect(JSON.parse(res.body).error).toMatch(/your own profile/i);
+    expect(res.statusCode).toBe(201);
+    return JSON.parse(res.body).user;
+  }
+
+  it('admin can send setup emails to all pending users', async () => {
+    await createPendingUser('pending1', 'pending1@test.com');
+    await createPendingUser('pending2', 'pending2@test.com');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).sent).toBeGreaterThanOrEqual(2);
+  });
+
+  it('admin can send to specific userIds list', async () => {
+    const u = await createPendingUser('specific1', 'specific1@test.com');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [u.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).sent).toBe(1);
+  });
+
+  it('silently skips non-pending users in userIds', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: [user1.id] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).sent).toBe(0);
+  });
+
+  it('returns 401 without token and 403 for regular user', async () => {
+    const noToken = await app.inject({ method: 'POST', url: '/api/users/send-setup-emails', payload: {} });
+    expect(noToken.statusCode).toBe(401);
+    const forbidden = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${userToken}` },
+      payload: {},
+    });
+    expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('validates userIds (max 500, valid UUIDs)', async () => {
+    const fakeIds = Array.from({ length: 501 }, (_, i) => `00000000-0000-0000-0000-${String(i).padStart(12, '0')}`);
+    const tooMany = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: fakeIds },
+    });
+    expect(tooMany.statusCode).toBe(400);
+    expect(JSON.parse(tooMany.body).error).toMatch(/500/);
+
+    const invalid = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { userIds: ['not-a-uuid'] },
+    });
+    expect(invalid.statusCode).toBe(400);
+    expect(JSON.parse(invalid.body).error).toMatch(/invalid/i);
   });
 });

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -80,7 +80,7 @@ describe('GET /api/users', () => {
     expect(admin.memberships).toEqual([]);
   });
 
-  it('AM sees only users in subjects containing their managed assignments', async () => {
+  it('assignment manager cannot list users — the route is admin-only', async () => {
     const s2only = await createUser({ username: 's2only', email: 's2only@test.com' });
     await addUserToSubject(s2only.id, subject2.id);
 
@@ -89,17 +89,15 @@ describe('GET /api/users', () => {
       url: '/api/users',
       headers: { authorization: `Bearer ${amToken}` },
     });
-    expect(res.statusCode).toBe(200);
-    const usernames = JSON.parse(res.body).users.map((u) => u.username);
-    expect(usernames).toContain('user1');
-    expect(usernames).not.toContain('s2only');
+    expect(res.statusCode).toBe(403);
 
-    // Admin sees both
+    // Admin still sees everyone
     const adminRes = await app.inject({
       method: 'GET',
       url: '/api/users',
       headers: { authorization: `Bearer ${adminToken}` },
     });
+    expect(adminRes.statusCode).toBe(200);
     const allUsernames = JSON.parse(adminRes.body).users.map((u) => u.username);
     expect(allUsernames).toContain('user1');
     expect(allUsernames).toContain('s2only');
@@ -721,8 +719,72 @@ describe('PUT /api/users/:id', () => {
     expect(JSON.parse(res.body).error).toMatch(/username/i);
   });
 
+  it('AM can edit a user enrolled in a managed subject; out-of-scope user returns 403', async () => {
+    const inScope = await createUser({ username: 'inscope', email: 'inscope@test.com' });
+    await addUserToSubject(inScope.id, subject1.id);
+    const outScope = await createUser({ username: 'outscope', email: 'outscope@test.com' });
+    await addUserToSubject(outScope.id, subject2.id);
+
+    const okRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${inScope.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: 'inscope-new@test.com', firstName: 'In', lastName: 'Scope' },
+    });
+    expect(okRes.statusCode).toBe(200);
+    expect(JSON.parse(okRes.body).user.email).toBe('inscope-new@test.com');
+
+    const forbidden = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${outScope.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: 'outscope-new@test.com', firstName: 'Out', lastName: 'Scope' },
+    });
+    expect(forbidden.statusCode).toBe(403);
+    expect(JSON.parse(forbidden.body).error).toBe('Forbidden: user is not in a subject you manage');
+  });
+
+  it('AM can still edit a user whose managed-subject membership is suspended (includeDisabled scope)', async () => {
+    const suspended = await createUser({ username: 'suspscope', email: 'suspscope@test.com' });
+    await addUserToSubject(suspended.id, subject1.id, false);
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${suspended.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: 'suspscope-new@test.com', firstName: 'Still', lastName: 'Editable' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).user.email).toBe('suspscope-new@test.com');
+  });
+
+  it('AM cannot enable or disable accounts; admin can', async () => {
+    const u = await createUser({ username: 'amdisable', email: 'amdisable@test.com' });
+    await addUserToSubject(u.id, subject1.id);
+
+    const amRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { email: u.email, firstName: 'A', lastName: 'M', enabled: false },
+    });
+    expect(amRes.statusCode).toBe(403);
+    expect(JSON.parse(amRes.body).error).toBe('Only admins can enable or disable accounts');
+
+    const adminRes = await app.inject({
+      method: 'PUT',
+      url: `/api/users/${u.id}`,
+      headers: { authorization: `Bearer ${adminToken}` },
+      payload: { email: u.email, firstName: 'A', lastName: 'M', enabled: false },
+    });
+    expect(adminRes.statusCode).toBe(200);
+    expect(JSON.parse(adminRes.body).user.enabled).toBe(false);
+  });
+
   it('AM cannot escalate a user role; admin can change roles', async () => {
     const u = await createUser({ username: 'rolechange', email: 'rolechange@test.com' });
+    // The target must be enrolled in a subject the AM manages, or the AM gets 403
+    await addUserToSubject(u.id, subject1.id);
 
     const amRes = await app.inject({
       method: 'PUT',
@@ -1311,7 +1373,7 @@ describe('POST /api/users/import', () => {
 // POST /api/users/send-setup-emails
 // ---------------------------------------------------------------------------
 describe('POST /api/users/send-setup-emails', () => {
-  async function createPendingUser(username, email) {
+  async function createPendingUser(username, email, subjectId = null) {
     const res = await app.inject({
       method: 'POST',
       url: '/api/users',
@@ -1321,7 +1383,7 @@ describe('POST /api/users/send-setup-emails', () => {
         email,
         firstName: 'P',
         lastName: 'User',
-        subjectIds: [subject1.id],
+        subjectIds: [subjectId || subject1.id],
         sendSetupEmail: false,
       },
     });
@@ -1376,6 +1438,43 @@ describe('POST /api/users/send-setup-emails', () => {
       payload: {},
     });
     expect(forbidden.statusCode).toBe(403);
+  });
+
+  it('AM can send to explicit targets in managed subjects; any out-of-scope target returns 403', async () => {
+    const inScope = await createPendingUser('ampendin', 'ampendin@test.com');
+    const outScope = await createPendingUser('ampendout', 'ampendout@test.com', subject2.id);
+
+    const forbidden = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { userIds: [inScope.id, outScope.id] },
+    });
+    expect(forbidden.statusCode).toBe(403);
+    expect(JSON.parse(forbidden.body).error).toBe('Forbidden: user is not in a subject you manage');
+
+    const ok = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: { userIds: [inScope.id] },
+    });
+    expect(ok.statusCode).toBe(200);
+    expect(JSON.parse(ok.body).sent).toBe(1);
+  });
+
+  it('AM all-pending mode only sends to pending users of managed subjects', async () => {
+    await createPendingUser('ampendall1', 'ampendall1@test.com');
+    await createPendingUser('ampendall2', 'ampendall2@test.com', subject2.id);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/users/send-setup-emails',
+      headers: { authorization: `Bearer ${amToken}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).sent).toBe(1);
   });
 
   it('validates userIds (max 500, valid UUIDs)', async () => {

--- a/backend/tests/unit/assignments.test.js
+++ b/backend/tests/unit/assignments.test.js
@@ -897,7 +897,9 @@ describe('Assignments Routes', () => {
       Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
       User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
       Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
-      const err = new Error('User is not a member of this subject');
+      // The model now throws 'User is not an active member of this subject';
+      // the route maps any 403 to its own hardcoded skip reason.
+      const err = new Error('User is not an active member of this subject');
       err.statusCode = 403;
       UserGroup.assignUserToGroup.mockRejectedValue(err);
       await handlers['/assignments/:id/import-mappings_post'](

--- a/backend/tests/unit/assignments.test.js
+++ b/backend/tests/unit/assignments.test.js
@@ -1,0 +1,1010 @@
+// Mock models at the top level
+jest.mock('../../src/models/Assignment');
+jest.mock('../../src/models/Subject');
+jest.mock('../../src/models/Group');
+jest.mock('../../src/models/UserGroup');
+jest.mock('../../src/models/User');
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
+const Assignment = require('../../src/models/Assignment');
+const Subject = require('../../src/models/Subject');
+const Group = require('../../src/models/Group');
+const UserGroup = require('../../src/models/UserGroup');
+const User = require('../../src/models/User');
+
+const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
+const ASSIGNMENT_ID = '40000000-0000-4000-8000-000000000001';
+const ASSIGNMENT_ID_2 = '40000000-0000-4000-8000-000000000002';
+const GROUP_ID = '10000000-0000-4000-8000-000000000001';
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+const USER_ID_2 = '00000000-0000-4000-8000-000000000002';
+const ADMIN_ID = '00000000-0000-4000-8000-00000000000a';
+
+describe('Assignments Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockFastify = (options = {}) => ({
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    checkRole: jest.fn().mockResolvedValue(options.checkRoleResult ?? true),
+    requireAdmin: jest.fn().mockResolvedValue(options.requireAdminResult ?? true),
+    requireAssignmentManager: jest.fn().mockResolvedValue(options.requireAssignmentManagerResult ?? true),
+    assertManagesAssignment: jest.fn().mockResolvedValue(options.assertManagesResult ?? true),
+  });
+
+  const captureHandlers = (mockFastify) => {
+    const handlers = {};
+    const wrapMethod = (method) => {
+      mockFastify[method].mockImplementation((path, ...args) => {
+        const config = args[0];
+        const handler = args.find((a) => typeof a === 'function');
+        if (config && config.preHandler) {
+          handlers[`${path}_${method}_pre`] = config.preHandler;
+        }
+        if (handler) {
+          handlers[`${path}_${method}`] = handler;
+        }
+      });
+    };
+    wrapMethod('get');
+    wrapMethod('post');
+    wrapMethod('put');
+    wrapMethod('delete');
+    return handlers;
+  };
+
+  const setup = (options = {}) => {
+    const mockFastify = createMockFastify(options);
+    const handlers = captureHandlers(mockFastify);
+    const assignmentsRoutes = require('../../src/routes/assignments');
+    assignmentsRoutes(mockFastify, {});
+    const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+    return { mockFastify, handlers, mockReply };
+  };
+
+  describe('GET /assignments', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('returns 400 for invalid subjectId query', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, query: { subjectId: 'bad' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+      expect(Assignment.findAll).not.toHaveBeenCalled();
+    });
+
+    it('returns all assignments for admin, passing subjectId filter', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [{ id: ASSIGNMENT_ID, name: 'A1', subject_id: SUBJECT_ID }];
+      Assignment.findAll.mockResolvedValue(rows);
+      await handlers['/assignments_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, query: { subjectId: SUBJECT_ID } },
+        mockReply
+      );
+      expect(Assignment.findAll).toHaveBeenCalledWith({ subjectId: SUBJECT_ID });
+      expect(mockReply.send).toHaveBeenCalledWith({ assignments: rows });
+    });
+
+    it('filters assignments for assignment_manager to managed union own-subject assignments', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [
+        { id: ASSIGNMENT_ID, name: 'Managed', subject_id: SUBJECT_ID },
+        { id: ASSIGNMENT_ID_2, name: 'OwnSubject', subject_id: SUBJECT_ID },
+        { id: '40000000-0000-4000-8000-000000000003', name: 'Other', subject_id: SUBJECT_ID },
+      ];
+      Assignment.findAll.mockResolvedValue(rows);
+      Assignment.findManagedBy.mockResolvedValue([{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }]);
+      Assignment.findForUser.mockResolvedValue([{ id: ASSIGNMENT_ID_2, subject_id: SUBJECT_ID }]);
+      await handlers['/assignments_get']({ user: { id: USER_ID, role: 'assignment_manager' }, query: {} }, mockReply);
+      expect(Assignment.findManagedBy).toHaveBeenCalledWith(USER_ID);
+      expect(Assignment.findForUser).toHaveBeenCalledWith(USER_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        assignments: [
+          { id: ASSIGNMENT_ID, name: 'Managed', subject_id: SUBJECT_ID },
+          { id: ASSIGNMENT_ID_2, name: 'OwnSubject', subject_id: SUBJECT_ID },
+        ],
+      });
+    });
+
+    it('filters assignments for regular user to own subjects only', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [
+        { id: ASSIGNMENT_ID, name: 'Mine', subject_id: SUBJECT_ID },
+        { id: ASSIGNMENT_ID_2, name: 'NotMine', subject_id: SUBJECT_ID },
+      ];
+      Assignment.findAll.mockResolvedValue(rows);
+      Assignment.findForUser.mockResolvedValue([{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }]);
+      await handlers['/assignments_get']({ user: { id: USER_ID, role: 'user' }, query: {} }, mockReply);
+      expect(Assignment.findManagedBy).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({
+        assignments: [{ id: ASSIGNMENT_ID, name: 'Mine', subject_id: SUBJECT_ID }],
+      });
+    });
+
+    it('handles error when fetching assignments', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findAll.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments_get']({ user: { id: ADMIN_ID, role: 'admin' }, query: {} }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /assignments/:id', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid assignment ID' });
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
+    });
+
+    it('returns 403 for non-member regular user', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Subject.isMember.mockResolvedValue(false);
+      await handlers['/assignments/:id_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(Subject.isMember).toHaveBeenCalledWith(SUBJECT_ID, USER_ID);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('returns 403 for assignment_manager who neither is member nor manages', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.isManager.mockResolvedValue(false);
+      await handlers['/assignments/:id_get'](
+        { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(Assignment.isManager).toHaveBeenCalledWith(USER_ID, ASSIGNMENT_ID);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('allows member user', async () => {
+      const { handlers, mockReply } = setup();
+      const assignment = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'A1' };
+      Assignment.findById.mockResolvedValue(assignment);
+      Subject.isMember.mockResolvedValue(true);
+      await handlers['/assignments/:id_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ assignment });
+    });
+
+    it('allows managing assignment_manager who is not a member', async () => {
+      const { handlers, mockReply } = setup();
+      const assignment = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'A1' };
+      Assignment.findById.mockResolvedValue(assignment);
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.isManager.mockResolvedValue(true);
+      await handlers['/assignments/:id_get'](
+        { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ assignment });
+    });
+
+    it('allows admin without membership checks', async () => {
+      const { handlers, mockReply } = setup();
+      const assignment = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'A1' };
+      Assignment.findById.mockResolvedValue(assignment);
+      await handlers['/assignments/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(Subject.isMember).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ assignment });
+    });
+
+    it('handles error when fetching assignment', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('POST /assignments', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments_post_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/assignments_post_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('rejects invalid body', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments_post']({ body: { name: 'A1' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+      expect(Assignment.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/assignments_post']({ body: { subjectId: SUBJECT_ID, name: 'A1' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+    });
+
+    it('rejects duplicate assignment name within subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Assignment.findByName.mockResolvedValue({ id: ASSIGNMENT_ID, name: 'A1' });
+      await handlers['/assignments_post']({ body: { subjectId: SUBJECT_ID, name: 'A1' } }, mockReply);
+      expect(Assignment.findByName).toHaveBeenCalledWith(SUBJECT_ID, 'A1');
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(Assignment.create).not.toHaveBeenCalled();
+    });
+
+    it('creates assignment successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Assignment.findByName.mockResolvedValue(null);
+      const created = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'A1' };
+      Assignment.create.mockResolvedValue(created);
+      await handlers['/assignments_post']({ body: { subjectId: SUBJECT_ID, name: 'A1' } }, mockReply);
+      expect(Assignment.create).toHaveBeenCalledWith(SUBJECT_ID, 'A1');
+      expect(mockReply.code).toHaveBeenCalledWith(201);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'Assignment created successfully',
+        assignment: created,
+      });
+    });
+
+    it('handles error when creating assignment', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Assignment.findByName.mockResolvedValue(null);
+      Assignment.create.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments_post']({ body: { subjectId: SUBJECT_ID, name: 'A1' } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('PUT /assignments/:id', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_put_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'user' } };
+      const result = await handlers['/assignments/:id_put_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_put']({ params: { id: 'bad' }, body: { name: 'A1' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid assignment ID' });
+    });
+
+    it('rejects invalid body', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_put']({ params: { id: ASSIGNMENT_ID }, body: { name: '' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id_put']({ params: { id: ASSIGNMENT_ID }, body: { name: 'New' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('rejects duplicate name owned by a different assignment in the same subject', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'Old' });
+      Assignment.findByName.mockResolvedValue({ id: ASSIGNMENT_ID_2, name: 'New' });
+      await handlers['/assignments/:id_put']({ params: { id: ASSIGNMENT_ID }, body: { name: 'New' } }, mockReply);
+      expect(Assignment.findByName).toHaveBeenCalledWith(SUBJECT_ID, 'New');
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(Assignment.update).not.toHaveBeenCalled();
+    });
+
+    it('updates assignment successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'Old' });
+      Assignment.findByName.mockResolvedValue(null);
+      const updated = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'New' };
+      Assignment.update.mockResolvedValue(updated);
+      await handlers['/assignments/:id_put']({ params: { id: ASSIGNMENT_ID }, body: { name: 'New' } }, mockReply);
+      expect(Assignment.update).toHaveBeenCalledWith(ASSIGNMENT_ID, { name: 'New' });
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'Assignment updated successfully',
+        assignment: updated,
+      });
+    });
+
+    it('handles error when updating assignment', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id_put']({ params: { id: ASSIGNMENT_ID }, body: { name: 'New' } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('DELETE /assignments/:id', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_delete_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/assignments/:id_delete_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id_delete']({ params: { id: 'bad' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id_delete']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(Assignment.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes assignment successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      Assignment.delete.mockResolvedValue({ id: ASSIGNMENT_ID });
+      await handlers['/assignments/:id_delete']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(Assignment.delete).toHaveBeenCalledWith(ASSIGNMENT_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Assignment deleted successfully' });
+    });
+
+    it('handles error when deleting assignment', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      Assignment.delete.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id_delete']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /assignments/:id/groups', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/groups_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad' }, query: {} },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID }, query: {} },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 403 for non-member regular user', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Subject.isMember.mockResolvedValue(false);
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: ASSIGNMENT_ID }, query: {} },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(Group.findAllByAssignment).not.toHaveBeenCalled();
+    });
+
+    it('returns groups with enabledOnly=false by default', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Subject.isMember.mockResolvedValue(true);
+      const groups = [{ id: GROUP_ID, name: 'G1' }];
+      Group.findAllByAssignment.mockResolvedValue(groups);
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: ASSIGNMENT_ID }, query: {} },
+        mockReply
+      );
+      expect(Group.findAllByAssignment).toHaveBeenCalledWith(ASSIGNMENT_ID, { enabledOnly: false });
+      expect(mockReply.send).toHaveBeenCalledWith({ groups });
+    });
+
+    it('passes enabledOnly=true when ?enabled=true', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      const groups = [{ id: GROUP_ID, name: 'G1', enabled: true }];
+      Group.findAllByAssignment.mockResolvedValue(groups);
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID }, query: { enabled: 'true' } },
+        mockReply
+      );
+      expect(Group.findAllByAssignment).toHaveBeenCalledWith(ASSIGNMENT_ID, { enabledOnly: true });
+      expect(mockReply.send).toHaveBeenCalledWith({ groups });
+    });
+
+    it('handles error when fetching groups', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id/groups_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID }, query: {} },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /assignments/:id/managers', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/managers_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/assignments/:id/managers_get_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/managers_get']({ params: { id: 'bad' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id/managers_get']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns managers successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      const managers = [{ id: USER_ID, username: 'am1' }];
+      Assignment.getManagers.mockResolvedValue(managers);
+      await handlers['/assignments/:id/managers_get']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(Assignment.getManagers).toHaveBeenCalledWith(ASSIGNMENT_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({ managers });
+    });
+
+    it('handles error when fetching managers', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id/managers_get']({ params: { id: ASSIGNMENT_ID } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('PUT /assignments/:id/managers', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/managers_put_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/assignments/:id/managers_put_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/managers_put']({ params: { id: 'bad' }, body: { userIds: [] } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid assignment ID' });
+    });
+
+    it('rejects invalid body', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: 'not-an-array' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(Assignment.setManagers).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 400 when one or more users do not exist', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByIds.mockResolvedValue([]);
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'One or more users do not exist' });
+      expect(Assignment.setManagers).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when a user does not have the assignment_manager role', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByIds.mockResolvedValue([
+        { id: USER_ID, role_name: 'assignment_manager' },
+        { id: USER_ID_2, role_name: 'user' },
+      ]);
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [USER_ID, USER_ID_2] } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'All managers must have the assignment_manager role' });
+      expect(Assignment.setManagers).not.toHaveBeenCalled();
+    });
+
+    it('sets managers successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByIds.mockResolvedValue([{ id: USER_ID, role_name: 'assignment_manager' }]);
+      Assignment.setManagers.mockResolvedValue();
+      const managers = [{ id: USER_ID, username: 'am1' }];
+      Assignment.getManagers.mockResolvedValue(managers);
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(Assignment.setManagers).toHaveBeenCalledWith(ASSIGNMENT_ID, [USER_ID]);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'Assignment managers updated successfully',
+        managers,
+      });
+    });
+
+    it('clears managers with an empty userIds array without user lookup', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      Assignment.setManagers.mockResolvedValue();
+      Assignment.getManagers.mockResolvedValue([]);
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [] } },
+        mockReply
+      );
+      expect(User.findByIds).not.toHaveBeenCalled();
+      expect(Assignment.setManagers).toHaveBeenCalledWith(ASSIGNMENT_ID, []);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'Assignment managers updated successfully',
+        managers: [],
+      });
+    });
+
+    it('handles error when setting managers', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByIds.mockResolvedValue([{ id: USER_ID, role_name: 'assignment_manager' }]);
+      Assignment.setManagers.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id/managers_put'](
+        { params: { id: ASSIGNMENT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /assignments/:id/export-mappings', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/export-mappings_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/export-mappings_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id/export-mappings_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns reply when assertManagesAssignment fails', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ assertManagesResult: false });
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: ASSIGNMENT_ID } };
+      const result = await handlers['/assignments/:id/export-mappings_get'](request, mockReply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, mockReply, ASSIGNMENT_ID);
+      expect(result).toBe(mockReply);
+      expect(UserGroup.getExportMappings).not.toHaveBeenCalled();
+    });
+
+    it('returns mappings with group_name mapped to groupName', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      UserGroup.getExportMappings.mockResolvedValue([
+        { email: 'a@test.com', group_name: 'G1' },
+        { email: 'b@test.com', group_name: 'G2' },
+      ]);
+      await handlers['/assignments/:id/export-mappings_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(UserGroup.getExportMappings).toHaveBeenCalledWith(ASSIGNMENT_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        mappings: [
+          { email: 'a@test.com', groupName: 'G1' },
+          { email: 'b@test.com', groupName: 'G2' },
+        ],
+      });
+    });
+
+    it('handles error when exporting mappings', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      UserGroup.getExportMappings.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id/export-mappings_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: ASSIGNMENT_ID } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('POST /assignments/:id/import-mappings', () => {
+    const adminReq = (body) => ({
+      user: { id: ADMIN_ID, role: 'admin' },
+      params: { id: ASSIGNMENT_ID },
+      body,
+    });
+
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/import-mappings_post_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/assignments/:id/import-mappings_post'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad' }, body: { rows: [] } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid assignment ID' });
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue(null);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns reply when assertManagesAssignment fails', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ assertManagesResult: false });
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      const request = {
+        user: { id: USER_ID, role: 'assignment_manager' },
+        params: { id: ASSIGNMENT_ID },
+        body: { rows: [{ email: 'a@test.com', groupName: 'G1' }] },
+      };
+      const result = await handlers['/assignments/:id/import-mappings_post'](request, mockReply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, mockReply, ASSIGNMENT_ID);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 when rows is missing or empty', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      await handlers['/assignments/:id/import-mappings_post'](adminReq({ rows: [] }), mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'No mappings to import' });
+    });
+
+    it('returns 400 when rows exceed the maximum', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      const rows = Array.from({ length: 2001 }, (_, i) => ({ email: `u${i}@test.com`, groupName: 'G1' }));
+      await handlers['/assignments/:id/import-mappings_post'](adminReq({ rows }), mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.stringContaining('maximum') });
+    });
+
+    it('imports mappings successfully with replace and assignment-scoped group lookup', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      UserGroup.assignUserToGroup.mockResolvedValue();
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(Group.findByNames).toHaveBeenCalledWith(ASSIGNMENT_ID, ['G1']);
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID, { replace: true });
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: [], errors: [] });
+    });
+
+    it('skips rows for unknown emails', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'ghost@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [{ email: 'ghost@test.com', groupName: 'G1', reason: 'User not found' }],
+        errors: [],
+      });
+    });
+
+    it('skips rows for unknown group names', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'Ghost' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [{ email: 'a@test.com', groupName: 'Ghost', reason: 'Group not found' }],
+        errors: [],
+      });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('skips admin and assignment_manager target users', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'admin@test.com', role_name: 'admin' }]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'admin@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [
+          {
+            email: 'admin@test.com',
+            groupName: 'G1',
+            reason: 'Admins and Assignment Managers cannot be assigned to a group',
+          },
+        ],
+        errors: [],
+      });
+    });
+
+    it('skips rows when the user is not a member of the subject (403)', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      const err = new Error('User is not a member of this subject');
+      err.statusCode = 403;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [{ email: 'a@test.com', groupName: 'G1', reason: 'User is not a member of this subject' }],
+        errors: [],
+      });
+    });
+
+    it('skips rows when the group is full (409)', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      const err = new Error('Group is full');
+      err.statusCode = 409;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [{ email: 'a@test.com', groupName: 'G1', reason: 'Group is full' }],
+        errors: [],
+      });
+    });
+
+    it('passes through pre-marked skip rows', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([]);
+      Group.findByNames.mockResolvedValue([]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ action: 'skip', email: 'a@test.com', groupName: 'G1', skipReason: 'Duplicate row' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [{ email: 'a@test.com', groupName: 'G1', reason: 'Duplicate row' }],
+        errors: [],
+      });
+    });
+
+    it('records validation errors for invalid rows', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([]);
+      Group.findByNames.mockResolvedValue([]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'not-an-email', groupName: 'G1' }] }),
+        mockReply
+      );
+      const payload = mockReply.send.mock.calls[0][0];
+      expect(payload.imported).toBe(0);
+      expect(payload.errors).toHaveLength(1);
+      expect(payload.errors[0]).toMatchObject({ email: 'not-an-email', groupName: 'G1' });
+    });
+
+    it('returns 409 for ambiguous case-insensitive group names', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([
+        { id: GROUP_ID, name: 'g1' },
+        { id: '10000000-0000-4000-8000-000000000002', name: 'G1' },
+      ]);
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.stringContaining('Ambiguous group name') });
+    });
+
+    it('records generic errors for unexpected row failures', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockResolvedValue([{ id: USER_ID, email: 'a@test.com', role_name: 'user' }]);
+      Group.findByNames.mockResolvedValue([{ id: GROUP_ID, name: 'G1' }]);
+      UserGroup.assignUserToGroup.mockRejectedValue(new Error('Database error'));
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({
+        imported: 0,
+        skipped: [],
+        errors: [{ email: 'a@test.com', groupName: 'G1', error: 'Failed to process row' }],
+      });
+    });
+
+    it('handles error when importing mappings', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID });
+      User.findByEmails.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/assignments/:id/import-mappings_post'](
+        adminReq({ rows: [{ email: 'a@test.com', groupName: 'G1' }] }),
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/backend/tests/unit/auth.test.js
+++ b/backend/tests/unit/auth.test.js
@@ -34,6 +34,18 @@ jest.mock('../../src/services/email', () => ({
   sendEmail: jest.fn(),
 }));
 
+jest.mock('../../src/models/Subject', () => ({
+  findForUser: jest.fn(),
+}));
+
+jest.mock('../../src/models/Assignment', () => ({
+  findManagedBy: jest.fn(),
+}));
+
+jest.mock('../../src/models/UserGroup', () => ({
+  findMembershipsForUser: jest.fn(),
+}));
+
 jest.mock('../../src/config/index', () => ({
   app: {
     registrationEnabled: true,
@@ -51,11 +63,18 @@ jest.mock('../../src/utils/logger', () => ({
 
 const User = require('../../src/models/User');
 const Role = require('../../src/models/Role');
+const Subject = require('../../src/models/Subject');
+const Assignment = require('../../src/models/Assignment');
+const UserGroup = require('../../src/models/UserGroup');
 const PasswordResetToken = require('../../src/models/PasswordResetToken');
 const { sendPasswordResetEmail } = require('../../src/services/email');
 const config = require('../../src/config/index');
 
 describe('Auth Routes', () => {
+  const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
+  const ASSIGNMENT_ID = '40000000-0000-4000-8000-000000000001';
+  const GROUP_ID = '10000000-0000-4000-8000-000000000001';
+
   let mockReply;
   let mockFastify;
   let capturedHandlers;
@@ -87,6 +106,11 @@ describe('Auth Routes', () => {
       }),
       generateToken: jest.fn().mockResolvedValue('mock-token'),
     };
+
+    // Default hierarchy enrichment mocks
+    Subject.findForUser.mockResolvedValue([]);
+    UserGroup.findMembershipsForUser.mockResolvedValue([]);
+    Assignment.findManagedBy.mockResolvedValue([]);
   });
 
   describe('POST /auth/register', () => {
@@ -484,34 +508,45 @@ describe('Auth Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid credentials' });
     });
 
-    it('successfully logs in user', async () => {
+    it('successfully logs in user with subjects and memberships and no group claims in the JWT', async () => {
       const mockUser = {
         id: '00000000-0000-4000-8000-000000000001',
         username: 'testuser',
         email: 'test@test.com',
+        first_name: 'Test',
+        last_name: 'User',
         enabled: true,
         password_hash: 'hash',
         role_name: 'admin',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        group_name: 'Team A',
         student_id: 'S123',
       };
       User.findByUsername.mockResolvedValue(mockUser);
       User.verifyPassword.mockResolvedValue(true);
       mockFastify.generateToken.mockResolvedValue('jwt-token-123');
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID, name: 'Subject 1', created_at: 'now' }]);
+      const memberships = [
+        {
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'Assignment 1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'Subject 1',
+          group_id: GROUP_ID,
+          group_name: 'Group 1',
+        },
+      ];
+      UserGroup.findMembershipsForUser.mockResolvedValue(memberships);
 
       const authRoutes = require('../../src/routes/auth');
       authRoutes(mockFastify, {});
 
       await capturedHandlers['/auth/login']({ body: { username: 'testuser', password: 'correctpassword' } }, mockReply);
 
+      // JWT payload must contain only id/username/email/role — no groupId/groupName claims
       expect(mockFastify.generateToken).toHaveBeenCalledWith({
         id: '00000000-0000-4000-8000-000000000001',
         username: 'testuser',
         email: 'test@test.com',
         role: 'admin',
-        groupId: '10000000-0000-4000-8000-000000000001',
-        groupName: 'Team A',
       });
       expect(mockReply.send).toHaveBeenCalledWith({
         message: 'Login successful',
@@ -520,12 +555,73 @@ describe('Auth Routes', () => {
           id: '00000000-0000-4000-8000-000000000001',
           username: 'testuser',
           email: 'test@test.com',
+          firstName: 'Test',
+          lastName: 'User',
           role: 'admin',
-          groupId: '10000000-0000-4000-8000-000000000001',
-          groupName: 'Team A',
           studentId: 'S123',
+          subjects: [{ id: SUBJECT_ID, name: 'Subject 1' }],
+          memberships,
+          managedAssignments: [],
         },
       });
+    });
+
+    it('includes managedAssignments for assignment_manager login', async () => {
+      const mockUser = {
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'manager',
+        email: 'am@test.com',
+        first_name: 'Man',
+        last_name: 'Ager',
+        enabled: true,
+        password_hash: 'hash',
+        role_name: 'assignment_manager',
+        student_id: null,
+      };
+      User.findByUsername.mockResolvedValue(mockUser);
+      User.verifyPassword.mockResolvedValue(true);
+      const managed = [{ id: ASSIGNMENT_ID, name: 'Assignment 1', subject_id: SUBJECT_ID, subject_name: 'Subject 1' }];
+      Assignment.findManagedBy.mockResolvedValue(managed);
+
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      await capturedHandlers['/auth/login']({ body: { username: 'manager', password: 'correctpassword' } }, mockReply);
+
+      expect(Assignment.findManagedBy).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000002');
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({ role: 'assignment_manager', managedAssignments: managed }),
+        })
+      );
+    });
+
+    it('does not query managed assignments for regular user login', async () => {
+      const mockUser = {
+        id: '00000000-0000-4000-8000-000000000003',
+        username: 'regular',
+        email: 'reg@test.com',
+        first_name: 'Reg',
+        last_name: 'User',
+        enabled: true,
+        password_hash: 'hash',
+        role_name: 'user',
+        student_id: null,
+      };
+      User.findByUsername.mockResolvedValue(mockUser);
+      User.verifyPassword.mockResolvedValue(true);
+
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      await capturedHandlers['/auth/login']({ body: { username: 'regular', password: 'correctpassword' } }, mockReply);
+
+      expect(Assignment.findManagedBy).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: expect.objectContaining({ managedAssignments: [] }),
+        })
+      );
     });
 
     it('handles login error', async () => {
@@ -608,7 +704,7 @@ describe('Auth Routes', () => {
       expect(result).toBeUndefined();
     });
 
-    it('returns current user info', async () => {
+    it('returns current user info enriched with subjects, memberships and managedAssignments', async () => {
       const authRoutes = require('../../src/routes/auth');
       authRoutes(mockFastify, {});
 
@@ -616,11 +712,23 @@ describe('Auth Routes', () => {
         id: '00000000-0000-4000-8000-000000000001',
         username: 'testuser',
         email: 'test@test.com',
+        first_name: 'Test',
+        last_name: 'User',
         role_name: 'admin',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        group_name: 'Team A',
         student_id: null,
       });
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID, name: 'Subject 1', created_at: 'now' }]);
+      const memberships = [
+        {
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'Assignment 1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'Subject 1',
+          group_id: GROUP_ID,
+          group_name: 'Group 1',
+        },
+      ];
+      UserGroup.findMembershipsForUser.mockResolvedValue(memberships);
 
       const request = {
         user: {
@@ -628,24 +736,55 @@ describe('Auth Routes', () => {
           username: 'testuser',
           email: 'test@test.com',
           role: 'admin',
-          groupId: '10000000-0000-4000-8000-000000000001',
-          groupName: 'Team A',
         },
       };
 
       await capturedHandlers['/auth/me'](request, mockReply);
 
       expect(User.findById).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
+      expect(Subject.findForUser).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
+      expect(UserGroup.findMembershipsForUser).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
       expect(mockReply.send).toHaveBeenCalledWith({
         user: {
           id: '00000000-0000-4000-8000-000000000001',
           username: 'testuser',
           email: 'test@test.com',
+          firstName: 'Test',
+          lastName: 'User',
           role: 'admin',
-          groupId: '10000000-0000-4000-8000-000000000001',
-          groupName: 'Team A',
           studentId: null,
+          subjects: [{ id: SUBJECT_ID, name: 'Subject 1' }],
+          memberships,
+          managedAssignments: [],
         },
+      });
+    });
+
+    it('includes managedAssignments for assignment_manager in /auth/me', async () => {
+      const authRoutes = require('../../src/routes/auth');
+      authRoutes(mockFastify, {});
+
+      User.findById.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'manager',
+        email: 'am@test.com',
+        first_name: 'Man',
+        last_name: 'Ager',
+        role_name: 'assignment_manager',
+        student_id: null,
+      });
+      const managed = [{ id: ASSIGNMENT_ID, name: 'Assignment 1', subject_id: SUBJECT_ID, subject_name: 'Subject 1' }];
+      Assignment.findManagedBy.mockResolvedValue(managed);
+
+      const request = { user: { id: '00000000-0000-4000-8000-000000000002' } };
+      await capturedHandlers['/auth/me'](request, mockReply);
+
+      expect(Assignment.findManagedBy).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000002');
+      expect(mockReply.send).toHaveBeenCalledWith({
+        user: expect.objectContaining({
+          role: 'assignment_manager',
+          managedAssignments: managed,
+        }),
       });
     });
 

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -1,7 +1,10 @@
 // Mock models at the top level
 jest.mock('../../src/models/Group');
-jest.mock('../../src/models/User');
+jest.mock('../../src/models/UserGroup');
+jest.mock('../../src/models/Assignment');
+jest.mock('../../src/models/Subject');
 jest.mock('../../src/models/Config');
+jest.mock('../../src/models/User');
 
 jest.mock('../../src/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
@@ -13,8 +16,40 @@ jest.mock('../../src/utils/logger', () => ({
 }));
 
 const Group = require('../../src/models/Group');
-const User = require('../../src/models/User');
+const UserGroup = require('../../src/models/UserGroup');
+const Assignment = require('../../src/models/Assignment');
+const Subject = require('../../src/models/Subject');
 const Config = require('../../src/models/Config');
+const User = require('../../src/models/User');
+
+const GROUP_ID = '10000000-0000-4000-8000-000000000001';
+const OTHER_GROUP_ID = '10000000-0000-4000-8000-000000000002';
+const MISSING_GROUP_ID = '10000000-0000-4000-8000-000000000999';
+const ASSIGNMENT_ID = '20000000-0000-4000-8000-000000000001';
+const OTHER_ASSIGNMENT_ID = '20000000-0000-4000-8000-000000000002';
+const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
+const ADMIN_ID = '00000000-0000-4000-8000-000000000001';
+const AM_ID = '00000000-0000-4000-8000-000000000002';
+const USER_ID = '00000000-0000-4000-8000-000000000010';
+
+const adminUser = () => ({ id: ADMIN_ID, role: 'admin' });
+const amUser = () => ({ id: AM_ID, role: 'assignment_manager' });
+const plainUser = () => ({ id: USER_ID, role: 'user' });
+
+const mockGroupRow = (overrides = {}) => ({
+  id: GROUP_ID,
+  assignment_id: ASSIGNMENT_ID,
+  name: 'Team A',
+  enabled: true,
+  max_members: 5,
+  member_count: 2,
+  assignment_name: 'Assignment 1',
+  subject_id: SUBJECT_ID,
+  subject_name: 'COMP10001',
+  created_at: new Date('2026-01-01T00:00:00Z'),
+  updated_at: new Date('2026-01-02T00:00:00Z'),
+  ...overrides,
+});
 
 describe('Groups Routes', () => {
   beforeEach(() => {
@@ -28,6 +63,7 @@ describe('Groups Routes', () => {
     delete: jest.fn(),
     requireAdmin: jest.fn().mockResolvedValue(true),
     requireAssignmentManager: jest.fn().mockResolvedValue(true),
+    assertManagesAssignment: jest.fn().mockResolvedValue(true),
   });
 
   const captureHandlers = (mockFastify) => {
@@ -61,70 +97,33 @@ describe('Groups Routes', () => {
 
   const mockReply = () => ({ code: jest.fn().mockReturnThis(), send: jest.fn() });
 
-  describe('GET /groups', () => {
-    it('rejects unauthenticated request', () => {
+  const denyManagesAssignment = (mockFastify) => {
+    mockFastify.assertManagesAssignment.mockImplementation(async (request, reply) => {
+      reply.code(403).send({ error: 'Forbidden: You do not manage this assignment' });
+      return false;
+    });
+  };
+
+  describe('removed endpoints', () => {
+    it('does not register GET /groups (listing moved to /assignments/:id/groups)', () => {
       const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups_get_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(handlers['/groups_get']).toBeUndefined();
+      expect(handlers['/groups_get_pre']).toBeUndefined();
     });
 
-    it('allows authenticated request', () => {
+    it('does not register GET /groups/enabled', () => {
       const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups_get_pre']({ user: { id: '00000000-0000-4000-8000-000000000001' } }, reply);
-      expect(reply.code).not.toHaveBeenCalled();
+      expect(handlers['/groups/enabled_get']).toBeUndefined();
     });
 
-    it('returns all groups successfully', async () => {
+    it('does not register POST /groups/import-mappings', () => {
       const { handlers } = setupRoute();
-      Group.findAll.mockResolvedValue([{ id: '10000000-0000-4000-8000-000000000001', name: 'Team A', enabled: true }]);
-      const reply = mockReply();
-      await handlers['/groups_get']({}, reply);
-      expect(Group.findAll).toHaveBeenCalled();
-      expect(reply.send).toHaveBeenCalledWith({
-        groups: [{ id: '10000000-0000-4000-8000-000000000001', name: 'Team A', enabled: true }],
-      });
+      expect(handlers['/groups/import-mappings_post']).toBeUndefined();
     });
 
-    it('handles error when fetching groups', async () => {
+    it('does not register GET /groups/export-mappings', () => {
       const { handlers } = setupRoute();
-      Group.findAll.mockRejectedValue(new Error('Database error'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups_get']({}, reply);
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
-    });
-  });
-
-  describe('GET /groups/enabled', () => {
-    it('rejects unauthenticated request', () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups/enabled_get_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-    });
-
-    it('returns enabled groups successfully', async () => {
-      const { handlers } = setupRoute();
-      Group.findEnabled.mockResolvedValue([
-        { id: '10000000-0000-4000-8000-000000000001', name: 'Active Team', enabled: true },
-      ]);
-      const reply = mockReply();
-      await handlers['/groups/enabled_get']({}, reply);
-      expect(Group.findEnabled).toHaveBeenCalled();
-    });
-
-    it('handles error when fetching enabled groups', async () => {
-      const { handlers } = setupRoute();
-      Group.findEnabled.mockRejectedValue(new Error('Database error'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups/enabled_get']({}, reply);
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(handlers['/groups/export-mappings_get']).toBeUndefined();
     });
   });
 
@@ -134,36 +133,20 @@ describe('Groups Routes', () => {
       const reply = mockReply();
       handlers['/groups/:id_get_pre']({ user: null }, reply);
       expect(reply.code).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
     });
 
-    it('returns group by id with members', async () => {
+    it('allows authenticated request through preHandler', () => {
       const { handlers } = setupRoute();
-      const mockGroup = {
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Test Group',
-        enabled: true,
-        max_members: 10,
-        member_count: 3,
-        created_at: new Date(),
-        updated_at: new Date(),
-      };
-      const mockMembers = [{ id: '00000000-0000-4000-8000-000000000001', username: 'user1', role_name: 'user' }];
-      Group.findById.mockResolvedValue(mockGroup);
-      Group.getMembers.mockResolvedValue(mockMembers);
       const reply = mockReply();
-      await handlers['/groups/:id_get']({ params: { id: '10000000-0000-4000-8000-000000000001' } }, reply);
-      expect(Group.findById).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001');
-      expect(Group.getMembers).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001');
-      expect(reply.send).toHaveBeenCalledWith({
-        group: expect.objectContaining({ maxMembers: 10, memberCount: 3 }),
-        members: mockMembers,
-      });
+      handlers['/groups/:id_get_pre']({ user: plainUser() }, reply);
+      expect(reply.code).not.toHaveBeenCalled();
     });
 
     it('returns 400 for invalid UUID in path param', async () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
-      await handlers['/groups/:id_get']({ params: { id: 'not-a-uuid' } }, reply);
+      await handlers['/groups/:id_get']({ user: adminUser(), params: { id: 'not-a-uuid' } }, reply);
       expect(reply.code).toHaveBeenCalledWith(400);
       expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
       expect(Group.findById).not.toHaveBeenCalled();
@@ -173,8 +156,84 @@ describe('Groups Routes', () => {
       const { handlers } = setupRoute();
       Group.findById.mockResolvedValue(null);
       const reply = mockReply();
-      await handlers['/groups/:id_get']({ params: { id: '10000000-0000-4000-8000-000000000999' } }, reply);
+      await handlers['/groups/:id_get']({ user: adminUser(), params: { id: MISSING_GROUP_ID } }, reply);
       expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+    });
+
+    it('returns full group mapping with members for admin', async () => {
+      const { handlers } = setupRoute();
+      const row = mockGroupRow();
+      const members = [{ id: USER_ID, username: 'user1', role_name: 'user' }];
+      Group.findById.mockResolvedValue(row);
+      UserGroup.getMembers.mockResolvedValue(members);
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
+      expect(Group.findById).toHaveBeenCalledWith(GROUP_ID);
+      expect(UserGroup.getMembers).toHaveBeenCalledWith(GROUP_ID);
+      expect(reply.send).toHaveBeenCalledWith({
+        group: {
+          id: GROUP_ID,
+          name: 'Team A',
+          enabled: true,
+          maxMembers: 5,
+          memberCount: 2,
+          assignmentId: ASSIGNMENT_ID,
+          assignmentName: 'Assignment 1',
+          subjectId: SUBJECT_ID,
+          subjectName: 'COMP10001',
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        },
+        members,
+      });
+    });
+
+    it('allows a subject member to view the group', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(mockGroupRow());
+      Subject.isMember.mockResolvedValue(true);
+      UserGroup.getMembers.mockResolvedValue([]);
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(Subject.isMember).toHaveBeenCalledWith(SUBJECT_ID, USER_ID);
+      expect(reply.code).not.toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ group: expect.any(Object), members: [] }));
+    });
+
+    it('rejects a plain user who is not a subject member', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(mockGroupRow());
+      Subject.isMember.mockResolvedValue(false);
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Forbidden: You do not have access to this group' });
+      expect(UserGroup.getMembers).not.toHaveBeenCalled();
+    });
+
+    it('allows an assignment manager who manages the assignment', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(mockGroupRow());
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.isManager.mockResolvedValue(true);
+      UserGroup.getMembers.mockResolvedValue([]);
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ user: amUser(), params: { id: GROUP_ID } }, reply);
+      expect(Assignment.isManager).toHaveBeenCalledWith(AM_ID, ASSIGNMENT_ID);
+      expect(reply.code).not.toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ members: [] }));
+    });
+
+    it('rejects an assignment manager who does not manage the assignment', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(mockGroupRow());
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.isManager.mockResolvedValue(false);
+      const reply = mockReply();
+      await handlers['/groups/:id_get']({ user: amUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Forbidden: You do not have access to this group' });
     });
 
     it('handles error when fetching group', async () => {
@@ -182,177 +241,141 @@ describe('Groups Routes', () => {
       Group.findById.mockRejectedValue(new Error('Database error'));
       const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
-      await handlers['/groups/:id_get']({ params: { id: '10000000-0000-4000-8000-000000000001' } }, reply);
+      await handlers['/groups/:id_get']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
       expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to retrieve group' });
     });
   });
 
   describe('POST /groups', () => {
+    beforeEach(() => {
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, name: 'Assignment 1', subject_id: SUBJECT_ID });
+      Group.findByName.mockResolvedValue(null);
+    });
+
     it('rejects unauthenticated request', () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
       handlers['/groups_post_pre']({ user: null }, reply);
       expect(reply.code).toHaveBeenCalledWith(401);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
     });
 
-    it('returns reply when admin check fails in preHandler', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAdmin.mockResolvedValue(false);
-      const reply = mockReply();
-      const request = { user: { id: '00000000-0000-4000-8000-000000000001', role: 'user' } };
-      const result = await handlers['/groups_post_pre'](request, reply);
-      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
-    });
-
-    it('rejects missing group name', async () => {
+    it('rejects invalid body (missing assignmentId)', async () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
-      await handlers['/groups_post'](
-        { user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' }, body: {} },
-        reply
-      );
+      await handlers['/groups_post']({ user: adminUser(), body: { name: 'Team A' } }, reply);
       expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+      expect(Group.create).not.toHaveBeenCalled();
     });
 
-    it('rejects when group name already exists', async () => {
+    it('rejects invalid body (missing name)', async () => {
       const { handlers } = setupRoute();
-      Group.findByName.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Existing Group',
-        enabled: true,
-      });
       const reply = mockReply();
-      await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'existing group' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(409);
-    });
-
-    it('creates group with enabled=true by default', async () => {
-      const { handlers } = setupRoute();
-      Group.findByName.mockResolvedValue(null);
-      Group.create.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'New Group',
-        enabled: true,
-        max_members: null,
-      });
-      const reply = mockReply();
-      await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'New Group' },
-        },
-        reply
-      );
-      expect(Group.create).toHaveBeenCalledWith('New Group', true, null);
-      expect(reply.code).toHaveBeenCalledWith(201);
-    });
-
-    it('creates group with enabled=false', async () => {
-      const { handlers } = setupRoute();
-      Group.findByName.mockResolvedValue(null);
-      Group.create.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Disabled Group',
-        enabled: false,
-        max_members: null,
-      });
-      const reply = mockReply();
-      await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'Disabled Group', enabled: false },
-        },
-        reply
-      );
-      expect(Group.create).toHaveBeenCalledWith('Disabled Group', false, null);
-    });
-
-    it('creates group with maxMembers', async () => {
-      const { handlers } = setupRoute();
-      Group.findByName.mockResolvedValue(null);
-      Group.create.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Limited',
-        enabled: true,
-        max_members: 5,
-      });
-      const reply = mockReply();
-      await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'Limited', maxMembers: 5 },
-        },
-        reply
-      );
-      expect(Group.create).toHaveBeenCalledWith('Limited', true, 5);
-      expect(reply.code).toHaveBeenCalledWith(201);
-      expect(reply.send).toHaveBeenCalledWith(
-        expect.objectContaining({ group: expect.objectContaining({ maxMembers: 5 }) })
-      );
+      await handlers['/groups_post']({ user: adminUser(), body: { assignmentId: ASSIGNMENT_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
     });
 
     it('rejects invalid maxMembers (non-positive)', async () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
       await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'Bad', maxMembers: 0 },
-        },
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'Bad', maxMembers: 0 } },
         reply
       );
       expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: expect.any(String) });
     });
 
-    it('rejects invalid maxMembers (NaN)', async () => {
+    it('returns 404 when assignment not found', async () => {
       const { handlers } = setupRoute();
+      Assignment.findById.mockResolvedValue(null);
       const reply = mockReply();
       await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'Bad', maxMembers: 'abc' },
-        },
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'Team A' } },
         reply
       );
-      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
+      expect(Group.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user does not manage the assignment', async () => {
+      const { mockFastify, handlers } = setupRoute();
+      denyManagesAssignment(mockFastify);
+      const reply = mockReply();
+      const request = { user: plainUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'Team A' } };
+      await handlers['/groups_post'](request, reply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, reply, ASSIGNMENT_ID);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Forbidden: You do not manage this assignment' });
+      expect(Group.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects when group name already exists within the assignment', async () => {
+      const { handlers } = setupRoute();
+      Group.findByName.mockResolvedValue({ id: OTHER_GROUP_ID, name: 'Team A' });
+      const reply = mockReply();
+      await handlers['/groups_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'team a' } },
+        reply
+      );
+      expect(Group.findByName).toHaveBeenCalledWith(ASSIGNMENT_ID, 'team a');
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group name already exists' });
+    });
+
+    it('creates group with defaults (enabled=true, unlimited members)', async () => {
+      const { handlers } = setupRoute();
+      Group.create.mockResolvedValue({
+        id: GROUP_ID,
+        assignment_id: ASSIGNMENT_ID,
+        name: 'New Group',
+        enabled: true,
+        max_members: null,
+      });
+      const reply = mockReply();
+      await handlers['/groups_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'New Group' } },
+        reply
+      );
+      expect(Group.create).toHaveBeenCalledWith(ASSIGNMENT_ID, 'New Group', true, null);
+      expect(reply.code).toHaveBeenCalledWith(201);
+      expect(reply.send).toHaveBeenCalledWith({
+        message: 'Group created successfully',
+        group: { id: GROUP_ID, name: 'New Group', enabled: true, maxMembers: null, assignmentId: ASSIGNMENT_ID },
+      });
+    });
+
+    it('creates group with enabled=false and maxMembers', async () => {
+      const { handlers } = setupRoute();
+      Group.create.mockResolvedValue({
+        id: GROUP_ID,
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Limited',
+        enabled: false,
+        max_members: 5,
+      });
+      const reply = mockReply();
+      await handlers['/groups_post'](
+        { user: amUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'Limited', enabled: false, maxMembers: 5 } },
+        reply
+      );
+      expect(Group.create).toHaveBeenCalledWith(ASSIGNMENT_ID, 'Limited', false, 5);
+      expect(reply.code).toHaveBeenCalledWith(201);
+      expect(reply.send).toHaveBeenCalledWith(
+        expect.objectContaining({ group: expect.objectContaining({ maxMembers: 5, enabled: false }) })
+      );
     });
 
     it('handles error when creating group', async () => {
       const { handlers } = setupRoute();
-      Group.findByName.mockResolvedValue(null);
       Group.create.mockRejectedValue(new Error('Database error'));
       const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'New Group' },
-        },
-        reply
-      );
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
-    });
-
-    it('returns 500 when Group.findByName rejects with DB error', async () => {
-      const { handlers } = setupRoute();
-      Group.findByName.mockRejectedValue(new Error('connection refused'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'New Group' },
-        },
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, name: 'New Group' } },
         reply
       );
       expect(mockLogger.error).toHaveBeenCalled();
@@ -361,7 +384,162 @@ describe('Groups Routes', () => {
     });
   });
 
+  describe('POST /groups/bulk', () => {
+    beforeEach(() => {
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, name: 'Assignment 1', subject_id: SUBJECT_ID });
+      Group.findByNames.mockResolvedValue([]);
+    });
+
+    it('rejects unauthenticated request', () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      handlers['/groups/bulk_post_pre']({ user: null }, reply);
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects invalid body (missing assignmentId)', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_post']({ user: adminUser(), body: { groups: [{ name: 'A' }] } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(Group.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects empty groups array', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [] } },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects batch larger than 2000 groups', async () => {
+      const { handlers } = setupRoute();
+      const groups = Array.from({ length: 2001 }, (_, i) => ({ name: `Group ${i}` }));
+      const reply = mockReply();
+      await handlers['/groups/bulk_post']({ user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(Group.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when assignment not found', async () => {
+      const { handlers } = setupRoute();
+      Assignment.findById.mockResolvedValue(null);
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'A' }] } },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
+    });
+
+    it('returns 403 when user does not manage the assignment', async () => {
+      const { mockFastify, handlers } = setupRoute();
+      denyManagesAssignment(mockFastify);
+      const reply = mockReply();
+      const request = { user: amUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'A' }] } };
+      await handlers['/groups/bulk_post'](request, reply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, reply, ASSIGNMENT_ID);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(Group.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects duplicate names within the batch (case-insensitive)', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'Team A' }, { name: 'team a' }] } },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Duplicate group names within the batch are not allowed' });
+      expect(Group.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('rejects when names already exist in the assignment, listing conflicts', async () => {
+      const { handlers } = setupRoute();
+      Group.findByNames.mockResolvedValue([{ id: OTHER_GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team A' }]);
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        {
+          user: adminUser(),
+          body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'Team A' }, { name: 'Team B' }] },
+        },
+        reply
+      );
+      expect(Group.findByNames).toHaveBeenCalledWith(ASSIGNMENT_ID, ['Team A', 'Team B']);
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: expect.stringContaining('One or more group names already exist'),
+      });
+      expect(reply.send).toHaveBeenCalledWith({ error: expect.stringContaining('Team A') });
+      expect(Group.bulkCreate).not.toHaveBeenCalled();
+    });
+
+    it('creates groups successfully with normalised defaults', async () => {
+      const { handlers } = setupRoute();
+      const created = [
+        { id: GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team A', enabled: true, max_members: null },
+        { id: OTHER_GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team B', enabled: false, max_members: 4 },
+      ];
+      Group.bulkCreate.mockResolvedValue(created);
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        {
+          user: adminUser(),
+          body: {
+            assignmentId: ASSIGNMENT_ID,
+            groups: [{ name: 'Team A' }, { name: 'Team B', enabled: false, maxMembers: 4 }],
+          },
+        },
+        reply
+      );
+      expect(Group.bulkCreate).toHaveBeenCalledWith(ASSIGNMENT_ID, [
+        { name: 'Team A', enabled: true, maxMembers: null },
+        { name: 'Team B', enabled: false, maxMembers: 4 },
+      ]);
+      expect(reply.code).toHaveBeenCalledWith(201);
+      expect(reply.send).toHaveBeenCalledWith({ message: 'Groups created successfully', groups: created });
+    });
+
+    it('returns 409 on unique-violation race during insert', async () => {
+      const { handlers } = setupRoute();
+      const dbErr = new Error('duplicate key value violates unique constraint');
+      dbErr.code = '23505';
+      Group.bulkCreate.mockRejectedValue(dbErr);
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'Team A' }] } },
+        reply
+      );
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'One or more group names already exist' });
+    });
+
+    it('handles error when bulk creating groups', async () => {
+      const { handlers } = setupRoute();
+      Group.bulkCreate.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      const reply = mockReply();
+      await handlers['/groups/bulk_post'](
+        { user: adminUser(), body: { assignmentId: ASSIGNMENT_ID, groups: [{ name: 'Team A' }] } },
+        reply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to create groups' });
+    });
+  });
+
   describe('PUT /groups/:id', () => {
+    beforeEach(() => {
+      Group.findById.mockResolvedValue(mockGroupRow());
+      Group.findByName.mockResolvedValue(null);
+    });
+
     it('rejects unauthenticated request', () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
@@ -369,17 +547,12 @@ describe('Groups Routes', () => {
       expect(reply.code).toHaveBeenCalledWith(401);
     });
 
-    it('returns reply when admin check fails in preHandler', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAdmin.mockResolvedValue(false);
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers } = setupRoute();
       const reply = mockReply();
-      const request = {
-        user: { id: '00000000-0000-4000-8000-000000000001', role: 'user' },
-        params: { id: '10000000-0000-4000-8000-000000000001' },
-      };
-      const result = await handlers['/groups/:id_put_pre'](request, reply);
-      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
+      await handlers['/groups/:id_put']({ user: adminUser(), params: { id: 'nope' }, body: { name: 'X' } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
     });
 
     it('returns 404 when group not found', async () => {
@@ -387,214 +560,140 @@ describe('Groups Routes', () => {
       Group.findById.mockResolvedValue(null);
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000999' },
-          body: { name: 'New Name' },
-        },
+        { user: adminUser(), params: { id: MISSING_GROUP_ID }, body: { name: 'X' } },
         reply
       );
       expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
     });
 
-    it('updates group successfully', async () => {
+    it('returns 403 when user does not manage the group assignment', async () => {
+      const { mockFastify, handlers } = setupRoute();
+      denyManagesAssignment(mockFastify);
+      const reply = mockReply();
+      const request = { user: plainUser(), params: { id: GROUP_ID }, body: { name: 'X' } };
+      await handlers['/groups/:id_put'](request, reply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, reply, ASSIGNMENT_ID);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(Group.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid body (maxMembers non-positive)', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Old Name',
-        enabled: true,
-        member_count: 0,
-      });
-      Group.update.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'New Name',
-        enabled: false,
-      });
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { name: 'New Name', enabled: false },
-        },
+        { user: adminUser(), params: { id: GROUP_ID }, body: { maxMembers: 0 } },
         reply
       );
-      expect(Group.update).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001', {
-        name: 'New Name',
-        enabled: false,
-      });
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(Group.update).not.toHaveBeenCalled();
     });
 
-    it('updates group with partial fields', async () => {
+    it('rejects rename when name is taken by a different group in the assignment', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Old Name',
-        enabled: true,
-        member_count: 0,
-      });
-      Group.update.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Old Name',
-        enabled: false,
-      });
+      Group.findByName.mockResolvedValue({ id: OTHER_GROUP_ID, name: 'Taken' });
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { enabled: false },
-        },
+        { user: adminUser(), params: { id: GROUP_ID }, body: { name: 'Taken' } },
         reply
       );
-      expect(Group.update).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001', {
-        enabled: false,
-      });
+      expect(Group.findByName).toHaveBeenCalledWith(ASSIGNMENT_ID, 'Taken');
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group name already exists' });
+      expect(Group.update).not.toHaveBeenCalled();
     });
 
-    it('updates group with maxMembers', async () => {
+    it('allows rename when the matching name belongs to the same group', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        enabled: true,
-        member_count: 2,
-      });
+      Group.findByName.mockResolvedValue({ id: GROUP_ID, name: 'team a' });
+      Group.update.mockResolvedValue({ id: GROUP_ID, name: 'Team A', enabled: true });
+      const reply = mockReply();
+      await handlers['/groups/:id_put'](
+        { user: adminUser(), params: { id: GROUP_ID }, body: { name: 'Team A' } },
+        reply
+      );
+      expect(reply.code).not.toHaveBeenCalledWith(409);
+      expect(Group.update).toHaveBeenCalledWith(GROUP_ID, { name: 'Team A', enabled: undefined });
+    });
+
+    it('rejects maxMembers below current member count with old message', async () => {
+      const { handlers } = setupRoute();
+      Group.getMemberCount.mockResolvedValue(5);
+      const reply = mockReply();
+      await handlers['/groups/:id_put'](
+        { user: adminUser(), params: { id: GROUP_ID }, body: { maxMembers: 3 } },
+        reply
+      );
+      expect(Group.getMemberCount).toHaveBeenCalledWith(GROUP_ID);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group already has 5 members, cannot set limit to 3' });
+      expect(Group.update).not.toHaveBeenCalled();
+    });
+
+    it('updates group with valid maxMembers', async () => {
+      const { handlers } = setupRoute();
       Group.getMemberCount.mockResolvedValue(2);
-      Group.update.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        max_members: 5,
-      });
+      Group.update.mockResolvedValue({ id: GROUP_ID, name: 'Team A', max_members: 5 });
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { maxMembers: 5 },
-        },
+        { user: adminUser(), params: { id: GROUP_ID }, body: { maxMembers: 5 } },
         reply
       );
-      expect(Group.getMemberCount).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001');
-      expect(Group.update).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001', {
+      expect(Group.update).toHaveBeenCalledWith(GROUP_ID, {
+        name: undefined,
+        enabled: undefined,
         maxMembers: 5,
       });
+      expect(reply.send).toHaveBeenCalledWith({
+        message: 'Group updated successfully',
+        group: { id: GROUP_ID, name: 'Team A', max_members: 5 },
+      });
     });
 
-    it('sets maxMembers to null (unlimited)', async () => {
+    it('sets maxMembers to null (unlimited) without member count check', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        enabled: true,
-        max_members: 5,
-      });
-      Group.update.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        max_members: null,
-      });
+      Group.update.mockResolvedValue({ id: GROUP_ID, name: 'Team A', max_members: null });
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { maxMembers: null },
-        },
+        { user: adminUser(), params: { id: GROUP_ID }, body: { maxMembers: null } },
         reply
       );
-      expect(Group.update).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001', {
+      expect(Group.getMemberCount).not.toHaveBeenCalled();
+      expect(Group.update).toHaveBeenCalledWith(GROUP_ID, {
+        name: undefined,
+        enabled: undefined,
         maxMembers: null,
       });
     });
 
-    it('rejects maxMembers less than current member count', async () => {
+    it('updates enabled flag only', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        enabled: true,
-        member_count: 5,
-      });
-      Group.getMemberCount.mockResolvedValue(5);
+      Group.update.mockResolvedValue({ id: GROUP_ID, name: 'Team A', enabled: false });
       const reply = mockReply();
-      await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { maxMembers: 3 },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({
-        error: 'Group already has 5 members, cannot set limit to 3',
-      });
-    });
-
-    it('rejects invalid maxMembers (non-positive)', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        enabled: true,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { maxMembers: 0 },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: expect.any(String) });
-    });
-
-    it('rejects invalid maxMembers (NaN)', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        enabled: true,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { maxMembers: 'abc' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
+      await handlers['/groups/:id_put']({ user: amUser(), params: { id: GROUP_ID }, body: { enabled: false } }, reply);
+      expect(Group.update).toHaveBeenCalledWith(GROUP_ID, { name: undefined, enabled: false });
     });
 
     it('handles error when updating group', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Old Name',
-        enabled: true,
-      });
       Group.update.mockRejectedValue(new Error('Database error'));
       const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
       await handlers['/groups/:id_put'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-          body: { name: 'New Name' },
-        },
+        { user: adminUser(), params: { id: GROUP_ID }, body: { name: 'New Name' } },
         reply
       );
       expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to update group' });
     });
   });
 
   describe('DELETE /groups/:id', () => {
+    beforeEach(() => {
+      Group.findById.mockResolvedValue(mockGroupRow());
+    });
+
     it('rejects unauthenticated request', () => {
       const { handlers } = setupRoute();
       const reply = mockReply();
@@ -602,50 +701,42 @@ describe('Groups Routes', () => {
       expect(reply.code).toHaveBeenCalledWith(401);
     });
 
-    it('returns reply when admin check fails in preHandler', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAdmin.mockResolvedValue(false);
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers } = setupRoute();
       const reply = mockReply();
-      const request = {
-        user: { id: '00000000-0000-4000-8000-000000000001', role: 'user' },
-        params: { id: '10000000-0000-4000-8000-000000000001' },
-      };
-      const result = await handlers['/groups/:id_delete_pre'](request, reply);
-      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
+      await handlers['/groups/:id_delete']({ user: adminUser(), params: { id: 'nope' } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
+    });
+
+    it('returns 404 when group not found', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(null);
+      const reply = mockReply();
+      await handlers['/groups/:id_delete']({ user: adminUser(), params: { id: MISSING_GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+      expect(Group.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user does not manage the group assignment', async () => {
+      const { mockFastify, handlers } = setupRoute();
+      denyManagesAssignment(mockFastify);
+      const reply = mockReply();
+      const request = { user: plainUser(), params: { id: GROUP_ID } };
+      await handlers['/groups/:id_delete'](request, reply);
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, reply, ASSIGNMENT_ID);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(Group.delete).not.toHaveBeenCalled();
     });
 
     it('deletes group successfully', async () => {
       const { handlers } = setupRoute();
-      Group.delete.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Deleted Group',
-        enabled: true,
-      });
+      Group.delete.mockResolvedValue({ id: GROUP_ID, name: 'Team A' });
       const reply = mockReply();
-      await handlers['/groups/:id_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(Group.delete).toHaveBeenCalledWith('10000000-0000-4000-8000-000000000001');
+      await handlers['/groups/:id_delete']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
+      expect(Group.delete).toHaveBeenCalledWith(GROUP_ID);
       expect(reply.send).toHaveBeenCalledWith({ message: 'Group deleted successfully' });
-    });
-
-    it('returns 404 when group not found for deletion', async () => {
-      const { handlers } = setupRoute();
-      Group.delete.mockResolvedValue(null);
-      const reply = mockReply();
-      await handlers['/groups/:id_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000999' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(404);
     });
 
     it('handles error when deleting group', async () => {
@@ -653,21 +744,149 @@ describe('Groups Routes', () => {
       Group.delete.mockRejectedValue(new Error('Database error'));
       const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
-      await handlers['/groups/:id_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
+      await handlers['/groups/:id_delete']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
       expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to delete group' });
+    });
+  });
+
+  describe('DELETE /groups/bulk', () => {
+    it('rejects unauthenticated request', () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      handlers['/groups/bulk_delete_pre']({ user: null }, reply);
+      expect(reply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when assignment manager check fails in preHandler', async () => {
+      const { mockFastify, handlers } = setupRoute();
+      mockFastify.requireAssignmentManager.mockResolvedValue(false);
+      const reply = mockReply();
+      const request = { user: plainUser() };
+      const result = await handlers['/groups/bulk_delete_pre'](request, reply);
+      expect(mockFastify.requireAssignmentManager).toHaveBeenCalledWith(request, reply);
+      expect(result).toBe(reply);
+    });
+
+    it('rejects non-array ids', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: { ids: 'nope' } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'ids must be a non-empty array of up to 2000 items' });
+    });
+
+    it('rejects empty ids array', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: { ids: [] } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects more than 2000 ids', async () => {
+      const { handlers } = setupRoute();
+      const ids = Array.from({ length: 2001 }, () => GROUP_ID);
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: { ids } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects ids with invalid UUID format', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: { ids: [GROUP_ID, 'not-a-uuid'] } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'One or more IDs have an invalid format' });
+    });
+
+    it('handles missing body', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: undefined }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+    });
+
+    it('deletes deduplicated groups as admin without manager scope checks', async () => {
+      const { handlers } = setupRoute();
+      Group.bulkDelete.mockResolvedValue(2);
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete'](
+        { user: adminUser(), body: { ids: [GROUP_ID, OTHER_GROUP_ID, GROUP_ID] } },
+        reply
+      );
+      expect(Assignment.isManager).not.toHaveBeenCalled();
+      expect(Group.bulkDelete).toHaveBeenCalledWith([GROUP_ID, OTHER_GROUP_ID]);
+      expect(reply.send).toHaveBeenCalledWith({ message: 'Groups deleted successfully', deleted: 2 });
+    });
+
+    it('allows assignment manager who manages all affected assignments', async () => {
+      const { handlers } = setupRoute();
+      Group.findByIds.mockResolvedValue([
+        { id: GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team A' },
+        { id: OTHER_GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team B' },
+      ]);
+      Assignment.isManager.mockResolvedValue(true);
+      Group.bulkDelete.mockResolvedValue(2);
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: amUser(), body: { ids: [GROUP_ID, OTHER_GROUP_ID] } }, reply);
+      expect(Group.findByIds).toHaveBeenCalledWith([GROUP_ID, OTHER_GROUP_ID]);
+      expect(Assignment.isManager).toHaveBeenCalledWith(AM_ID, ASSIGNMENT_ID);
+      expect(reply.send).toHaveBeenCalledWith({ message: 'Groups deleted successfully', deleted: 2 });
+    });
+
+    it('rejects assignment manager who does not manage one of the assignments', async () => {
+      const { handlers } = setupRoute();
+      Group.findByIds.mockResolvedValue([
+        { id: GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Team A' },
+        { id: OTHER_GROUP_ID, assignment_id: OTHER_ASSIGNMENT_ID, name: 'Team B' },
+      ]);
+      Assignment.isManager.mockImplementation(async (_userId, assignmentId) => assignmentId === ASSIGNMENT_ID);
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: amUser(), body: { ids: [GROUP_ID, OTHER_GROUP_ID] } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Forbidden: You do not manage this assignment' });
+      expect(Group.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('handles error when bulk deleting groups', async () => {
+      const { handlers } = setupRoute();
+      Group.bulkDelete.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      const reply = mockReply();
+      await handlers['/groups/bulk_delete']({ user: adminUser(), body: { ids: [GROUP_ID] } }, reply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to delete groups' });
     });
   });
 
   describe('POST /groups/:id/join', () => {
     beforeEach(() => {
       Config.get.mockResolvedValue('false');
+      Group.findById.mockResolvedValue(mockGroupRow());
+      UserGroup.assignUserToGroup.mockResolvedValue();
+      User.findById.mockResolvedValue({ id: 'caller', enabled: true });
+    });
+
+    it('returns 403 when the account is disabled', async () => {
+      const { handlers } = setupRoute();
+      User.findById.mockResolvedValue({ id: 'caller', enabled: false });
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Account is disabled' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the calling user no longer exists', async () => {
+      const { handlers } = setupRoute();
+      User.findById.mockResolvedValue(null);
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'User not found' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
     it('rejects unauthenticated request', () => {
@@ -677,302 +896,132 @@ describe('Groups Routes', () => {
       expect(reply.code).toHaveBeenCalledWith(401);
     });
 
-    it('joins group successfully', async () => {
+    it('returns 400 for invalid UUID', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-        max_members: 5,
-        member_count: 2,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: null,
-        enabled: true,
-      });
-      Group.assignUserToGroup.mockResolvedValue();
       const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalledWith(
-        '00000000-0000-4000-8000-000000000010',
-        '10000000-0000-4000-8000-000000000001'
-      );
-      expect(reply.send).toHaveBeenCalledWith({
-        message: 'Successfully joined group',
-        groupId: '10000000-0000-4000-8000-000000000001',
-        groupName: 'Team A',
-      });
-    });
-
-    it('joins group with unlimited capacity', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Open Team',
-        enabled: true,
-        max_members: null,
-        member_count: 100,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: null,
-        enabled: true,
-      });
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalledWith(
-        '00000000-0000-4000-8000-000000000010',
-        '10000000-0000-4000-8000-000000000001'
-      );
-    });
-
-    it('returns 404 when group not found', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue(null);
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000999' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(404);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
-    });
-
-    it('returns 404 when user not found', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-        max_members: null,
-        member_count: 0,
-      });
-      User.findById.mockResolvedValue(undefined);
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000099' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(404);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'User not found' });
-    });
-
-    it('rejects when user account is disabled', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-        max_members: null,
-        member_count: 0,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: null,
-        enabled: false,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(403);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Account is disabled' });
-      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
-    });
-
-    it('rejects joining a disabled group', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Disabled',
-        enabled: false,
-        max_members: null,
-        member_count: 0,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: 'nope' } }, reply);
       expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Cannot join a disabled group' });
-    });
-
-    it('rejects when user is already in a group', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000002',
-        name: 'Team B',
-        enabled: true,
-        max_members: null,
-        member_count: 1,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        enabled: true,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000002' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({
-        error: 'You are already in a group. Leave your current group first.',
-      });
-    });
-
-    it('rejects when group is full', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Full Team',
-        enabled: true,
-        max_members: 3,
-        member_count: 3,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: null,
-        enabled: true,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(409);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Group is full' });
-    });
-
-    it('handles error when joining group', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockRejectedValue(new Error('Database error'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
     });
 
     it('rejects normal user when join lock is enabled', async () => {
       const { handlers } = setupRoute();
       Config.get.mockResolvedValue('true');
       const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010', role: 'user' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
       expect(reply.code).toHaveBeenCalledWith(403);
       expect(reply.send).toHaveBeenCalledWith({
         error: 'Group joining is currently locked. Please contact the teaching staff.',
       });
-      expect(Group.findById).not.toHaveBeenCalled();
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
     it('allows admin to join when lock is enabled', async () => {
       const { handlers } = setupRoute();
       Config.get.mockResolvedValue('true');
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-        max_members: null,
-        member_count: 0,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        group_id: null,
-        enabled: true,
-      });
-      Group.assignUserToGroup.mockResolvedValue();
       const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
+      await handlers['/groups/:id/join_post']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalled();
       expect(reply.code).not.toHaveBeenCalledWith(403);
     });
 
     it('allows assignment_manager to join when lock is enabled', async () => {
       const { handlers } = setupRoute();
       Config.get.mockResolvedValue('true');
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-        max_members: null,
-        member_count: 0,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000002',
-        group_id: null,
-        enabled: true,
-      });
-      Group.assignUserToGroup.mockResolvedValue();
       const reply = mockReply();
-      await handlers['/groups/:id/join_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000002', role: 'assignment_manager' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
+      await handlers['/groups/:id/join_post']({ user: amUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalled();
       expect(reply.code).not.toHaveBeenCalledWith(403);
+    });
+
+    it('returns 404 when group not found', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(null);
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: MISSING_GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('rejects joining a disabled group', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockResolvedValue(mockGroupRow({ enabled: false }));
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Cannot join a disabled group' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('joins group successfully without replacing existing membership', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID, { replace: false });
+      expect(reply.send).toHaveBeenCalledWith({
+        message: 'Successfully joined group',
+        groupId: GROUP_ID,
+        groupName: 'Team A',
+      });
+    });
+
+    it('maps 403 when user is not a member of the subject', async () => {
+      const { handlers } = setupRoute();
+      const err = new Error('User is not a member of this subject');
+      err.statusCode = 403;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+    });
+
+    it('maps 409 when user is already in a group for the assignment', async () => {
+      const { handlers } = setupRoute();
+      const err = new Error('User is already in a group for this assignment');
+      err.statusCode = 409;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'User is already in a group for this assignment' });
+    });
+
+    it('maps 409 when group is full', async () => {
+      const { handlers } = setupRoute();
+      const err = new Error('Group is full');
+      err.statusCode = 409;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(409);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Group is full' });
+    });
+
+    it('handles unexpected error when joining group', async () => {
+      const { handlers } = setupRoute();
+      Group.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      const reply = mockReply();
+      await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(reply.code).toHaveBeenCalledWith(500);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to join group' });
     });
   });
 
   describe('POST /groups/:id/leave', () => {
     beforeEach(() => {
       Config.get.mockResolvedValue('false');
+      Group.findById.mockResolvedValue(mockGroupRow());
+      UserGroup.findMembership.mockResolvedValue({
+        user_id: USER_ID,
+        group_id: GROUP_ID,
+        assignment_id: ASSIGNMENT_ID,
+      });
+      UserGroup.remove.mockResolvedValue({ user_id: USER_ID, group_id: GROUP_ID, assignment_id: ASSIGNMENT_ID });
+      User.findById.mockResolvedValue({ id: 'caller', enabled: true });
     });
 
     it('rejects unauthenticated request', () => {
@@ -982,137 +1031,100 @@ describe('Groups Routes', () => {
       expect(reply.code).toHaveBeenCalledWith(401);
     });
 
-    it('leaves group successfully', async () => {
+    it('returns 403 when the account is disabled', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        enabled: true,
-      });
-      User.updateGroup.mockResolvedValue({});
+      User.findById.mockResolvedValue({ id: 'caller', enabled: false });
       const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(User.updateGroup).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000010', null);
-      expect(reply.send).toHaveBeenCalledWith({ message: 'Successfully left group' });
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Account is disabled' });
+      expect(UserGroup.remove).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the calling user no longer exists', async () => {
+      const { handlers } = setupRoute();
+      User.findById.mockResolvedValue(null);
+      const reply = mockReply();
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(404);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'User not found' });
+      expect(UserGroup.remove).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: 'nope' } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(400);
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
+    });
+
+    it('rejects normal user when join lock is enabled', async () => {
+      const { handlers } = setupRoute();
+      Config.get.mockResolvedValue('true');
+      const reply = mockReply();
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(reply.code).toHaveBeenCalledWith(403);
+      expect(reply.send).toHaveBeenCalledWith({
+        error: 'Group joining is currently locked. Please contact the teaching staff.',
+      });
+      expect(UserGroup.remove).not.toHaveBeenCalled();
+    });
+
+    it('allows admin to leave when lock is enabled', async () => {
+      const { handlers } = setupRoute();
+      Config.get.mockResolvedValue('true');
+      UserGroup.findMembership.mockResolvedValue({
+        user_id: ADMIN_ID,
+        group_id: GROUP_ID,
+        assignment_id: ASSIGNMENT_ID,
+      });
+      const reply = mockReply();
+      await handlers['/groups/:id/leave_post']({ user: adminUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.remove).toHaveBeenCalledWith(ADMIN_ID, ASSIGNMENT_ID);
+      expect(reply.code).not.toHaveBeenCalledWith(403);
     });
 
     it('returns 404 when group not found', async () => {
       const { handlers } = setupRoute();
       Group.findById.mockResolvedValue(null);
       const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000999' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: MISSING_GROUP_ID } }, reply);
       expect(reply.code).toHaveBeenCalledWith(404);
       expect(reply.send).toHaveBeenCalledWith({ error: 'Group not found' });
     });
 
-    it('returns 404 when user not found', async () => {
+    it('rejects when user has no membership for the assignment', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue(undefined);
+      UserGroup.findMembership.mockResolvedValue(null);
       const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000099' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(404);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'User not found' });
-    });
-
-    it('rejects when user account is disabled', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        enabled: false,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(403);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Account is disabled' });
-      expect(User.updateGroup).not.toHaveBeenCalled();
-    });
-
-    it('rejects when user is not in this group', async () => {
-      const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000002',
-        name: 'Team B',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        enabled: true,
-      });
-      const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000002' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.findMembership).toHaveBeenCalledWith(USER_ID, ASSIGNMENT_ID);
       expect(reply.code).toHaveBeenCalledWith(400);
       expect(reply.send).toHaveBeenCalledWith({ error: 'You are not a member of this group' });
+      expect(UserGroup.remove).not.toHaveBeenCalled();
     });
 
-    it('rejects when user is not in any group', async () => {
+    it('rejects when user is in a different group of the assignment', async () => {
       const { handlers } = setupRoute();
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000010',
-        group_id: null,
-        enabled: true,
+      UserGroup.findMembership.mockResolvedValue({
+        user_id: USER_ID,
+        group_id: OTHER_GROUP_ID,
+        assignment_id: ASSIGNMENT_ID,
       });
       const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
       expect(reply.code).toHaveBeenCalledWith(400);
       expect(reply.send).toHaveBeenCalledWith({ error: 'You are not a member of this group' });
+      expect(UserGroup.remove).not.toHaveBeenCalled();
+    });
+
+    it('leaves group successfully', async () => {
+      const { handlers } = setupRoute();
+      const reply = mockReply();
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
+      expect(UserGroup.remove).toHaveBeenCalledWith(USER_ID, ASSIGNMENT_ID);
+      expect(reply.send).toHaveBeenCalledWith({ message: 'Successfully left group' });
     });
 
     it('handles error when leaving group', async () => {
@@ -1120,788 +1132,10 @@ describe('Groups Routes', () => {
       Group.findById.mockRejectedValue(new Error('Database error'));
       const { logger: mockLogger } = require('../../src/utils/logger');
       const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
+      await handlers['/groups/:id/leave_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
       expect(mockLogger.error).toHaveBeenCalled();
       expect(reply.code).toHaveBeenCalledWith(500);
-    });
-
-    it('rejects normal user when join lock is enabled', async () => {
-      const { handlers } = setupRoute();
-      Config.get.mockResolvedValue('true');
-      const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000010', role: 'user' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(403);
-      expect(reply.send).toHaveBeenCalledWith({
-        error: 'Group joining is currently locked. Please contact the teaching staff.',
-      });
-      expect(Group.findById).not.toHaveBeenCalled();
-    });
-
-    it('allows admin to leave when lock is enabled', async () => {
-      const { handlers } = setupRoute();
-      Config.get.mockResolvedValue('true');
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team A',
-        enabled: true,
-      });
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        group_id: '10000000-0000-4000-8000-000000000001',
-        enabled: true,
-      });
-      User.updateGroup.mockResolvedValue({});
-      const reply = mockReply();
-      await handlers['/groups/:id/leave_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          params: { id: '10000000-0000-4000-8000-000000000001' },
-        },
-        reply
-      );
-      expect(User.updateGroup).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', null);
-      expect(reply.code).not.toHaveBeenCalledWith(403);
-    });
-  });
-
-  describe('POST /groups/import-mappings', () => {
-    beforeEach(() => {
-      User.findByEmails.mockResolvedValue([]);
-      Group.findByNames.mockResolvedValue([]);
-    });
-
-    it('rejects unauthenticated request', () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups/import-mappings_post_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-    });
-
-    it('returns reply when AM check fails in preHandler', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAssignmentManager.mockResolvedValue(false);
-      const reply = mockReply();
-      const request = { user: { id: '00000000-0000-4000-8000-000000000010', role: 'user' } };
-      const result = await handlers['/groups/import-mappings_post_pre'](request, reply);
-      expect(mockFastify.requireAssignmentManager).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
-    });
-
-    it('rejects missing or empty rows', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post']({ user: { id: 'u1', role: 'admin' }, body: { rows: [] } }, reply);
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'No mappings to import' });
-    });
-
-    it('rejects when rows exceed MAX_IMPORT_MAPPINGS', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      const rows = Array.from({ length: 2001 }, (_, i) => ({
-        email: `user${i}@test.com`,
-        groupName: `Group${i}`,
-        action: 'import',
-      }));
-      await handlers['/groups/import-mappings_post']({ user: { id: 'u1', role: 'admin' }, body: { rows } }, reply);
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.stringContaining('exceeds maximum') })
-      );
-    });
-
-    it('imports a valid row successfully', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([
-        { id: '00000000-0000-4000-8000-000000000010', email: 'alice@test.com', role_name: 'user' },
-      ]);
-      Group.findByNames.mockResolvedValue([{ id: '10000000-0000-4000-8000-000000000001', name: 'Team A' }]);
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
-      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 1, skipped: [], errors: [] }));
-    });
-
-    it('performs exactly 2 batch DB queries for a valid import', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([
-        { id: 'u1', email: 'a@test.com', role_name: 'user' },
-        { id: 'u2', email: 'b@test.com', role_name: 'user' },
-      ]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: {
-            rows: [
-              { email: 'a@test.com', groupName: 'Team A', action: 'import' },
-              { email: 'b@test.com', groupName: 'Team A', action: 'import' },
-            ],
-          },
-        },
-        reply
-      );
-      expect(User.findByEmails).toHaveBeenCalledTimes(1);
-      expect(Group.findByNames).toHaveBeenCalledTimes(1);
-      expect(Group.assignUserToGroup).toHaveBeenCalledTimes(2);
-      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 2 }));
-    });
-
-    it('skips a row when action is skip', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: {
-            rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'skip', skipReason: 'Unknown user' }],
-          },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
-      const result = reply.send.mock.calls[0][0];
-      expect(result.skipped).toHaveLength(1);
-      expect(result.skipped[0].reason).toBe('Unknown user');
-    });
-
-    it('skips row when user not found', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([]); // email not in DB
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'nobody@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      const result = reply.send.mock.calls[0][0];
-      expect(result.skipped[0].reason).toBe('User not found');
-    });
-
-    it('skips row when group not found', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([]); // group not in DB
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'NoSuchGroup', action: 'import' }] },
-        },
-        reply
-      );
-      const result = reply.send.mock.calls[0][0];
-      expect(result.skipped[0].reason).toBe('Group not found');
-    });
-
-    it('records error when group is full', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      const fullErr = new Error('Group is full');
-      fullErr.statusCode = 409;
-      Group.assignUserToGroup.mockRejectedValue(fullErr);
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      const result = reply.send.mock.calls[0][0];
-      expect(result.errors[0].error).toBe('Group is full');
-    });
-
-    it('records per-row error when assignUserToGroup throws an unexpected error', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      Group.assignUserToGroup.mockRejectedValue(new Error('DB connection lost'));
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      const result = reply.send.mock.calls[0][0];
-      expect(result.errors[0].error).toBe('Failed to process row');
-    });
-
-    it('returns 500 when batch lookup fails', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockRejectedValue(new Error('DB down'));
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(500);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to import mappings' });
-    });
-
-    it('skips row when target user is an admin', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'admin1', email: 'admin@test.com', role_name: 'admin' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'admin@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
-      const result = reply.send.mock.calls[0][0];
-      expect(result.skipped[0].reason).toBe('Admins and Assignment Managers cannot be assigned to a group');
-    });
-
-    it('skips row when target user is an assignment_manager', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'am1', email: 'am@test.com', role_name: 'assignment_manager' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'am@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
-      const result = reply.send.mock.calls[0][0];
-      expect(result.skipped[0].reason).toBe('Admins and Assignment Managers cannot be assigned to a group');
-    });
-
-    it('imports successfully when target user is a normal user', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u2', email: 'normaluser@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'normaluser@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
-      const result = reply.send.mock.calls[0][0];
-      expect(result.imported).toBe(1);
-    });
-
-    it('returns 409 when two groups share the same name differing only by case', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([
-        { id: 'g1', name: 'Team A' },
-        { id: 'g2', name: 'team a' },
-      ]);
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(409);
-      expect(reply.send).toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.stringContaining('Ambiguous group name') })
-      );
-      expect(Group.assignUserToGroup).not.toHaveBeenCalled();
-    });
-
-    it('does not flag collision when two group rows share the same id (deduplication)', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([
-        { id: 'g1', name: 'Team A' },
-        { id: 'g1', name: 'Team A' },
-      ]);
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: { rows: [{ email: 'alice@test.com', groupName: 'Team A', action: 'import' }] },
-        },
-        reply
-      );
-      expect(reply.code).not.toHaveBeenCalledWith(409);
-      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ imported: 1 }));
-    });
-
-    it('preserves input row order across skip, validation error, and import rows', async () => {
-      const { handlers } = setupRoute();
-      User.findByEmails.mockResolvedValue([{ id: 'u1', email: 'alice@test.com', role_name: 'user' }]);
-      Group.findByNames.mockResolvedValue([{ id: 'g1', name: 'Team A' }]);
-      Group.assignUserToGroup.mockResolvedValue();
-      const reply = mockReply();
-      await handlers['/groups/import-mappings_post'](
-        {
-          user: { id: 'u1', role: 'admin' },
-          body: {
-            rows: [
-              { email: 'alice@test.com', groupName: 'Team A', action: 'import' },
-              { email: 'bad@test.com', groupName: 'Team A', action: 'skip', skipReason: 'Manual skip' },
-              { email: '', groupName: '', action: 'import' }, // validation error
-            ],
-          },
-        },
-        reply
-      );
-      const result = reply.send.mock.calls[0][0];
-      // imported row comes first in original order
-      expect(result.imported).toBe(1);
-      // skip row (row 2) appears in skipped
-      expect(result.skipped[0].reason).toBe('Manual skip');
-      // validation error (row 3) appears in errors
-      expect(result.errors).toHaveLength(1);
-    });
-  });
-
-  describe('GET /groups/export-mappings', () => {
-    it('rejects unauthenticated request', () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups/export-mappings_get_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-    });
-
-    it('returns reply when AM check fails in preHandler', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAssignmentManager.mockResolvedValue(false);
-      const reply = mockReply();
-      const request = { user: { id: '00000000-0000-4000-8000-000000000010', role: 'user' } };
-      const result = await handlers['/groups/export-mappings_get_pre'](request, reply);
-      expect(mockFastify.requireAssignmentManager).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
-    });
-
-    it('returns user-group mappings', async () => {
-      const { handlers } = setupRoute();
-      Group.getExportMappings.mockResolvedValue([
-        { email: 'alice@test.com', group_name: 'Team A' },
-        { email: 'bob@test.com', group_name: 'Team B' },
-      ]);
-      const reply = mockReply();
-      await handlers['/groups/export-mappings_get']({ user: { id: 'u1', role: 'admin' } }, reply);
-      expect(reply.send).toHaveBeenCalledWith({
-        mappings: [
-          { email: 'alice@test.com', groupName: 'Team A' },
-          { email: 'bob@test.com', groupName: 'Team B' },
-        ],
-      });
-    });
-
-    it('returns empty array when no mappings', async () => {
-      const { handlers } = setupRoute();
-      Group.getExportMappings.mockResolvedValue([]);
-      const reply = mockReply();
-      await handlers['/groups/export-mappings_get']({ user: { id: 'u1', role: 'admin' } }, reply);
-      expect(reply.send).toHaveBeenCalledWith({ mappings: [] });
-    });
-
-    it('handles DB error (500)', async () => {
-      const { handlers } = setupRoute();
-      Group.getExportMappings.mockRejectedValue(new Error('DB error'));
-      const reply = mockReply();
-      await handlers['/groups/export-mappings_get']({ user: { id: 'u1', role: 'admin' } }, reply);
-      expect(reply.code).toHaveBeenCalledWith(500);
-    });
-  });
-
-  describe('POST /groups/bulk', () => {
-    // ── Auth / RBAC ──────────────────────────────────────────────────────────
-
-    it('rejects unauthenticated request (401)', () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      handlers['/groups/bulk_post_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
-    });
-
-    it('returns reply when admin check fails (non-admin user)', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAdmin.mockResolvedValue(false);
-      const reply = mockReply();
-      const request = { user: { id: '00000000-0000-4000-8000-000000000001', role: 'user' } };
-      const result = await handlers['/groups/bulk_post_pre'](request, reply);
-      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
-    });
-
-    // ── Input validation ─────────────────────────────────────────────────────
-
-    it('rejects missing body (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        { user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' }, body: null },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-    });
-
-    it('rejects non-array body (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { name: 'Group A' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(String) }));
-    });
-
-    it('rejects empty array body (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Request body must be a non-empty array' });
-    });
-
-    it('rejects array exceeding max batch size (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      const oversized = Array.from({ length: 2001 }, (_, i) => ({ name: `Group ${i + 1}` }));
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: oversized,
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Batch size exceeds maximum of 2000 groups per request' });
-    });
-
-    it('rejects item with missing name (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Valid Group' }, { enabled: true }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('items[1]') }));
-    });
-
-    it('rejects item with empty name string (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: '' }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-    });
-
-    it('rejects item with name exceeding 100 characters (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'A'.repeat(101) }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-    });
-
-    it('rejects item with non-string name (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 42 }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-    });
-
-    // ── Happy path ───────────────────────────────────────────────────────────
-
-    it('creates two groups successfully (201)', async () => {
-      const { handlers } = setupRoute();
-      const createdGroups = [
-        { id: '10000000-0000-4000-8000-000000000001', name: 'Group A', enabled: true, max_members: null },
-        { id: '10000000-0000-4000-8000-000000000002', name: 'Group B', enabled: true, max_members: null },
-      ];
-      Group.bulkCreate.mockResolvedValue(createdGroups);
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Group A' }, { name: 'Group B' }],
-        },
-        reply
-      );
-      expect(Group.bulkCreate).toHaveBeenCalledWith([
-        { name: 'Group A', enabled: true, maxMembers: null },
-        { name: 'Group B', enabled: true, maxMembers: null },
-      ]);
-      expect(reply.code).toHaveBeenCalledWith(201);
-      expect(reply.send).toHaveBeenCalledWith({
-        message: 'Groups created successfully',
-        groups: createdGroups,
-      });
-    });
-
-    it('passes enabled and maxMembers fields when provided', async () => {
-      const { handlers } = setupRoute();
-      const createdGroups = [
-        { id: '10000000-0000-4000-8000-000000000001', name: 'Group A', enabled: false, max_members: 5 },
-      ];
-      Group.bulkCreate.mockResolvedValue(createdGroups);
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Group A', enabled: false, maxMembers: 5 }],
-        },
-        reply
-      );
-      expect(Group.bulkCreate).toHaveBeenCalledWith([{ name: 'Group A', enabled: false, maxMembers: 5 }]);
-      expect(reply.code).toHaveBeenCalledWith(201);
-    });
-
-    it('handles exactly 100 groups (boundary — allowed)', async () => {
-      const { handlers } = setupRoute();
-      const body = Array.from({ length: 100 }, (_, i) => ({ name: `Group ${i + 1}` }));
-      const createdGroups = body.map((g, i) => ({
-        id: `10000000-0000-4000-8000-0000000000${String(i + 1).padStart(2, '0')}`,
-        name: g.name,
-        enabled: true,
-        max_members: null,
-      }));
-      Group.bulkCreate.mockResolvedValue(createdGroups);
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body,
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(201);
-    });
-
-    // ── Duplicate names ──────────────────────────────────────────────────────
-
-    it('rolls back and returns 409 when duplicate group name exists in DB', async () => {
-      const { handlers } = setupRoute();
-      const err = new Error('duplicate key value violates unique constraint');
-      err.code = '23505';
-      Group.bulkCreate.mockRejectedValue(err);
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Existing Group' }, { name: 'New Group' }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(409);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'One or more group names already exist' });
-    });
-
-    it('rejects duplicate names within the batch itself (400)', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Group A' }, { name: 'Group A' }],
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Duplicate group names within the batch are not allowed' });
-    });
-
-    // ── Database / server errors ─────────────────────────────────────────────
-
-    it('returns 500 on unexpected database error and rolls back', async () => {
-      const { handlers } = setupRoute();
-      Group.bulkCreate.mockRejectedValue(new Error('Connection lost'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups/bulk_post'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: [{ name: 'Group A' }, { name: 'Group B' }],
-        },
-        reply
-      );
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to create groups' });
-    });
-  });
-
-  // ── DELETE /groups/bulk ──────────────────────────────────────────────────
-  describe('DELETE /groups/bulk', () => {
-    it('rejects unauthenticated request', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete_pre']({ user: null }, reply);
-      expect(reply.code).toHaveBeenCalledWith(401);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
-    });
-
-    it('rejects non-admin user (403)', async () => {
-      const { mockFastify, handlers } = setupRoute();
-      mockFastify.requireAdmin.mockResolvedValue(false);
-      const reply = mockReply();
-      const request = {
-        user: { id: '00000000-0000-4000-8000-000000000002', role: 'assignment_manager' },
-        body: { ids: ['10000000-0000-4000-8000-000000000001'] },
-      };
-      const result = await handlers['/groups/bulk_delete_pre'](request, reply);
-      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, reply);
-      expect(result).toBe(reply);
-    });
-
-    it('deletes 2 groups and returns { deleted: 2 }', async () => {
-      const { handlers } = setupRoute();
-      Group.bulkDelete.mockResolvedValue(2);
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: {
-            ids: ['10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000002'],
-          },
-        },
-        reply
-      );
-      expect(Group.bulkDelete).toHaveBeenCalledWith([
-        '10000000-0000-4000-8000-000000000001',
-        '10000000-0000-4000-8000-000000000002',
-      ]);
-      expect(reply.send).toHaveBeenCalledWith({ message: 'Groups deleted successfully', deleted: 2 });
-    });
-
-    it('returns 400 when ids is an empty array', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete'](
-        { user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' }, body: { ids: [] } },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'ids must be a non-empty array of up to 2000 items' });
-    });
-
-    it('returns 400 when ids exceeds 2000', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      const ids = Array.from({ length: 2001 }, (_, i) => `id-${i}`);
-      await handlers['/groups/bulk_delete'](
-        { user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' }, body: { ids } },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'ids must be a non-empty array of up to 2000 items' });
-    });
-
-    it('returns 400 when body.ids is not an array', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { ids: 'not-an-array' },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'ids must be a non-empty array of up to 2000 items' });
-    });
-
-    it('returns 400 when ids contain non-UUID values', async () => {
-      const { handlers } = setupRoute();
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { ids: ['not-a-uuid', '10000000-0000-4000-8000-000000000001'] },
-        },
-        reply
-      );
-      expect(reply.code).toHaveBeenCalledWith(400);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'One or more IDs have an invalid format' });
-      expect(Group.bulkDelete).not.toHaveBeenCalled();
-    });
-
-    it('returns 500 on DB error', async () => {
-      const { handlers } = setupRoute();
-      Group.bulkDelete.mockRejectedValue(new Error('DB exploded'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-      const reply = mockReply();
-      await handlers['/groups/bulk_delete'](
-        {
-          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-          body: { ids: ['10000000-0000-4000-8000-000000000001'] },
-        },
-        reply
-      );
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(reply.code).toHaveBeenCalledWith(500);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to delete groups' });
+      expect(reply.send).toHaveBeenCalledWith({ error: 'Failed to leave group' });
     });
   });
 });

--- a/backend/tests/unit/groups.test.js
+++ b/backend/tests/unit/groups.test.js
@@ -966,15 +966,15 @@ describe('Groups Routes', () => {
       });
     });
 
-    it('maps 403 when user is not a member of the subject', async () => {
+    it('maps 403 when user is not an active member of the subject', async () => {
       const { handlers } = setupRoute();
-      const err = new Error('User is not a member of this subject');
+      const err = new Error('User is not an active member of this subject');
       err.statusCode = 403;
       UserGroup.assignUserToGroup.mockRejectedValue(err);
       const reply = mockReply();
       await handlers['/groups/:id/join_post']({ user: plainUser(), params: { id: GROUP_ID } }, reply);
       expect(reply.code).toHaveBeenCalledWith(403);
-      expect(reply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+      expect(reply.send).toHaveBeenCalledWith({ error: 'User is not an active member of this subject' });
     });
 
     it('maps 409 when user is already in a group for the assignment', async () => {

--- a/backend/tests/unit/middleware.test.js
+++ b/backend/tests/unit/middleware.test.js
@@ -245,4 +245,88 @@ describe('RBAC Middleware', () => {
 
     expect(mockReply.code).toHaveBeenCalledWith(403);
   });
+
+  describe('assertManagesAssignment', () => {
+    const ASSIGNMENT_ID = 'a0000000-0000-0000-0000-000000000001';
+    const USER_ID = 'u0000000-0000-0000-0000-000000000001';
+
+    const setup = async (isManagerResult) => {
+      jest.doMock('../../src/models/Assignment', () => ({
+        isManager: jest.fn().mockResolvedValue(isManagerResult),
+      }));
+      const Assignment = require('../../src/models/Assignment');
+      const rbacPlugin = require('../../src/middleware/rbac');
+      await rbacPlugin(fastify, {});
+      const assertManagesAssignment = fastify.decorate.mock.calls.find(
+        (call) => call[0] === 'assertManagesAssignment'
+      )[1];
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      return { assertManagesAssignment, mockReply, Assignment };
+    };
+
+    afterEach(() => {
+      jest.dontMock('../../src/models/Assignment');
+    });
+
+    it('is registered as a decorator', async () => {
+      const { assertManagesAssignment } = await setup(false);
+      expect(assertManagesAssignment).toEqual(expect.any(Function));
+    });
+
+    it('returns 401 for unauthenticated requests', async () => {
+      const { assertManagesAssignment, mockReply } = await setup(false);
+
+      const result = await assertManagesAssignment({ user: null }, mockReply, ASSIGNMENT_ID);
+
+      expect(result).toBe(false);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('allows admin without consulting the manager table', async () => {
+      const { assertManagesAssignment, mockReply, Assignment } = await setup(false);
+
+      const result = await assertManagesAssignment({ user: { id: USER_ID, role: 'admin' } }, mockReply, ASSIGNMENT_ID);
+
+      expect(result).toBe(true);
+      expect(Assignment.isManager).not.toHaveBeenCalled();
+      expect(mockReply.code).not.toHaveBeenCalled();
+    });
+
+    it('allows an assignment manager who manages the assignment', async () => {
+      const { assertManagesAssignment, mockReply, Assignment } = await setup(true);
+
+      const result = await assertManagesAssignment(
+        { user: { id: USER_ID, role: 'assignment_manager' } },
+        mockReply,
+        ASSIGNMENT_ID
+      );
+
+      expect(result).toBe(true);
+      expect(Assignment.isManager).toHaveBeenCalledWith(USER_ID, ASSIGNMENT_ID);
+      expect(mockReply.code).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 for an assignment manager who does not manage the assignment', async () => {
+      const { assertManagesAssignment, mockReply } = await setup(false);
+
+      const result = await assertManagesAssignment(
+        { user: { id: USER_ID, role: 'assignment_manager' } },
+        mockReply,
+        ASSIGNMENT_ID
+      );
+
+      expect(result).toBe(false);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('returns 403 for a plain user regardless of the manager table', async () => {
+      const { assertManagesAssignment, mockReply, Assignment } = await setup(true);
+
+      const result = await assertManagesAssignment({ user: { id: USER_ID, role: 'user' } }, mockReply, ASSIGNMENT_ID);
+
+      expect(result).toBe(false);
+      expect(Assignment.isManager).not.toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+  });
 });

--- a/backend/tests/unit/models/assignment.test.js
+++ b/backend/tests/unit/models/assignment.test.js
@@ -130,6 +130,14 @@ describe('Assignment Model', () => {
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [USER_ID]);
       expect(result).toEqual(rows);
     });
+
+    it('excludes assignments of subjects where the membership is suspended', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await Assignment.findForUser(USER_ID);
+
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('us.enabled = true'));
+    });
   });
 
   describe('findManagedBy', () => {

--- a/backend/tests/unit/models/assignment.test.js
+++ b/backend/tests/unit/models/assignment.test.js
@@ -1,0 +1,259 @@
+jest.mock('../../../src/db/pool', () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+const pool = require('../../../src/db/pool');
+const Assignment = require('../../../src/models/Assignment');
+
+const SUBJECT_ID = 's0000000-0000-0000-0000-000000000001';
+const ASSIGNMENT_ID = 'a0000000-0000-0000-0000-000000000001';
+const USER_ID = 'u0000000-0000-0000-0000-000000000001';
+
+describe('Assignment Model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('returns all assignments with subject name and group count', async () => {
+      const rows = [{ id: ASSIGNMENT_ID, name: 'A1', subject_id: SUBJECT_ID, subject_name: 'S1', group_count: 3 }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Assignment.findAll();
+
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('FROM assignments'));
+      expect(result).toEqual(rows);
+    });
+
+    it('filters by subjectId when provided', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await Assignment.findAll({ subjectId: SUBJECT_ID });
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('a.subject_id = $1'), [SUBJECT_ID]);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns the assignment with subject info', async () => {
+      const row = { id: ASSIGNMENT_ID, name: 'A1', subject_id: SUBJECT_ID, subject_name: 'S1' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Assignment.findById(ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE a.id = $1'), [ASSIGNMENT_ID]);
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when not found', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Assignment.findById(ASSIGNMENT_ID)).toBeNull();
+    });
+  });
+
+  describe('findByName', () => {
+    it('matches case-insensitively within the subject', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: ASSIGNMENT_ID }] });
+
+      await Assignment.findByName(SUBJECT_ID, 'a1');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('subject_id = $1'), [SUBJECT_ID, 'a1']);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('LOWER(name) = LOWER($2)'));
+    });
+
+    it('returns null when not found', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Assignment.findByName(SUBJECT_ID, 'nope')).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('inserts with subject id and returns the row', async () => {
+      const row = { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'A1' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Assignment.create(SUBJECT_ID, 'A1');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO assignments'), [SUBJECT_ID, 'A1']);
+      expect(result).toEqual(row);
+    });
+
+    it('propagates unique-constraint errors', async () => {
+      const err = new Error('duplicate');
+      err.code = '23505';
+      pool.query.mockRejectedValue(err);
+      await expect(Assignment.create(SUBJECT_ID, 'Dup')).rejects.toMatchObject({ code: '23505' });
+    });
+  });
+
+  describe('update', () => {
+    it('updates the name', async () => {
+      const row = { id: ASSIGNMENT_ID, name: 'Renamed' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Assignment.update(ASSIGNMENT_ID, { name: 'Renamed' });
+
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE assignments SET'),
+        expect.arrayContaining(['Renamed', ASSIGNMENT_ID])
+      );
+      expect(result).toEqual(row);
+    });
+
+    it('falls back to findById when no fields provided', async () => {
+      pool.query.mockResolvedValue({ rows: [{ id: ASSIGNMENT_ID }] });
+      await Assignment.update(ASSIGNMENT_ID, {});
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('WHERE a.id = $1'));
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes and returns the row', async () => {
+      const row = { id: ASSIGNMENT_ID };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Assignment.delete(ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith('DELETE FROM assignments WHERE id = $1 RETURNING *', [ASSIGNMENT_ID]);
+      expect(result).toEqual(row);
+    });
+  });
+
+  describe('findForUser', () => {
+    it('returns assignments in the user subjects (derived participation)', async () => {
+      const rows = [{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Assignment.findForUser(USER_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [USER_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('findManagedBy', () => {
+    it('returns assignments managed by the user', async () => {
+      const rows = [{ id: ASSIGNMENT_ID, name: 'A1', subject_id: SUBJECT_ID, subject_name: 'S1' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Assignment.findManagedBy(USER_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('assignment_managers'), [USER_ID]);
+      expect(result).toEqual(rows);
+    });
+
+    it('returns empty array when the user manages nothing', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Assignment.findManagedBy(USER_ID)).toEqual([]);
+    });
+  });
+
+  describe('isManager', () => {
+    it('returns true when a manager row exists', async () => {
+      pool.query.mockResolvedValue({ rows: [{ exists: true }] });
+      expect(await Assignment.isManager(USER_ID, ASSIGNMENT_ID)).toBe(true);
+    });
+
+    it('returns false when no manager row exists', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Assignment.isManager(USER_ID, ASSIGNMENT_ID)).toBe(false);
+    });
+  });
+
+  describe('getManagers', () => {
+    it('returns manager users', async () => {
+      const rows = [{ id: USER_ID, username: 'am1' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Assignment.getManagers(ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('JOIN assignment_managers'), [ASSIGNMENT_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('setManagers', () => {
+    let mockClient;
+
+    beforeEach(() => {
+      mockClient = { query: jest.fn(), release: jest.fn() };
+      pool.connect.mockResolvedValue(mockClient);
+    });
+
+    it('replaces the manager set in a transaction', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] });
+
+      await Assignment.setManagers(ASSIGNMENT_ID, [USER_ID]);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('DELETE FROM assignment_managers'), [
+        ASSIGNMENT_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(3, expect.stringContaining('INSERT INTO assignment_managers'), [
+        ASSIGNMENT_ID,
+        [USER_ID],
+      ]);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('clears all managers when given an empty list', async () => {
+      mockClient.query.mockResolvedValue({ rows: [] });
+
+      await Assignment.setManagers(ASSIGNMENT_ID, []);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('DELETE FROM assignment_managers'), [
+        ASSIGNMENT_ID,
+      ]);
+      // No INSERT for an empty set
+      const insertCalls = mockClient.query.mock.calls.filter(([sql]) =>
+        String(sql).includes('INSERT INTO assignment_managers')
+      );
+      expect(insertCalls).toHaveLength(0);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    it('rolls back and re-throws on error', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockRejectedValueOnce(new Error('boom'));
+
+      await expect(Assignment.setManagers(ASSIGNMENT_ID, [USER_ID])).rejects.toThrow('boom');
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('addManagers', () => {
+    it('adds the user as manager of multiple assignments idempotently and returns the inserted count', async () => {
+      pool.query.mockResolvedValue({ rowCount: 2 });
+
+      const result = await Assignment.addManagers(USER_ID, [ASSIGNMENT_ID, 'a0000000-0000-0000-0000-000000000002']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ON CONFLICT'), [
+        USER_ID,
+        [ASSIGNMENT_ID, 'a0000000-0000-0000-0000-000000000002'],
+      ]);
+      expect(result).toBe(2);
+    });
+
+    it('returns 0 for an empty assignment list without querying', async () => {
+      const result = await Assignment.addManagers(USER_ID, []);
+      expect(result).toBe(0);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('managesAnyInSubject', () => {
+    it('returns true when the user manages an assignment in the subject', async () => {
+      pool.query.mockResolvedValue({ rows: [{ exists: true }] });
+      expect(await Assignment.managesAnyInSubject(USER_ID, SUBJECT_ID)).toBe(true);
+    });
+
+    it('returns false otherwise', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Assignment.managesAnyInSubject(USER_ID, SUBJECT_ID)).toBe(false);
+    });
+  });
+});

--- a/backend/tests/unit/models/group.test.js
+++ b/backend/tests/unit/models/group.test.js
@@ -8,16 +8,19 @@ jest.mock('../../../src/db/pool', () => ({
 
 const pool = require('../../../src/db/pool');
 
+const ASSIGNMENT_ID = 'a0000000-0000-4000-8000-000000000001';
+
 describe('Group Model', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('findAll', () => {
-    it('returns all groups with member_count ordered by name', async () => {
+  describe('findAllByAssignment', () => {
+    it('returns groups for the assignment with member_count ordered by name', async () => {
       const mockGroups = [
         {
           id: '10000000-0000-4000-8000-000000000001',
+          assignment_id: ASSIGNMENT_ID,
           name: 'Alpha Team',
           enabled: true,
           max_members: null,
@@ -25,6 +28,7 @@ describe('Group Model', () => {
         },
         {
           id: '10000000-0000-4000-8000-000000000002',
+          assignment_id: ASSIGNMENT_ID,
           name: 'Beta Team',
           enabled: true,
           max_members: 5,
@@ -33,55 +37,27 @@ describe('Group Model', () => {
       ];
       pool.query.mockResolvedValue({ rows: mockGroups });
 
-      const result = await Group.findAll();
+      const result = await Group.findAllByAssignment(ASSIGNMENT_ID);
 
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('member_count'));
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY g.name'));
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('member_count'), [ASSIGNMENT_ID]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('assignment_id = $1'), [ASSIGNMENT_ID]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY g.name'), [ASSIGNMENT_ID]);
       expect(result).toEqual(mockGroups);
     });
 
-    it('returns empty array when no groups', async () => {
+    it('counts members from user_groups', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
-      const result = await Group.findAll();
+      await Group.findAllByAssignment(ASSIGNMENT_ID);
 
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('findById', () => {
-    it('returns group by id with member_count', async () => {
-      const mockGroup = {
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Test Group',
-        enabled: true,
-        max_members: 10,
-        member_count: 3,
-      };
-      pool.query.mockResolvedValue({ rows: [mockGroup] });
-
-      const result = await Group.findById('10000000-0000-4000-8000-000000000001');
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('member_count'), [
-        '10000000-0000-4000-8000-000000000001',
-      ]);
-      expect(result).toEqual(mockGroup);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM user_groups'), [ASSIGNMENT_ID]);
     });
 
-    it('returns undefined when group not found', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await Group.findById('10000000-0000-4000-8000-000000000999');
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('findEnabled', () => {
-    it('returns only enabled groups with member_count', async () => {
+    it('filters to enabled groups when enabledOnly is true', async () => {
       const mockGroups = [
         {
           id: '10000000-0000-4000-8000-000000000001',
+          assignment_id: ASSIGNMENT_ID,
           name: 'Active Team',
           enabled: true,
           max_members: null,
@@ -90,19 +66,124 @@ describe('Group Model', () => {
       ];
       pool.query.mockResolvedValue({ rows: mockGroups });
 
-      const result = await Group.findEnabled();
+      const result = await Group.findAllByAssignment(ASSIGNMENT_ID, { enabledOnly: true });
 
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('enabled = true'));
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('member_count'));
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('enabled = true'), [ASSIGNMENT_ID]);
       expect(result).toEqual(mockGroups);
     });
 
-    it('returns empty array when no enabled groups', async () => {
+    it('does not filter by enabled when enabledOnly is false', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
-      const result = await Group.findEnabled();
+      await Group.findAllByAssignment(ASSIGNMENT_ID, { enabledOnly: false });
+
+      expect(pool.query).not.toHaveBeenCalledWith(expect.stringContaining('enabled = true'), expect.anything());
+    });
+
+    it('returns empty array when assignment has no groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findAllByAssignment(ASSIGNMENT_ID);
 
       expect(result).toEqual([]);
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Group.findAllByAssignment(ASSIGNMENT_ID)).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('findById', () => {
+    it('returns group by id with assignment/subject info and member_count', async () => {
+      const mockGroup = {
+        id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Test Group',
+        enabled: true,
+        max_members: 10,
+        member_count: 3,
+        assignment_name: 'Assignment 1',
+        subject_id: 's0000000-0000-4000-8000-000000000001',
+        subject_name: 'COMP10001',
+      };
+      pool.query.mockResolvedValue({ rows: [mockGroup] });
+
+      const result = await Group.findById('10000000-0000-4000-8000-000000000001');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('member_count'), [
+        '10000000-0000-4000-8000-000000000001',
+      ]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('assignment_name'), [
+        '10000000-0000-4000-8000-000000000001',
+      ]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('subject_name'), [
+        '10000000-0000-4000-8000-000000000001',
+      ]);
+      expect(result).toEqual(mockGroup);
+    });
+
+    it('returns null when group not found', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findById('10000000-0000-4000-8000-000000000999');
+
+      expect(result).toBeNull();
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Group.findById('10000000-0000-4000-8000-000000000001')).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('findByIds', () => {
+    it('returns matching groups for the given ids', async () => {
+      const mockGroups = [
+        { id: '10000000-0000-4000-8000-000000000001', assignment_id: ASSIGNMENT_ID, name: 'Group A' },
+        { id: '10000000-0000-4000-8000-000000000002', assignment_id: ASSIGNMENT_ID, name: 'Group B' },
+      ];
+      pool.query.mockResolvedValue({ rows: mockGroups });
+
+      const result = await Group.findByIds([
+        '10000000-0000-4000-8000-000000000001',
+        '10000000-0000-4000-8000-000000000002',
+      ]);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE id = ANY($1)'), [
+        ['10000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000002'],
+      ]);
+      expect(result).toEqual(mockGroups);
+    });
+
+    it('returns empty array without querying when ids is empty', async () => {
+      const result = await Group.findByIds([]);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when ids is undefined', async () => {
+      const result = await Group.findByIds(undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no ids match', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findByIds(['10000000-0000-4000-8000-000000000999']);
+
+      expect(result).toEqual([]);
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Group.findByIds(['10000000-0000-4000-8000-000000000001'])).rejects.toThrow('connection refused');
     });
   });
 
@@ -110,30 +191,39 @@ describe('Group Model', () => {
     it('creates group with defaults (enabled=true, maxMembers=null)', async () => {
       const mockGroup = {
         id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
         name: 'New Group',
         enabled: true,
         max_members: null,
       };
       pool.query.mockResolvedValue({ rows: [mockGroup] });
 
-      const result = await Group.create('New Group');
+      const result = await Group.create(ASSIGNMENT_ID, 'New Group');
 
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO groups'), ['New Group', true, null]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO groups'), [
+        ASSIGNMENT_ID,
+        'New Group',
+        true,
+        null,
+      ]);
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('assignment_id'), expect.any(Array));
       expect(result).toEqual(mockGroup);
     });
 
     it('creates group with enabled=false', async () => {
       const mockGroup = {
         id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
         name: 'Disabled Group',
         enabled: false,
         max_members: null,
       };
       pool.query.mockResolvedValue({ rows: [mockGroup] });
 
-      const result = await Group.create('Disabled Group', false);
+      const result = await Group.create(ASSIGNMENT_ID, 'Disabled Group', false);
 
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO groups'), [
+        ASSIGNMENT_ID,
         'Disabled Group',
         false,
         null,
@@ -144,20 +234,30 @@ describe('Group Model', () => {
     it('creates group with maxMembers', async () => {
       const mockGroup = {
         id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
         name: 'Limited Group',
         enabled: true,
         max_members: 5,
       };
       pool.query.mockResolvedValue({ rows: [mockGroup] });
 
-      const result = await Group.create('Limited Group', true, 5);
+      const result = await Group.create(ASSIGNMENT_ID, 'Limited Group', true, 5);
 
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO groups'), [
+        ASSIGNMENT_ID,
         'Limited Group',
         true,
         5,
       ]);
       expect(result).toEqual(mockGroup);
+    });
+
+    it('propagates DB error (e.g. unique constraint)', async () => {
+      const uniqueErr = new Error('duplicate key value violates unique constraint');
+      uniqueErr.code = '23505';
+      pool.query.mockRejectedValue(uniqueErr);
+
+      await expect(Group.create(ASSIGNMENT_ID, 'Dup Group')).rejects.toMatchObject({ code: '23505' });
     });
   });
 
@@ -286,11 +386,14 @@ describe('Group Model', () => {
   });
 
   describe('getMemberCount', () => {
-    it('returns count of members in group', async () => {
+    it('returns count of members in group from user_groups', async () => {
       pool.query.mockResolvedValue({ rows: [{ count: 5 }] });
 
       const result = await Group.getMemberCount('10000000-0000-4000-8000-000000000001');
 
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM user_groups'), [
+        '10000000-0000-4000-8000-000000000001',
+      ]);
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('COUNT'), [
         '10000000-0000-4000-8000-000000000001',
       ]);
@@ -304,281 +407,11 @@ describe('Group Model', () => {
 
       expect(result).toBe(0);
     });
-  });
-
-  describe('getMembers', () => {
-    it('returns group members with role info including first_name and last_name', async () => {
-      const mockMembers = [
-        {
-          id: '00000000-0000-4000-8000-000000000001',
-          username: 'user1',
-          email: 'user1@test.com',
-          first_name: 'Alice',
-          last_name: 'Smith',
-          student_id: 'S001',
-          enabled: true,
-          role_name: 'user',
-        },
-        {
-          id: '00000000-0000-4000-8000-000000000002',
-          username: 'user2',
-          email: 'user2@test.com',
-          first_name: 'Bob',
-          last_name: 'Jones',
-          student_id: 'S002',
-          enabled: true,
-          role_name: 'admin',
-        },
-      ];
-      pool.query.mockResolvedValue({ rows: mockMembers });
-
-      const result = await Group.getMembers('10000000-0000-4000-8000-000000000001');
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('u.first_name, u.last_name'), [
-        '10000000-0000-4000-8000-000000000001',
-      ]);
-      expect(result).toEqual(mockMembers);
-    });
-
-    it('returns empty array when group has no members', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await Group.getMembers('10000000-0000-4000-8000-000000000001');
-
-      expect(result).toEqual([]);
-    });
-
-    it('orders members by username', async () => {
-      const mockMembers = [
-        {
-          id: '00000000-0000-4000-8000-000000000002',
-          username: 'alice',
-          email: 'alice@test.com',
-          first_name: 'Alice',
-          last_name: 'A',
-          role_name: 'user',
-        },
-        {
-          id: '00000000-0000-4000-8000-000000000001',
-          username: 'bob',
-          email: 'bob@test.com',
-          first_name: 'Bob',
-          last_name: 'B',
-          role_name: 'admin',
-        },
-      ];
-      pool.query.mockResolvedValue({ rows: mockMembers });
-
-      const result = await Group.getMembers('10000000-0000-4000-8000-000000000001');
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY u.username'), [
-        '10000000-0000-4000-8000-000000000001',
-      ]);
-      expect(result).toEqual(mockMembers);
-    });
-  });
-
-  describe('findByNames', () => {
-    it('returns groups matching the given names (case-insensitive)', async () => {
-      const mockGroups = [
-        { id: '10000000-0000-4000-8000-000000000001', name: 'Team Alpha', enabled: true, max_members: null },
-        { id: '10000000-0000-4000-8000-000000000002', name: 'Team Beta', enabled: true, max_members: 5 },
-      ];
-      pool.query.mockResolvedValue({ rows: mockGroups });
-
-      const result = await Group.findByNames(['Team Alpha', 'Team Beta']);
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE LOWER(name) = ANY($1)'), [
-        ['team alpha', 'team beta'],
-      ]);
-      expect(result).toEqual(mockGroups);
-    });
-
-    it('lowercases all names before querying', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      await Group.findByNames(['UPPER GROUP', 'MiXeD Group']);
-
-      expect(pool.query).toHaveBeenCalledWith(expect.any(String), [['upper group', 'mixed group']]);
-    });
-
-    it('returns empty array without querying when names is empty', async () => {
-      const result = await Group.findByNames([]);
-
-      expect(pool.query).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
-    });
-
-    it('returns empty array without querying when names is undefined', async () => {
-      const result = await Group.findByNames(undefined);
-
-      expect(pool.query).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
-    });
-
-    it('returns empty array when no names match', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await Group.findByNames(['nonexistent group']);
-
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('findByName', () => {
-    it('returns group when name matches (case-insensitive)', async () => {
-      const mockGroup = {
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Team Alpha',
-        enabled: true,
-        max_members: null,
-      };
-      pool.query.mockResolvedValue({ rows: [mockGroup] });
-
-      const result = await Group.findByName('team alpha');
-
-      expect(pool.query).toHaveBeenCalledWith('SELECT * FROM groups WHERE LOWER(name) = LOWER($1)', ['team alpha']);
-      expect(result).toEqual(mockGroup);
-    });
-
-    it('returns null when group name not found', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await Group.findByName('nonexistent');
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('getExportMappings', () => {
-    it('returns user-group mappings for normal users only', async () => {
-      const mockRows = [
-        { email: 'alice@test.com', group_name: 'Team A' },
-        { email: 'bob@test.com', group_name: 'Team B' },
-      ];
-      pool.query.mockResolvedValue({ rows: mockRows });
-
-      const result = await Group.getExportMappings();
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining("r.name = 'user'"));
-      expect(result).toEqual(mockRows);
-    });
-
-    it('returns empty array when no normal users have groups', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await Group.getExportMappings();
-
-      expect(result).toEqual([]);
-    });
 
     it('propagates DB error', async () => {
       pool.query.mockRejectedValue(new Error('connection refused'));
 
-      await expect(Group.getExportMappings()).rejects.toThrow('connection refused');
-    });
-  });
-
-  describe('assignUserToGroup', () => {
-    let mockClient;
-
-    beforeEach(() => {
-      mockClient = {
-        query: jest.fn(),
-        release: jest.fn(),
-      };
-      pool.connect.mockResolvedValue(mockClient);
-    });
-
-    it('assigns user to group successfully within a transaction', async () => {
-      // BEGIN, SELECT FOR UPDATE (group found, not full), UPDATE users, COMMIT
-      mockClient.query
-        .mockResolvedValueOnce() // BEGIN
-        .mockResolvedValueOnce({
-          rows: [
-            {
-              id: '10000000-0000-4000-8000-000000000001',
-              max_members: 5,
-              member_count: 2,
-            },
-          ],
-        }) // SELECT ... FOR UPDATE
-        .mockResolvedValueOnce() // UPDATE users
-        .mockResolvedValueOnce(); // COMMIT
-
-      await Group.assignUserToGroup('00000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000001');
-
-      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
-      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FOR UPDATE'), [
-        '10000000-0000-4000-8000-000000000001',
-      ]);
-      expect(mockClient.query).toHaveBeenNthCalledWith(3, expect.stringContaining('UPDATE users SET group_id'), [
-        '10000000-0000-4000-8000-000000000001',
-        '00000000-0000-4000-8000-000000000001',
-      ]);
-      expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
-      expect(mockClient.release).toHaveBeenCalled();
-    });
-
-    it('throws 404 error and rolls back if group not found', async () => {
-      mockClient.query
-        .mockResolvedValueOnce() // BEGIN
-        .mockResolvedValueOnce({ rows: [] }) // SELECT FOR UPDATE — no rows
-        .mockResolvedValueOnce(); // ROLLBACK
-
-      await expect(
-        Group.assignUserToGroup('00000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000999')
-      ).rejects.toMatchObject({ message: 'Group not found', statusCode: 404 });
-
-      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
-      expect(mockClient.release).toHaveBeenCalled();
-    });
-
-    it('throws 409 error and rolls back if group is full', async () => {
-      mockClient.query
-        .mockResolvedValueOnce() // BEGIN
-        .mockResolvedValueOnce({
-          rows: [{ id: '10000000-0000-4000-8000-000000000001', max_members: 3, member_count: 3 }],
-        }) // SELECT FOR UPDATE — group is full
-        .mockResolvedValueOnce(); // ROLLBACK
-
-      await expect(
-        Group.assignUserToGroup('00000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000001')
-      ).rejects.toMatchObject({ message: 'Group is full', statusCode: 409 });
-
-      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
-      expect(mockClient.release).toHaveBeenCalled();
-    });
-
-    it('allows assigning user when group has unlimited capacity (max_members null)', async () => {
-      mockClient.query
-        .mockResolvedValueOnce() // BEGIN
-        .mockResolvedValueOnce({
-          rows: [{ id: '10000000-0000-4000-8000-000000000001', max_members: null, member_count: 999 }],
-        }) // SELECT FOR UPDATE
-        .mockResolvedValueOnce() // UPDATE users
-        .mockResolvedValueOnce(); // COMMIT
-
-      await expect(
-        Group.assignUserToGroup('00000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000001')
-      ).resolves.toBeUndefined();
-
-      expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
-    });
-
-    it('rolls back and rethrows on unexpected DB error', async () => {
-      const dbError = new Error('Connection lost');
-      mockClient.query
-        .mockResolvedValueOnce() // BEGIN
-        .mockRejectedValueOnce(dbError) // SELECT FOR UPDATE fails
-        .mockResolvedValueOnce(); // ROLLBACK
-
-      await expect(
-        Group.assignUserToGroup('00000000-0000-4000-8000-000000000001', '10000000-0000-4000-8000-000000000001')
-      ).rejects.toThrow('Connection lost');
-
-      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
-      expect(mockClient.release).toHaveBeenCalled();
+      await expect(Group.getMemberCount('10000000-0000-4000-8000-000000000001')).rejects.toThrow('connection refused');
     });
   });
 
@@ -593,13 +426,25 @@ describe('Group Model', () => {
       pool.connect.mockResolvedValue(mockClient);
     });
 
-    it('inserts multiple groups in a single transaction and returns created rows', async () => {
+    it('inserts multiple groups with assignment_id in a single transaction and returns created rows', async () => {
       const input = [
         { name: 'Group A', enabled: true, maxMembers: null },
         { name: 'Group B', enabled: false, maxMembers: 5 },
       ];
-      const row1 = { id: '10000000-0000-4000-8000-000000000001', name: 'Group A', enabled: true, max_members: null };
-      const row2 = { id: '10000000-0000-4000-8000-000000000002', name: 'Group B', enabled: false, max_members: 5 };
+      const row1 = {
+        id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Group A',
+        enabled: true,
+        max_members: null,
+      };
+      const row2 = {
+        id: '10000000-0000-4000-8000-000000000002',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Group B',
+        enabled: false,
+        max_members: 5,
+      };
 
       mockClient.query
         .mockResolvedValueOnce() // BEGIN
@@ -607,18 +452,18 @@ describe('Group Model', () => {
         .mockResolvedValueOnce({ rows: [row2] }) // INSERT Group B
         .mockResolvedValueOnce(); // COMMIT
 
-      const result = await Group.bulkCreate(input);
+      const result = await Group.bulkCreate(ASSIGNMENT_ID, input);
 
       expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
       expect(mockClient.query).toHaveBeenNthCalledWith(
         2,
-        'INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *',
-        ['Group A', true, null]
+        'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+        [ASSIGNMENT_ID, 'Group A', true, null]
       );
       expect(mockClient.query).toHaveBeenNthCalledWith(
         3,
-        'INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *',
-        ['Group B', false, 5]
+        'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+        [ASSIGNMENT_ID, 'Group B', false, 5]
       );
       expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
       expect(mockClient.release).toHaveBeenCalled();
@@ -627,14 +472,20 @@ describe('Group Model', () => {
 
     it('commits transaction and releases client on success', async () => {
       const input = [{ name: 'Solo Group', enabled: true, maxMembers: null }];
-      const row = { id: '10000000-0000-4000-8000-000000000001', name: 'Solo Group', enabled: true, max_members: null };
+      const row = {
+        id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Solo Group',
+        enabled: true,
+        max_members: null,
+      };
 
       mockClient.query
         .mockResolvedValueOnce() // BEGIN
         .mockResolvedValueOnce({ rows: [row] }) // INSERT
         .mockResolvedValueOnce(); // COMMIT
 
-      await Group.bulkCreate(input);
+      await Group.bulkCreate(ASSIGNMENT_ID, input);
 
       expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
       expect(mockClient.release).toHaveBeenCalled();
@@ -653,7 +504,7 @@ describe('Group Model', () => {
         .mockRejectedValueOnce(uniqueErr) // INSERT fails
         .mockResolvedValueOnce(); // ROLLBACK
 
-      await expect(Group.bulkCreate(input)).rejects.toMatchObject({ code: '23505' });
+      await expect(Group.bulkCreate(ASSIGNMENT_ID, input)).rejects.toMatchObject({ code: '23505' });
 
       expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
       expect(mockClient.release).toHaveBeenCalled();
@@ -668,7 +519,7 @@ describe('Group Model', () => {
         .mockRejectedValueOnce(dbErr) // INSERT fails
         .mockResolvedValueOnce(); // ROLLBACK
 
-      await expect(Group.bulkCreate(input)).rejects.toThrow('Connection lost');
+      await expect(Group.bulkCreate(ASSIGNMENT_ID, input)).rejects.toThrow('Connection lost');
 
       expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
       expect(mockClient.release).toHaveBeenCalled();
@@ -676,14 +527,20 @@ describe('Group Model', () => {
 
     it('handles a single-item batch correctly', async () => {
       const input = [{ name: 'One Group', enabled: true, maxMembers: 10 }];
-      const row = { id: '10000000-0000-4000-8000-000000000001', name: 'One Group', enabled: true, max_members: 10 };
+      const row = {
+        id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'One Group',
+        enabled: true,
+        max_members: 10,
+      };
 
       mockClient.query
         .mockResolvedValueOnce() // BEGIN
         .mockResolvedValueOnce({ rows: [row] }) // INSERT
         .mockResolvedValueOnce(); // COMMIT
 
-      const result = await Group.bulkCreate(input);
+      const result = await Group.bulkCreate(ASSIGNMENT_ID, input);
 
       expect(result).toEqual([row]);
     });
@@ -693,7 +550,7 @@ describe('Group Model', () => {
         .mockResolvedValueOnce() // BEGIN
         .mockResolvedValueOnce(); // COMMIT
 
-      const result = await Group.bulkCreate([]);
+      const result = await Group.bulkCreate(ASSIGNMENT_ID, []);
 
       expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
       expect(mockClient.query).toHaveBeenNthCalledWith(2, 'COMMIT');
@@ -712,7 +569,7 @@ describe('Group Model', () => {
         .mockRejectedValueOnce(rollbackErr); // ROLLBACK also throws
 
       // When ROLLBACK itself throws, that error propagates (the finally block still releases)
-      await expect(Group.bulkCreate(input)).rejects.toThrow('Rollback failed');
+      await expect(Group.bulkCreate(ASSIGNMENT_ID, input)).rejects.toThrow('Rollback failed');
 
       expect(mockClient.release).toHaveBeenCalled();
     });
@@ -741,5 +598,109 @@ describe('Group Model', () => {
 
       await expect(Group.bulkDelete(['id1'])).rejects.toThrow('connection refused');
     });
+  });
+
+  describe('findByName', () => {
+    it('returns group when name matches within the assignment (case-insensitive)', async () => {
+      const mockGroup = {
+        id: '10000000-0000-4000-8000-000000000001',
+        assignment_id: ASSIGNMENT_ID,
+        name: 'Team Alpha',
+        enabled: true,
+        max_members: null,
+      };
+      pool.query.mockResolvedValue({ rows: [mockGroup] });
+
+      const result = await Group.findByName(ASSIGNMENT_ID, 'team alpha');
+
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('assignment_id = $1 AND LOWER(name) = LOWER($2)'),
+        [ASSIGNMENT_ID, 'team alpha']
+      );
+      expect(result).toEqual(mockGroup);
+    });
+
+    it('returns null when group name not found in the assignment', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findByName(ASSIGNMENT_ID, 'nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(Group.findByName(ASSIGNMENT_ID, 'team alpha')).rejects.toThrow('connection refused');
+    });
+  });
+
+  describe('findByNames', () => {
+    it('returns groups matching the given names within the assignment (case-insensitive)', async () => {
+      const mockGroups = [
+        {
+          id: '10000000-0000-4000-8000-000000000001',
+          assignment_id: ASSIGNMENT_ID,
+          name: 'Team Alpha',
+          enabled: true,
+          max_members: null,
+        },
+        {
+          id: '10000000-0000-4000-8000-000000000002',
+          assignment_id: ASSIGNMENT_ID,
+          name: 'Team Beta',
+          enabled: true,
+          max_members: 5,
+        },
+      ];
+      pool.query.mockResolvedValue({ rows: mockGroups });
+
+      const result = await Group.findByNames(ASSIGNMENT_ID, ['Team Alpha', 'Team Beta']);
+
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('assignment_id = $1 AND LOWER(name) = ANY($2::text[])'),
+        [ASSIGNMENT_ID, ['team alpha', 'team beta']]
+      );
+      expect(result).toEqual(mockGroups);
+    });
+
+    it('lowercases all names before querying', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await Group.findByNames(ASSIGNMENT_ID, ['UPPER GROUP', 'MiXeD Group']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.any(String), [ASSIGNMENT_ID, ['upper group', 'mixed group']]);
+    });
+
+    it('returns empty array without querying when names is empty', async () => {
+      const result = await Group.findByNames(ASSIGNMENT_ID, []);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array without querying when names is undefined', async () => {
+      const result = await Group.findByNames(ASSIGNMENT_ID, undefined);
+
+      expect(pool.query).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no names match', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      const result = await Group.findByNames(ASSIGNMENT_ID, ['nonexistent group']);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('removed methods', () => {
+    it.each(['findAll', 'findEnabled', 'assignUserToGroup', 'getExportMappings', 'getMembers'])(
+      'no longer exposes %s (moved or removed)',
+      (method) => {
+        expect(Group[method]).toBeUndefined();
+      }
+    );
   });
 });

--- a/backend/tests/unit/models/subject.test.js
+++ b/backend/tests/unit/models/subject.test.js
@@ -133,13 +133,28 @@ describe('Subject Model', () => {
   });
 
   describe('findForUser', () => {
-    it('returns subjects the user belongs to', async () => {
+    it('returns only enabled memberships by default', async () => {
       const rows = [{ id: SUBJECT_ID, name: 'Subject A' }];
       pool.query.mockResolvedValue({ rows });
 
       const result = await Subject.findForUser(USER_ID);
 
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [USER_ID]);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('us.enabled = true'));
+      expect(result).toEqual(rows);
+    });
+
+    it('returns all memberships tagged with membership_enabled when includeDisabled is true', async () => {
+      const rows = [
+        { id: SUBJECT_ID, name: 'Subject A', membership_enabled: true },
+        { id: 's0000000-0000-0000-0000-000000000002', name: 'Subject B', membership_enabled: false },
+      ];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Subject.findForUser(USER_ID, { includeDisabled: true });
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('us.enabled AS membership_enabled'), [USER_ID]);
+      expect(pool.query.mock.calls[0][0]).not.toEqual(expect.stringContaining('us.enabled = true'));
       expect(result).toEqual(rows);
     });
 
@@ -150,13 +165,15 @@ describe('Subject Model', () => {
   });
 
   describe('findForUsers', () => {
-    it('returns subject rows keyed by user for a batch of users', async () => {
-      const rows = [{ user_id: USER_ID, id: SUBJECT_ID, name: 'Subject A' }];
+    it('returns subject rows keyed by user for a batch of users, tagged with membership_enabled', async () => {
+      const rows = [{ user_id: USER_ID, id: SUBJECT_ID, name: 'Subject A', membership_enabled: false }];
       pool.query.mockResolvedValue({ rows });
 
       const result = await Subject.findForUsers([USER_ID]);
 
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [[USER_ID]]);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('us.enabled AS membership_enabled'));
+      expect(pool.query.mock.calls[0][0]).not.toEqual(expect.stringContaining('us.enabled = true'));
       expect(result).toEqual(rows);
     });
 
@@ -167,13 +184,14 @@ describe('Subject Model', () => {
   });
 
   describe('getMembers', () => {
-    it('returns member users with role names', async () => {
-      const rows = [{ id: USER_ID, username: 'u1', role_name: 'user' }];
+    it('returns member users with role names and membership_enabled', async () => {
+      const rows = [{ id: USER_ID, username: 'u1', role_name: 'user', membership_enabled: true }];
       pool.query.mockResolvedValue({ rows });
 
       const result = await Subject.getMembers(SUBJECT_ID);
 
       expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('JOIN user_subjects'), [SUBJECT_ID]);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('us.enabled AS membership_enabled'));
       expect(result).toEqual(rows);
     });
   });
@@ -251,10 +269,86 @@ describe('Subject Model', () => {
     });
   });
 
+  describe('setMemberEnabled', () => {
+    let mockClient;
+
+    beforeEach(() => {
+      mockClient = { query: jest.fn(), release: jest.fn() };
+      pool.connect.mockResolvedValue(mockClient);
+    });
+
+    it('suspending deletes the group memberships within the subject before updating, in one transaction', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 1 }) // DELETE user_groups within subject
+        .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE user_subjects
+        .mockResolvedValueOnce({}); // COMMIT
+
+      const result = await Subject.setMemberEnabled(SUBJECT_ID, USER_ID, false);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('DELETE FROM user_groups'), [
+        SUBJECT_ID,
+        USER_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(3, expect.stringContaining('UPDATE user_subjects'), [
+        SUBJECT_ID,
+        USER_ID,
+        false,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('enabling skips the group-membership delete and only updates the row', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE user_subjects
+        .mockResolvedValueOnce({}); // COMMIT
+
+      const result = await Subject.setMemberEnabled(SUBJECT_ID, USER_ID, true);
+
+      const deleteCalls = mockClient.query.mock.calls.filter(([sql]) =>
+        String(sql).includes('DELETE FROM user_groups')
+      );
+      expect(deleteCalls).toHaveLength(0);
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('UPDATE user_subjects'), [
+        SUBJECT_ID,
+        USER_ID,
+        true,
+      ]);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the user is not a member', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 0 }) // DELETE user_groups
+        .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE user_subjects
+        .mockResolvedValueOnce({}); // COMMIT
+
+      const result = await Subject.setMemberEnabled(SUBJECT_ID, USER_ID, false);
+      expect(result).toBe(false);
+    });
+
+    it('rolls back and re-throws on error', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockRejectedValueOnce(new Error('boom')); // DELETE user_groups
+
+      await expect(Subject.setMemberEnabled(SUBJECT_ID, USER_ID, false)).rejects.toThrow('boom');
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
   describe('isMember', () => {
-    it('returns true when a membership row exists', async () => {
+    it('returns true when an enabled membership row exists', async () => {
       pool.query.mockResolvedValue({ rows: [{ exists: true }] });
       expect(await Subject.isMember(SUBJECT_ID, USER_ID)).toBe(true);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('enabled = true'));
     });
 
     it('returns false when no membership row exists', async () => {

--- a/backend/tests/unit/models/subject.test.js
+++ b/backend/tests/unit/models/subject.test.js
@@ -1,0 +1,265 @@
+jest.mock('../../../src/db/pool', () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+const pool = require('../../../src/db/pool');
+const Subject = require('../../../src/models/Subject');
+
+const SUBJECT_ID = 's0000000-0000-0000-0000-000000000001';
+const USER_ID = 'u0000000-0000-0000-0000-000000000001';
+
+describe('Subject Model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('returns all subjects with assignment and member counts', async () => {
+      const rows = [
+        { id: SUBJECT_ID, name: 'Subject A', assignment_count: 2, member_count: 5 },
+        { id: 's0000000-0000-0000-0000-000000000002', name: 'Subject B', assignment_count: 0, member_count: 0 },
+      ];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Subject.findAll();
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('FROM subjects'));
+      expect(result).toEqual(rows);
+    });
+
+    it('returns empty array when no subjects exist', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.findAll()).toEqual([]);
+    });
+  });
+
+  describe('findById', () => {
+    it('returns the subject with counts', async () => {
+      const row = { id: SUBJECT_ID, name: 'Subject A', assignment_count: 1, member_count: 3 };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.findById(SUBJECT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('WHERE s.id = $1'), [SUBJECT_ID]);
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when not found', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.findById(SUBJECT_ID)).toBeNull();
+    });
+  });
+
+  describe('findByName', () => {
+    it('matches case-insensitively', async () => {
+      const row = { id: SUBJECT_ID, name: 'Subject A' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.findByName('subject a');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('LOWER(name) = LOWER($1)'), ['subject a']);
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when not found', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.findByName('nope')).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('inserts and returns the new subject', async () => {
+      const row = { id: SUBJECT_ID, name: 'New Subject' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.create('New Subject');
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO subjects'), ['New Subject']);
+      expect(result).toEqual(row);
+    });
+
+    it('propagates unique-constraint errors', async () => {
+      const err = new Error('duplicate key value violates unique constraint');
+      err.code = '23505';
+      pool.query.mockRejectedValue(err);
+
+      await expect(Subject.create('Dup')).rejects.toMatchObject({ code: '23505' });
+    });
+  });
+
+  describe('update', () => {
+    it('updates the name and returns the row', async () => {
+      const row = { id: SUBJECT_ID, name: 'Renamed' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.update(SUBJECT_ID, { name: 'Renamed' });
+
+      expect(pool.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE subjects SET'),
+        expect.arrayContaining(['Renamed', SUBJECT_ID])
+      );
+      expect(result).toEqual(row);
+    });
+
+    it('falls back to findById when no updatable fields given', async () => {
+      const row = { id: SUBJECT_ID, name: 'Same' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.update(SUBJECT_ID, {});
+
+      expect(pool.query).toHaveBeenCalledTimes(1);
+      expect(pool.query.mock.calls[0][0]).toEqual(expect.stringContaining('WHERE s.id = $1'));
+      expect(result).toEqual(row);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes and returns the row', async () => {
+      const row = { id: SUBJECT_ID, name: 'Doomed' };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await Subject.delete(SUBJECT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith('DELETE FROM subjects WHERE id = $1 RETURNING *', [SUBJECT_ID]);
+      expect(result).toEqual(row);
+    });
+
+    it('returns undefined when nothing was deleted', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.delete(SUBJECT_ID)).toBeUndefined();
+    });
+  });
+
+  describe('findForUser', () => {
+    it('returns subjects the user belongs to', async () => {
+      const rows = [{ id: SUBJECT_ID, name: 'Subject A' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Subject.findForUser(USER_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [USER_ID]);
+      expect(result).toEqual(rows);
+    });
+
+    it('returns empty array when the user has no subjects', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.findForUser(USER_ID)).toEqual([]);
+    });
+  });
+
+  describe('findForUsers', () => {
+    it('returns subject rows keyed by user for a batch of users', async () => {
+      const rows = [{ user_id: USER_ID, id: SUBJECT_ID, name: 'Subject A' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Subject.findForUsers([USER_ID]);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('user_subjects'), [[USER_ID]]);
+      expect(result).toEqual(rows);
+    });
+
+    it('returns empty array for an empty user list without querying', async () => {
+      expect(await Subject.findForUsers([])).toEqual([]);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMembers', () => {
+    it('returns member users with role names', async () => {
+      const rows = [{ id: USER_ID, username: 'u1', role_name: 'user' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await Subject.getMembers(SUBJECT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('JOIN user_subjects'), [SUBJECT_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('addUsers', () => {
+    it('bulk-inserts memberships idempotently and returns the inserted count', async () => {
+      pool.query.mockResolvedValue({ rowCount: 2 });
+
+      const result = await Subject.addUsers(SUBJECT_ID, [USER_ID, 'u0000000-0000-0000-0000-000000000002']);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ON CONFLICT'), [
+        SUBJECT_ID,
+        [USER_ID, 'u0000000-0000-0000-0000-000000000002'],
+      ]);
+      expect(result).toBe(2);
+    });
+
+    it('returns 0 for an empty user list without querying', async () => {
+      const result = await Subject.addUsers(SUBJECT_ID, []);
+      expect(result).toBe(0);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeUser', () => {
+    let mockClient;
+
+    beforeEach(() => {
+      mockClient = { query: jest.fn(), release: jest.fn() };
+      pool.connect.mockResolvedValue(mockClient);
+    });
+
+    it('removes the subject membership and the group memberships within the subject in one transaction', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 1 }) // DELETE user_groups within subject
+        .mockResolvedValueOnce({ rowCount: 1 }) // DELETE user_subjects
+        .mockResolvedValueOnce({}); // COMMIT
+
+      const result = await Subject.removeUser(SUBJECT_ID, USER_ID);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('DELETE FROM user_groups'), [
+        SUBJECT_ID,
+        USER_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(3, expect.stringContaining('DELETE FROM user_subjects'), [
+        SUBJECT_ID,
+        USER_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the user was not a member', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rowCount: 0 }) // DELETE user_groups
+        .mockResolvedValueOnce({ rowCount: 0 }) // DELETE user_subjects
+        .mockResolvedValueOnce({}); // COMMIT
+
+      const result = await Subject.removeUser(SUBJECT_ID, USER_ID);
+      expect(result).toBe(false);
+    });
+
+    it('rolls back and re-throws on error', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockRejectedValueOnce(new Error('boom')); // DELETE user_groups
+
+      await expect(Subject.removeUser(SUBJECT_ID, USER_ID)).rejects.toThrow('boom');
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('isMember', () => {
+    it('returns true when a membership row exists', async () => {
+      pool.query.mockResolvedValue({ rows: [{ exists: true }] });
+      expect(await Subject.isMember(SUBJECT_ID, USER_ID)).toBe(true);
+    });
+
+    it('returns false when no membership row exists', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await Subject.isMember(SUBJECT_ID, USER_ID)).toBe(false);
+    });
+  });
+});

--- a/backend/tests/unit/models/user.test.js
+++ b/backend/tests/unit/models/user.test.js
@@ -14,26 +14,29 @@ jest.mock('bcryptjs', () => ({
 const bcrypt = require('bcryptjs');
 const pool = require('../../../src/db/pool');
 
+const SUBJECT_ID = 's0000000-0000-4000-8000-000000000001';
+const ASSIGNMENT_ID = 'a0000000-0000-4000-8000-000000000001';
+const GROUP_ID = 'g0000000-0000-4000-8000-000000000001';
+const MANAGER_ID = 'm0000000-0000-4000-8000-000000000001';
+
 describe('User Model', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('findAll', () => {
-    it('returns all users with group and role info', async () => {
+    it('returns all users with role info', async () => {
       const mockUsers = [
         {
           id: 'u0000000-0000-0000-0000-000000000001',
           username: 'user1',
           email: 'user1@test.com',
-          group_name: 'Team A',
           role_name: 'user',
         },
         {
           id: 'u0000000-0000-0000-0000-000000000002',
           username: 'user2',
           email: 'user2@test.com',
-          group_name: 'Team B',
           role_name: 'admin',
         },
       ];
@@ -45,12 +48,109 @@ describe('User Model', () => {
       expect(result).toEqual(mockUsers);
     });
 
+    it('does not join or select from groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll();
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('LEFT JOIN groups');
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
+    });
+
     it('returns empty array when no users', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
       const result = await User.findAll();
 
       expect(result).toEqual([]);
+    });
+
+    it('filters by role', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ role: 'admin' });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('r.name = $1');
+      expect(values).toEqual(['admin']);
+    });
+
+    it('filters by status', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ status: 'pending' });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('u.status = $1');
+      expect(values).toEqual(['pending']);
+    });
+
+    it('filters by subjectId using user_subjects EXISTS', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ subjectId: SUBJECT_ID });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('FROM user_subjects us');
+      expect(sql).toContain('us.subject_id = $1');
+      expect(values).toEqual([SUBJECT_ID]);
+    });
+
+    it('filters by groupId using user_groups EXISTS', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ groupId: GROUP_ID });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('FROM user_groups ug');
+      expect(sql).toContain('ug.group_id = $1');
+      expect(values).toEqual([GROUP_ID]);
+    });
+
+    it('filters ungrouped users of an assignment when groupId is "none" with assignmentId', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ assignmentId: ASSIGNMENT_ID, groupId: 'none' });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      // Enrolled in the assignment's subject...
+      expect(sql).toContain('JOIN assignments a ON a.subject_id = us.subject_id');
+      expect(sql).toContain('a.id = $1');
+      // ...but with no user_groups row for the assignment
+      expect(sql).toContain('NOT EXISTS');
+      expect(sql).toContain('ug.assignment_id = $2');
+      expect(values).toEqual([ASSIGNMENT_ID, ASSIGNMENT_ID]);
+    });
+
+    it('scopes users by managedBy via assignment_managers', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ managedBy: MANAGER_ID });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('JOIN assignment_managers am ON am.assignment_id = a.id');
+      expect(sql).toContain('am.user_id = $1');
+      expect(values).toEqual([MANAGER_ID]);
+    });
+
+    it('combines multiple filters with sequential placeholders', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findAll({ role: 'user', status: 'active', subjectId: SUBJECT_ID });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).toContain('r.name = $1');
+      expect(sql).toContain('u.status = $2');
+      expect(sql).toContain('us.subject_id = $3');
+      expect(values).toEqual(['user', 'active', SUBJECT_ID]);
+    });
+
+    it('propagates DB error', async () => {
+      pool.query.mockRejectedValue(new Error('connection refused'));
+
+      await expect(User.findAll()).rejects.toThrow('connection refused');
     });
   });
 
@@ -71,6 +171,17 @@ describe('User Model', () => {
         ['u0000000-0000-0000-0000-000000000001', 'u0000000-0000-0000-0000-000000000002'],
       ]);
       expect(result).toEqual(mockUsers);
+    });
+
+    it('does not join or select from groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByIds(['u0000000-0000-0000-0000-000000000001']);
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('LEFT JOIN groups');
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
     });
 
     it('returns empty array without querying when ids is empty', async () => {
@@ -95,12 +206,11 @@ describe('User Model', () => {
   });
 
   describe('findById', () => {
-    it('returns user by id with group and role info', async () => {
+    it('returns user by id with role info', async () => {
       const mockUser = {
         id: 'u0000000-0000-0000-0000-000000000001',
         username: 'testuser',
         email: 'test@test.com',
-        group_name: 'Team A',
         role_name: 'user',
       };
       pool.query.mockResolvedValue({ rows: [mockUser] });
@@ -111,6 +221,17 @@ describe('User Model', () => {
         'u0000000-0000-0000-0000-000000000001',
       ]);
       expect(result).toEqual(mockUser);
+    });
+
+    it('does not join or select from groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findById('u0000000-0000-0000-0000-000000000001');
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('LEFT JOIN groups');
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
     });
 
     it('returns null when user not found', async () => {
@@ -128,7 +249,6 @@ describe('User Model', () => {
         id: 'u0000000-0000-0000-0000-000000000001',
         username: 'testuser',
         password_hash: 'hashed123',
-        group_name: 'Team A',
         role_name: 'user',
       };
       pool.query.mockResolvedValue({ rows: [mockUser] });
@@ -139,6 +259,17 @@ describe('User Model', () => {
         'testuser',
       ]);
       expect(result).toEqual(mockUser);
+    });
+
+    it('does not join or select from groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByUsername('testuser');
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('LEFT JOIN groups');
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
     });
 
     it('returns null when username not found', async () => {
@@ -164,6 +295,16 @@ describe('User Model', () => {
         ['a@test.com', 'b@test.com'],
       ]);
       expect(result).toEqual(mockUsers);
+    });
+
+    it('does not select group columns', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByEmails(['a@test.com']);
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
     });
 
     it('returns empty array without querying when emails is empty', async () => {
@@ -213,6 +354,17 @@ describe('User Model', () => {
       expect(pool.query).toHaveBeenCalledWith(expect.any(String), [['upper', 'mixed']]);
     });
 
+    it('does not join or select from groups', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByUsernames(['alice']);
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('LEFT JOIN groups');
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
+    });
+
     it('returns empty array without querying when usernames is empty', async () => {
       const result = await User.findByUsernames([]);
 
@@ -242,6 +394,16 @@ describe('User Model', () => {
         ['S001', 'S002'],
       ]);
       expect(result).toEqual(mockUsers);
+    });
+
+    it('does not select group columns', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByStudentIds(['S001']);
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
     });
 
     it('returns empty array without querying when studentIds is empty', async () => {
@@ -282,6 +444,16 @@ describe('User Model', () => {
       expect(result).toEqual(mockUser);
     });
 
+    it('does not select group columns', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByStudentId('S001');
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
+    });
+
     it('returns null when no row matches', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
@@ -306,6 +478,16 @@ describe('User Model', () => {
       expect(result).toEqual(mockUser);
     });
 
+    it('does not select group columns', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+
+      await User.findByEmail('test@test.com');
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+      expect(sql).not.toContain('group_name');
+    });
+
     it('returns null when email not found', async () => {
       pool.query.mockResolvedValue({ rows: [] });
 
@@ -316,13 +498,12 @@ describe('User Model', () => {
   });
 
   describe('create', () => {
-    it('creates user with hashed password and default role', async () => {
+    it('creates user with hashed password (active status)', async () => {
       const userData = {
         username: 'newuser',
         email: 'new@test.com',
         password: 'password123',
         studentId: 'S123',
-        groupId: 'g0000000-0000-0000-0000-000000000001',
         roleId: 'r0000000-0000-0000-0000-000000000003',
       };
       const mockCreatedUser = {
@@ -331,6 +512,7 @@ describe('User Model', () => {
         email: 'new@test.com',
         student_id: 'S123',
         enabled: true,
+        status: 'active',
         created_at: new Date(),
       };
 
@@ -347,9 +529,58 @@ describe('User Model', () => {
         'newuser',
         'newuser',
         'S123',
-        'g0000000-0000-0000-0000-000000000001',
         'r0000000-0000-0000-0000-000000000003',
         'active',
+      ]);
+      expect(result).toEqual(mockCreatedUser);
+    });
+
+    it('does not insert a group_id column', async () => {
+      bcrypt.hash.mockResolvedValue('hashedPassword123');
+      pool.query.mockResolvedValue({ rows: [{}] });
+
+      await User.create({
+        username: 'newuser',
+        email: 'new@test.com',
+        password: 'password123',
+        roleId: 'r0000000-0000-0000-0000-000000000003',
+      });
+
+      const [sql] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+    });
+
+    it('creates pending user without password (no hash)', async () => {
+      const userData = {
+        username: 'pendinguser',
+        email: 'pending@test.com',
+        studentId: null,
+        roleId: 'r0000000-0000-0000-0000-000000000003',
+      };
+      const mockCreatedUser = {
+        id: 'u0000000-0000-0000-0000-000000000001',
+        username: 'pendinguser',
+        email: 'pending@test.com',
+        student_id: null,
+        enabled: true,
+        status: 'pending',
+        created_at: new Date(),
+      };
+
+      pool.query.mockResolvedValue({ rows: [mockCreatedUser] });
+
+      const result = await User.create(userData);
+
+      expect(bcrypt.hash).not.toHaveBeenCalled();
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO users'), [
+        'pendinguser',
+        'pending@test.com',
+        null,
+        'pendinguser',
+        'pendinguser',
+        null,
+        'r0000000-0000-0000-0000-000000000003',
+        'pending',
       ]);
       expect(result).toEqual(mockCreatedUser);
     });
@@ -360,7 +591,6 @@ describe('User Model', () => {
         email: 'new@test.com',
         password: 'password123',
         studentId: null,
-        groupId: null,
         roleId: 'r0000000-0000-0000-0000-000000000003',
       };
       const mockCreatedUser = {
@@ -384,7 +614,6 @@ describe('User Model', () => {
         'newuser',
         'newuser',
         null,
-        null,
         'r0000000-0000-0000-0000-000000000003',
         'active',
       ]);
@@ -397,7 +626,6 @@ describe('User Model', () => {
         email: 'new@test.com',
         password: 'password123',
         studentId: null,
-        groupId: null,
         roleId: 'r0000000-0000-0000-0000-000000000003',
       };
 
@@ -413,7 +641,6 @@ describe('User Model', () => {
         email: 'admin@test.com',
         password: 'password123',
         studentId: null,
-        groupId: null,
         roleId: 'r0000000-0000-0000-0000-000000000001',
       };
       const mockCreatedUser = {
@@ -437,7 +664,6 @@ describe('User Model', () => {
         'adminuser',
         'adminuser',
         null,
-        null,
         'r0000000-0000-0000-0000-000000000001',
         'active',
       ]);
@@ -451,7 +677,6 @@ describe('User Model', () => {
         username: 'updateduser',
         email: 'updated@test.com',
         studentId: 'S456',
-        groupId: 'g0000000-0000-0000-0000-000000000002',
         roleId: 'r0000000-0000-0000-0000-000000000002',
         enabled: false,
       };
@@ -470,12 +695,24 @@ describe('User Model', () => {
         'updateduser',
         'updated@test.com',
         'S456',
-        'g0000000-0000-0000-0000-000000000002',
         'r0000000-0000-0000-0000-000000000002',
         false,
         'u0000000-0000-0000-0000-000000000001',
       ]);
       expect(result).toEqual(mockUpdatedUser);
+    });
+
+    it('ignores groupId and does not touch group_id', async () => {
+      pool.query.mockResolvedValue({ rows: [{}] });
+
+      await User.update('u0000000-0000-0000-0000-000000000001', {
+        username: 'updateduser',
+        groupId: 'g0000000-0000-0000-0000-000000000002',
+      });
+
+      const [sql, values] = pool.query.mock.calls[0];
+      expect(sql).not.toContain('group_id');
+      expect(values).toEqual(['updateduser', 'u0000000-0000-0000-0000-000000000001']);
     });
 
     it('updates user with partial fields', async () => {
@@ -510,53 +747,9 @@ describe('User Model', () => {
     });
   });
 
-  describe('updateGroup', () => {
-    it('updates user group', async () => {
-      const mockUpdatedUser = {
-        id: 'u0000000-0000-0000-0000-000000000001',
-        username: 'testuser',
-        group_id: 'g0000000-0000-0000-0000-000000000002',
-      };
-      pool.query.mockResolvedValue({ rows: [mockUpdatedUser] });
-
-      const result = await User.updateGroup(
-        'u0000000-0000-0000-0000-000000000001',
-        'g0000000-0000-0000-0000-000000000002'
-      );
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE users'), [
-        'g0000000-0000-0000-0000-000000000002',
-        'u0000000-0000-0000-0000-000000000001',
-      ]);
-      expect(result).toEqual(mockUpdatedUser);
-    });
-
-    it('sets group to null', async () => {
-      const mockUpdatedUser = {
-        id: 'u0000000-0000-0000-0000-000000000001',
-        username: 'testuser',
-        group_id: null,
-      };
-      pool.query.mockResolvedValue({ rows: [mockUpdatedUser] });
-
-      const result = await User.updateGroup('u0000000-0000-0000-0000-000000000001', null);
-
-      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE users'), [
-        null,
-        'u0000000-0000-0000-0000-000000000001',
-      ]);
-      expect(result).toEqual(mockUpdatedUser);
-    });
-
-    it('returns undefined when user not found', async () => {
-      pool.query.mockResolvedValue({ rows: [] });
-
-      const result = await User.updateGroup(
-        'u0000000-0000-0000-0000-000000000999',
-        'g0000000-0000-0000-0000-000000000001'
-      );
-
-      expect(result).toBeUndefined();
+  describe('removed methods', () => {
+    it('no longer exposes updateGroup (membership lives in UserGroup)', () => {
+      expect(User.updateGroup).toBeUndefined();
     });
   });
 

--- a/backend/tests/unit/models/userGroup.test.js
+++ b/backend/tests/unit/models/userGroup.test.js
@@ -144,7 +144,7 @@ describe('UserGroup Model', () => {
       pool.connect.mockResolvedValue(mockClient);
     });
 
-    it('assigns when the group exists, the user is a subject member, no existing membership, and capacity allows', async () => {
+    it('assigns when the group exists, the user is an active subject member, no existing membership, and capacity allows', async () => {
       mockClient.query
         .mockResolvedValueOnce({}) // BEGIN
         .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
@@ -157,6 +157,8 @@ describe('UserGroup Model', () => {
 
       expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
       expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FOR UPDATE'), [GROUP_ID]);
+      // The membership check must exclude suspended (enabled = false) memberships
+      expect(mockClient.query.mock.calls[2][0]).toEqual(expect.stringContaining('enabled = true'));
       expect(mockClient.query).toHaveBeenNthCalledWith(5, expect.stringContaining('INSERT INTO user_groups'), [
         USER_ID,
         GROUP_ID,
@@ -178,14 +180,15 @@ describe('UserGroup Model', () => {
       expect(mockClient.release).toHaveBeenCalled();
     });
 
-    it('throws 403 when the user is not a member of the parent subject (applies to ALL callers, admin included)', async () => {
+    it('throws 403 when the user is not an active member of the parent subject (applies to ALL callers, admin included)', async () => {
       mockClient.query
         .mockResolvedValueOnce({}) // BEGIN
         .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
-        .mockResolvedValueOnce({ rows: [] }); // subject membership — missing
+        .mockResolvedValueOnce({ rows: [] }); // subject membership — missing or suspended
 
       await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toMatchObject({
         statusCode: 403,
+        message: 'User is not an active member of this subject',
       });
       expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
     });

--- a/backend/tests/unit/models/userGroup.test.js
+++ b/backend/tests/unit/models/userGroup.test.js
@@ -1,0 +1,305 @@
+jest.mock('../../../src/db/pool', () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+const pool = require('../../../src/db/pool');
+const UserGroup = require('../../../src/models/UserGroup');
+
+const USER_ID = 'u0000000-0000-0000-0000-000000000001';
+const GROUP_ID = 'g0000000-0000-0000-0000-000000000001';
+const OTHER_GROUP_ID = 'g0000000-0000-0000-0000-000000000002';
+const ASSIGNMENT_ID = 'a0000000-0000-0000-0000-000000000001';
+const SUBJECT_ID = 's0000000-0000-0000-0000-000000000001';
+
+describe('UserGroup Model', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findMembership', () => {
+    it('returns the membership row for a (user, assignment)', async () => {
+      const row = { user_id: USER_ID, assignment_id: ASSIGNMENT_ID, group_id: GROUP_ID };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await UserGroup.findMembership(USER_ID, ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('FROM user_groups'), [USER_ID, ASSIGNMENT_ID]);
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when no membership exists', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await UserGroup.findMembership(USER_ID, ASSIGNMENT_ID)).toBeNull();
+    });
+  });
+
+  describe('findMembershipsForUser', () => {
+    it('returns memberships joined with group, assignment, and subject names', async () => {
+      const rows = [
+        {
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'A1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'S1',
+          group_id: GROUP_ID,
+          group_name: 'Team Alpha',
+        },
+      ];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await UserGroup.findMembershipsForUser(USER_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('JOIN groups'), [USER_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('findMembershipsForUsers', () => {
+    it('returns membership rows keyed by user for a batch of users', async () => {
+      const rows = [
+        {
+          user_id: USER_ID,
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'A1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'S1',
+          group_id: GROUP_ID,
+          group_name: 'Team Alpha',
+        },
+      ];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await UserGroup.findMembershipsForUsers([USER_ID]);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('ug.user_id = ANY($1)'), [[USER_ID]]);
+      expect(result).toEqual(rows);
+    });
+
+    it('returns empty array for an empty user list without querying', async () => {
+      expect(await UserGroup.findMembershipsForUsers([])).toEqual([]);
+      expect(pool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getMembers', () => {
+    it('returns member users of a group with role names', async () => {
+      const rows = [{ id: USER_ID, username: 'u1', role_name: 'user' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await UserGroup.getMembers(GROUP_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('JOIN user_groups'), [GROUP_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes the membership and returns the removed row', async () => {
+      const row = { user_id: USER_ID, assignment_id: ASSIGNMENT_ID, group_id: GROUP_ID };
+      pool.query.mockResolvedValue({ rows: [row] });
+
+      const result = await UserGroup.remove(USER_ID, ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM user_groups'), [
+        USER_ID,
+        ASSIGNMENT_ID,
+      ]);
+      expect(result).toEqual(row);
+    });
+
+    it('returns null when there was nothing to remove', async () => {
+      pool.query.mockResolvedValue({ rows: [] });
+      expect(await UserGroup.remove(USER_ID, ASSIGNMENT_ID)).toBeNull();
+    });
+  });
+
+  describe('getExportMappings', () => {
+    it('returns email/group_name pairs scoped to the assignment', async () => {
+      const rows = [{ email: 'u1@test.com', group_name: 'Team Alpha' }];
+      pool.query.mockResolvedValue({ rows });
+
+      const result = await UserGroup.getExportMappings(ASSIGNMENT_ID);
+
+      expect(pool.query).toHaveBeenCalledWith(expect.stringContaining('assignment_id'), [ASSIGNMENT_ID]);
+      expect(result).toEqual(rows);
+    });
+  });
+
+  describe('assignUserToGroup', () => {
+    let mockClient;
+
+    const groupRow = {
+      id: GROUP_ID,
+      assignment_id: ASSIGNMENT_ID,
+      subject_id: SUBJECT_ID,
+      name: 'Team Alpha',
+      enabled: true,
+      max_members: 5,
+      member_count: 2,
+    };
+
+    beforeEach(() => {
+      mockClient = { query: jest.fn(), release: jest.fn() };
+      pool.connect.mockResolvedValue(mockClient);
+    });
+
+    it('assigns when the group exists, the user is a subject member, no existing membership, and capacity allows', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [] }) // existing membership
+        .mockResolvedValueOnce({}) // INSERT
+        .mockResolvedValueOnce({}); // COMMIT
+
+      await UserGroup.assignUserToGroup(USER_ID, GROUP_ID);
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+      expect(mockClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FOR UPDATE'), [GROUP_ID]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(5, expect.stringContaining('INSERT INTO user_groups'), [
+        USER_ID,
+        GROUP_ID,
+        ASSIGNMENT_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('throws 404 when the group does not exist', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }); // lock group — not found
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toMatchObject({
+        statusCode: 404,
+      });
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it('throws 403 when the user is not a member of the parent subject (applies to ALL callers, admin included)', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [] }); // subject membership — missing
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toMatchObject({
+        statusCode: 403,
+      });
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    it('throws 409 when the user already has a group for the assignment and replace is false', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [{ user_id: USER_ID, group_id: OTHER_GROUP_ID }] }); // existing membership
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID, { replace: false })).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    it('replaces the existing membership when replace is true', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [{ user_id: USER_ID, group_id: OTHER_GROUP_ID }] }) // existing membership
+        .mockResolvedValueOnce({}) // DELETE existing
+        .mockResolvedValueOnce({}) // INSERT
+        .mockResolvedValueOnce({}); // COMMIT
+
+      await UserGroup.assignUserToGroup(USER_ID, GROUP_ID, { replace: true });
+
+      expect(mockClient.query).toHaveBeenNthCalledWith(5, expect.stringContaining('DELETE FROM user_groups'), [
+        USER_ID,
+        ASSIGNMENT_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenNthCalledWith(6, expect.stringContaining('INSERT INTO user_groups'), [
+        USER_ID,
+        GROUP_ID,
+        ASSIGNMENT_ID,
+      ]);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    it('is a no-op when replace is true and the user is already in the target group', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [{ user_id: USER_ID, group_id: GROUP_ID }] }) // already in target
+        .mockResolvedValueOnce({}); // COMMIT
+
+      await UserGroup.assignUserToGroup(USER_ID, GROUP_ID, { replace: true });
+
+      const insertCalls = mockClient.query.mock.calls.filter(([sql]) =>
+        String(sql).includes('INSERT INTO user_groups')
+      );
+      expect(insertCalls).toHaveLength(0);
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    it('throws 409 when the group is full', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ ...groupRow, member_count: 5, max_members: 5 }] }) // lock group — full
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [] }); // existing membership
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toMatchObject({
+        statusCode: 409,
+        message: 'Group is full',
+      });
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    it('allows assignment when max_members is null (unlimited)', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ ...groupRow, max_members: null, member_count: 999 }] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [] }) // existing membership
+        .mockResolvedValueOnce({}) // INSERT
+        .mockResolvedValueOnce({}); // COMMIT
+
+      await UserGroup.assignUserToGroup(USER_ID, GROUP_ID);
+
+      expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    it('maps a concurrent duplicate-membership insert (23505) to 409', async () => {
+      const pgErr = new Error('duplicate key value violates unique constraint "user_groups_pkey"');
+      pgErr.code = '23505';
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [] }) // existing membership
+        .mockRejectedValueOnce(pgErr); // INSERT hits PK race
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    });
+
+    it('releases the client even when COMMIT fails', async () => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [groupRow] }) // lock group
+        .mockResolvedValueOnce({ rows: [{ exists: true }] }) // subject membership
+        .mockResolvedValueOnce({ rows: [] }) // existing membership
+        .mockResolvedValueOnce({}) // INSERT
+        .mockRejectedValueOnce(new Error('commit failed')) // COMMIT
+        .mockResolvedValueOnce({}); // ROLLBACK
+
+      await expect(UserGroup.assignUserToGroup(USER_ID, GROUP_ID)).rejects.toThrow('commit failed');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tests/unit/schemas.test.js
+++ b/backend/tests/unit/schemas.test.js
@@ -34,6 +34,7 @@ const {
   createAssignmentSchema,
   updateAssignmentSchema,
   addSubjectUsersSchema,
+  setMemberEnabledSchema,
   setAssignmentManagersSchema,
   updateUserGroupSchema,
   bulkCreateGroupsSchema,
@@ -865,6 +866,28 @@ describe('addSubjectUsersSchema', () => {
 
   it('rejects a missing userIds field', () => {
     expect(err(addSubjectUsersSchema, {})).toEqual(expect.any(String));
+  });
+});
+
+describe('setMemberEnabledSchema', () => {
+  it('accepts enabled true', () => {
+    const data = ok(setMemberEnabledSchema, { enabled: true });
+    expect(data.enabled).toBe(true);
+  });
+
+  it('accepts enabled false', () => {
+    const data = ok(setMemberEnabledSchema, { enabled: false });
+    expect(data.enabled).toBe(false);
+  });
+
+  it('rejects a missing enabled field', () => {
+    expect(err(setMemberEnabledSchema, {})).toEqual(expect.any(String));
+  });
+
+  it('rejects a non-boolean enabled value', () => {
+    expect(err(setMemberEnabledSchema, { enabled: 'true' })).toEqual(expect.any(String));
+    expect(err(setMemberEnabledSchema, { enabled: 1 })).toEqual(expect.any(String));
+    expect(err(setMemberEnabledSchema, { enabled: null })).toEqual(expect.any(String));
   });
 });
 

--- a/backend/tests/unit/schemas.test.js
+++ b/backend/tests/unit/schemas.test.js
@@ -29,6 +29,14 @@ const {
   validateUUID,
   bulkCreateGroupItemSchema,
   BULK_CREATE_MAX,
+  createSubjectSchema,
+  updateSubjectSchema,
+  createAssignmentSchema,
+  updateAssignmentSchema,
+  addSubjectUsersSchema,
+  setAssignmentManagersSchema,
+  updateUserGroupSchema,
+  bulkCreateGroupsSchema,
 } = require('../../src/utils/schemas');
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -416,6 +424,46 @@ describe('createUserSchema', () => {
     const result = parseBody(createUserSchema, { ...validBody, username: '<script>xss</script>' });
     expect(result.error).toBe('Username may only contain letters, numbers, underscores, hyphens, and dots');
   });
+
+  it('accepts subjectIds as an array of UUIDs', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      subjectIds: ['10000000-0000-4000-8000-000000000001'],
+    });
+    expect(data.subjectIds).toEqual(['10000000-0000-4000-8000-000000000001']);
+  });
+
+  it('rejects subjectIds containing a non-UUID', () => {
+    expect(err(createUserSchema, { ...validBody, subjectIds: ['nope'] })).toEqual(expect.any(String));
+  });
+
+  it('accepts optional assignmentId and groupId UUIDs for placement', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      subjectIds: ['10000000-0000-4000-8000-000000000001'],
+      assignmentId: '20000000-0000-4000-8000-000000000001',
+      groupId: '30000000-0000-4000-8000-000000000001',
+    });
+    expect(data.assignmentId).toBe('20000000-0000-4000-8000-000000000001');
+    expect(data.groupId).toBe('30000000-0000-4000-8000-000000000001');
+  });
+
+  it('rejects a non-UUID assignmentId', () => {
+    expect(err(createUserSchema, { ...validBody, assignmentId: 'bad' })).toEqual(expect.any(String));
+  });
+
+  it('accepts assignmentIds (AM scope) as an array of UUIDs', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      role: 'assignment_manager',
+      assignmentIds: ['20000000-0000-4000-8000-000000000001'],
+    });
+    expect(data.assignmentIds).toEqual(['20000000-0000-4000-8000-000000000001']);
+  });
+
+  it('rejects assignmentIds containing a non-UUID', () => {
+    expect(err(createUserSchema, { ...validBody, assignmentIds: ['bad'] })).toEqual(expect.any(String));
+  });
 });
 
 // ── updateUserSchema ──────────────────────────────────────────────────────────
@@ -446,18 +494,9 @@ describe('updateUserSchema', () => {
     );
   });
 
-  it('accepts optional groupId as UUID (M1)', () => {
+  it('strips groupId — group membership is managed via PUT /users/:id/group, not user update', () => {
     const data = ok(updateUserSchema, { groupId: '10000000-0000-4000-8000-000000000001' });
-    expect(data.groupId).toBe('10000000-0000-4000-8000-000000000001');
-  });
-
-  it('accepts groupId as null (M1)', () => {
-    const data = ok(updateUserSchema, { groupId: null });
-    expect(data.groupId).toBeNull();
-  });
-
-  it('rejects groupId that is not a UUID (M1)', () => {
-    expect(err(updateUserSchema, { groupId: 'not-a-uuid' })).toEqual(expect.any(String));
+    expect(data.groupId).toBeUndefined();
   });
 });
 
@@ -516,17 +555,30 @@ describe('importUserRowSchema', () => {
 // ── createGroupSchema ─────────────────────────────────────────────────────────
 
 describe('createGroupSchema', () => {
-  it('accepts a valid group name', () => {
-    const data = ok(createGroupSchema, { name: 'Team A' });
+  const ASSIGNMENT_ID = '20000000-0000-4000-8000-000000000001';
+
+  it('accepts a valid group name with assignmentId', () => {
+    const data = ok(createGroupSchema, { assignmentId: ASSIGNMENT_ID, name: 'Team A' });
     expect(data.name).toBe('Team A');
+    expect(data.assignmentId).toBe(ASSIGNMENT_ID);
+  });
+
+  it('rejects a missing assignmentId', () => {
+    expect(err(createGroupSchema, { name: 'Team A' })).toEqual(expect.any(String));
+  });
+
+  it('rejects a non-UUID assignmentId', () => {
+    expect(err(createGroupSchema, { assignmentId: 'nope', name: 'Team A' })).toEqual(expect.any(String));
   });
 
   it('rejects empty group name', () => {
-    expect(err(createGroupSchema, { name: '' })).toBe('Group name is required');
+    expect(err(createGroupSchema, { assignmentId: ASSIGNMENT_ID, name: '' })).toBe('Group name is required');
   });
 
   it('rejects group name over 100 characters', () => {
-    expect(err(createGroupSchema, { name: 'x'.repeat(101) })).toBe('Group name must be at most 100 characters');
+    expect(err(createGroupSchema, { assignmentId: ASSIGNMENT_ID, name: 'x'.repeat(101) })).toBe(
+      'Group name must be at most 100 characters'
+    );
   });
 });
 
@@ -715,5 +767,175 @@ describe('bulkCreateGroupItemSchema', () => {
 describe('BULK_CREATE_MAX', () => {
   it('is set to 2000', () => {
     expect(BULK_CREATE_MAX).toBe(2000);
+  });
+});
+
+// ── hierarchy schemas ─────────────────────────────────────────────────────────
+
+const SUBJECT_ID = '10000000-0000-4000-8000-000000000001';
+const ASSIGNMENT_ID = '20000000-0000-4000-8000-000000000001';
+const GROUP_ID = '30000000-0000-4000-8000-000000000001';
+const USER_ID = '40000000-0000-4000-8000-000000000001';
+
+describe('createSubjectSchema', () => {
+  it('accepts a valid subject name', () => {
+    const data = ok(createSubjectSchema, { name: 'Software Engineering' });
+    expect(data.name).toBe('Software Engineering');
+  });
+
+  it('rejects an empty name', () => {
+    expect(err(createSubjectSchema, { name: '' })).toBe('Subject name is required');
+  });
+
+  it('rejects a name over 100 characters', () => {
+    expect(err(createSubjectSchema, { name: 'x'.repeat(101) })).toBe('Subject name must be at most 100 characters');
+  });
+
+  it('rejects a missing name', () => {
+    expect(err(createSubjectSchema, {})).toEqual(expect.any(String));
+  });
+});
+
+describe('updateSubjectSchema', () => {
+  it('accepts a valid name', () => {
+    const data = ok(updateSubjectSchema, { name: 'Renamed Subject' });
+    expect(data.name).toBe('Renamed Subject');
+  });
+
+  it('rejects an empty name', () => {
+    expect(err(updateSubjectSchema, { name: '' })).toBe('Subject name is required');
+  });
+});
+
+describe('createAssignmentSchema', () => {
+  it('accepts a valid subjectId and name', () => {
+    const data = ok(createAssignmentSchema, { subjectId: SUBJECT_ID, name: 'Assignment 1' });
+    expect(data.subjectId).toBe(SUBJECT_ID);
+    expect(data.name).toBe('Assignment 1');
+  });
+
+  it('rejects a missing subjectId', () => {
+    expect(err(createAssignmentSchema, { name: 'Assignment 1' })).toEqual(expect.any(String));
+  });
+
+  it('rejects a non-UUID subjectId', () => {
+    expect(err(createAssignmentSchema, { subjectId: 'nope', name: 'Assignment 1' })).toEqual(expect.any(String));
+  });
+
+  it('rejects an empty name', () => {
+    expect(err(createAssignmentSchema, { subjectId: SUBJECT_ID, name: '' })).toBe('Assignment name is required');
+  });
+
+  it('rejects a name over 100 characters', () => {
+    expect(err(createAssignmentSchema, { subjectId: SUBJECT_ID, name: 'x'.repeat(101) })).toBe(
+      'Assignment name must be at most 100 characters'
+    );
+  });
+});
+
+describe('updateAssignmentSchema', () => {
+  it('accepts a valid name', () => {
+    const data = ok(updateAssignmentSchema, { name: 'Renamed Assignment' });
+    expect(data.name).toBe('Renamed Assignment');
+  });
+
+  it('rejects an empty name', () => {
+    expect(err(updateAssignmentSchema, { name: '' })).toBe('Assignment name is required');
+  });
+});
+
+describe('addSubjectUsersSchema', () => {
+  it('accepts a list of user UUIDs', () => {
+    const data = ok(addSubjectUsersSchema, { userIds: [USER_ID] });
+    expect(data.userIds).toEqual([USER_ID]);
+  });
+
+  it('rejects an empty list', () => {
+    expect(err(addSubjectUsersSchema, { userIds: [] })).toEqual(expect.any(String));
+  });
+
+  it('rejects more than 2000 ids', () => {
+    const userIds = Array.from({ length: 2001 }, () => USER_ID);
+    expect(err(addSubjectUsersSchema, { userIds })).toEqual(expect.any(String));
+  });
+
+  it('rejects non-UUID entries', () => {
+    expect(err(addSubjectUsersSchema, { userIds: ['nope'] })).toEqual(expect.any(String));
+  });
+
+  it('rejects a missing userIds field', () => {
+    expect(err(addSubjectUsersSchema, {})).toEqual(expect.any(String));
+  });
+});
+
+describe('setAssignmentManagersSchema', () => {
+  it('accepts a list of user UUIDs', () => {
+    const data = ok(setAssignmentManagersSchema, { userIds: [USER_ID] });
+    expect(data.userIds).toEqual([USER_ID]);
+  });
+
+  it('accepts an empty list (clears all managers)', () => {
+    const data = ok(setAssignmentManagersSchema, { userIds: [] });
+    expect(data.userIds).toEqual([]);
+  });
+
+  it('rejects more than 2000 ids', () => {
+    const userIds = Array.from({ length: 2001 }, () => USER_ID);
+    expect(err(setAssignmentManagersSchema, { userIds })).toEqual(expect.any(String));
+  });
+
+  it('rejects non-UUID entries', () => {
+    expect(err(setAssignmentManagersSchema, { userIds: ['nope'] })).toEqual(expect.any(String));
+  });
+});
+
+describe('updateUserGroupSchema', () => {
+  it('accepts assignmentId with a group UUID', () => {
+    const data = ok(updateUserGroupSchema, { assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID });
+    expect(data.assignmentId).toBe(ASSIGNMENT_ID);
+    expect(data.groupId).toBe(GROUP_ID);
+  });
+
+  it('accepts groupId as null (remove from group)', () => {
+    const data = ok(updateUserGroupSchema, { assignmentId: ASSIGNMENT_ID, groupId: null });
+    expect(data.groupId).toBeNull();
+  });
+
+  it('rejects a missing assignmentId', () => {
+    expect(err(updateUserGroupSchema, { groupId: GROUP_ID })).toEqual(expect.any(String));
+  });
+
+  it('rejects a non-UUID groupId', () => {
+    expect(err(updateUserGroupSchema, { assignmentId: ASSIGNMENT_ID, groupId: 'nope' })).toEqual(expect.any(String));
+  });
+});
+
+describe('bulkCreateGroupsSchema', () => {
+  it('accepts an assignmentId with a list of group items', () => {
+    const data = ok(bulkCreateGroupsSchema, {
+      assignmentId: ASSIGNMENT_ID,
+      groups: [{ name: 'Team A' }, { name: 'Team B', enabled: false, maxMembers: 5 }],
+    });
+    expect(data.assignmentId).toBe(ASSIGNMENT_ID);
+    expect(data.groups).toHaveLength(2);
+  });
+
+  it('rejects an empty groups list', () => {
+    expect(err(bulkCreateGroupsSchema, { assignmentId: ASSIGNMENT_ID, groups: [] })).toEqual(expect.any(String));
+  });
+
+  it('rejects more groups than BULK_CREATE_MAX', () => {
+    const groups = Array.from({ length: BULK_CREATE_MAX + 1 }, (_, i) => ({ name: `G${i}` }));
+    expect(err(bulkCreateGroupsSchema, { assignmentId: ASSIGNMENT_ID, groups })).toEqual(expect.any(String));
+  });
+
+  it('rejects a missing assignmentId', () => {
+    expect(err(bulkCreateGroupsSchema, { groups: [{ name: 'Team A' }] })).toEqual(expect.any(String));
+  });
+
+  it('rejects an invalid group item (empty name)', () => {
+    expect(err(bulkCreateGroupsSchema, { assignmentId: ASSIGNMENT_ID, groups: [{ name: '' }] })).toBe(
+      'Group name is required'
+    );
   });
 });

--- a/backend/tests/unit/subjects.test.js
+++ b/backend/tests/unit/subjects.test.js
@@ -2,6 +2,7 @@
 jest.mock('../../src/models/Subject');
 jest.mock('../../src/models/Assignment');
 jest.mock('../../src/models/User');
+jest.mock('../../src/models/UserGroup');
 
 jest.mock('../../src/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
@@ -15,6 +16,7 @@ jest.mock('../../src/utils/logger', () => ({
 const Subject = require('../../src/models/Subject');
 const Assignment = require('../../src/models/Assignment');
 const User = require('../../src/models/User');
+const UserGroup = require('../../src/models/UserGroup');
 
 const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
 const SUBJECT_ID_2 = '30000000-0000-4000-8000-000000000002';
@@ -474,30 +476,69 @@ describe('Subjects Routes', () => {
       expect(mockReply.code).toHaveBeenCalledWith(403);
     });
 
-    it('returns members for managing assignment_manager', async () => {
+    it("returns members enriched with this subject's memberships for managing assignment_manager", async () => {
       const { handlers, mockReply } = setup();
       Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
       Assignment.managesAnyInSubject.mockResolvedValue(true);
       const users = [{ id: USER_ID, username: 'u1' }];
       Subject.getMembers.mockResolvedValue(users);
+      UserGroup.findMembershipsForUsers.mockResolvedValue([
+        {
+          user_id: USER_ID,
+          subject_id: SUBJECT_ID,
+          assignment_id: 'a0000000-0000-4000-8000-000000000001',
+          assignment_name: 'A1',
+          group_id: 'g0000000-0000-4000-8000-000000000001',
+          group_name: 'Team Alpha',
+        },
+        // Membership in ANOTHER subject must be filtered out of the response
+        {
+          user_id: USER_ID,
+          subject_id: 's0000000-0000-4000-8000-000000000099',
+          assignment_id: 'a0000000-0000-4000-8000-000000000002',
+          assignment_name: 'Other',
+          group_id: 'g0000000-0000-4000-8000-000000000002',
+          group_name: 'Elsewhere',
+        },
+      ]);
       await handlers['/subjects/:id/users_get'](
         { user: { id: USER_ID_2, role: 'assignment_manager' }, params: { id: SUBJECT_ID } },
         mockReply
       );
       expect(Subject.getMembers).toHaveBeenCalledWith(SUBJECT_ID);
-      expect(mockReply.send).toHaveBeenCalledWith({ users });
+      expect(UserGroup.findMembershipsForUsers).toHaveBeenCalledWith([USER_ID]);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        users: [
+          {
+            id: USER_ID,
+            username: 'u1',
+            memberships: [
+              {
+                subject_id: SUBJECT_ID,
+                assignment_id: 'a0000000-0000-4000-8000-000000000001',
+                assignment_name: 'A1',
+                group_id: 'g0000000-0000-4000-8000-000000000001',
+                group_name: 'Team Alpha',
+              },
+            ],
+          },
+        ],
+      });
     });
 
-    it('returns members for admin', async () => {
+    it('returns members for admin (empty memberships when none in this subject)', async () => {
       const { handlers, mockReply } = setup();
       Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
       const users = [{ id: USER_ID, username: 'u1' }];
       Subject.getMembers.mockResolvedValue(users);
+      UserGroup.findMembershipsForUsers.mockResolvedValue([]);
       await handlers['/subjects/:id/users_get'](
         { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
         mockReply
       );
-      expect(mockReply.send).toHaveBeenCalledWith({ users });
+      expect(mockReply.send).toHaveBeenCalledWith({
+        users: [{ id: USER_ID, username: 'u1', memberships: [] }],
+      });
     });
 
     it('handles error when fetching members', async () => {
@@ -588,6 +629,170 @@ describe('Subjects Routes', () => {
       const { logger: mockLogger } = require('../../src/utils/logger');
       await handlers['/subjects/:id/users_post'](
         { params: { id: SUBJECT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('PUT /subjects/:id/users/:userId', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_put_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('returns 400 for invalid subject UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_put'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad', userId: USER_ID }, body: { enabled: false } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('returns 400 for invalid user UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_put'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID, userId: 'bad' }, body: { enabled: false } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid user ID' });
+    });
+
+    it('returns 403 for plain user', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: USER_ID_2, role: 'user' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(Subject.setMemberEnabled).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 for assignment_manager not managing in subject', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: USER_ID_2, role: 'assignment_manager' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
+        mockReply
+      );
+      expect(Assignment.managesAnyInSubject).toHaveBeenCalledWith(USER_ID_2, SUBJECT_ID);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(Subject.setMemberEnabled).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid body (missing/non-boolean enabled)', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_put'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID, userId: USER_ID }, body: {} },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+
+      mockReply.code.mockClear();
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: ADMIN_ID, role: 'admin' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: 'nope' },
+        },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(Subject.setMemberEnabled).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: ADMIN_ID, role: 'admin' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+      expect(Subject.setMemberEnabled).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the user is not a member of the subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.setMemberEnabled.mockResolvedValue(false);
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: ADMIN_ID, role: 'admin' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+    });
+
+    it('managing assignment_manager can suspend a member', async () => {
+      const { handlers, mockReply } = setup();
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.setMemberEnabled.mockResolvedValue(true);
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: USER_ID_2, role: 'assignment_manager' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
+        mockReply
+      );
+      expect(Subject.setMemberEnabled).toHaveBeenCalledWith(SUBJECT_ID, USER_ID, false);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Member suspended', membershipEnabled: false });
+    });
+
+    it('admin can re-enable a member', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.setMemberEnabled.mockResolvedValue(true);
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: ADMIN_ID, role: 'admin' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: true },
+        },
+        mockReply
+      );
+      expect(Assignment.managesAnyInSubject).not.toHaveBeenCalled();
+      expect(Subject.setMemberEnabled).toHaveBeenCalledWith(SUBJECT_ID, USER_ID, true);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Member enabled', membershipEnabled: true });
+    });
+
+    it('handles error when updating the membership', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.setMemberEnabled.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id/users/:userId_put'](
+        {
+          user: { id: ADMIN_ID, role: 'admin' },
+          params: { id: SUBJECT_ID, userId: USER_ID },
+          body: { enabled: false },
+        },
         mockReply
       );
       expect(mockLogger.error).toHaveBeenCalled();

--- a/backend/tests/unit/subjects.test.js
+++ b/backend/tests/unit/subjects.test.js
@@ -1,0 +1,663 @@
+// Mock models at the top level
+jest.mock('../../src/models/Subject');
+jest.mock('../../src/models/Assignment');
+jest.mock('../../src/models/User');
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(), trace: jest.fn(), fatal: jest.fn() },
+  maskEmail: (e) => e,
+  maskName: (n) => n,
+  maskToken: (t) => t,
+  maskStudentId: (s) => s,
+  redactMeta: (m) => m,
+}));
+
+const Subject = require('../../src/models/Subject');
+const Assignment = require('../../src/models/Assignment');
+const User = require('../../src/models/User');
+
+const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
+const SUBJECT_ID_2 = '30000000-0000-4000-8000-000000000002';
+const USER_ID = '00000000-0000-4000-8000-000000000001';
+const USER_ID_2 = '00000000-0000-4000-8000-000000000002';
+const ADMIN_ID = '00000000-0000-4000-8000-00000000000a';
+
+describe('Subjects Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockFastify = (options = {}) => ({
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    checkRole: jest.fn().mockResolvedValue(options.checkRoleResult ?? true),
+    requireAdmin: jest.fn().mockResolvedValue(options.requireAdminResult ?? true),
+  });
+
+  const captureHandlers = (mockFastify) => {
+    const handlers = {};
+    const wrapMethod = (method) => {
+      mockFastify[method].mockImplementation((path, ...args) => {
+        const config = args[0];
+        const handler = args.find((a) => typeof a === 'function');
+        if (config && config.preHandler) {
+          handlers[`${path}_${method}_pre`] = config.preHandler;
+        }
+        if (handler) {
+          handlers[`${path}_${method}`] = handler;
+        }
+      });
+    };
+    wrapMethod('get');
+    wrapMethod('post');
+    wrapMethod('put');
+    wrapMethod('delete');
+    return handlers;
+  };
+
+  const setup = (options = {}) => {
+    const mockFastify = createMockFastify(options);
+    const handlers = captureHandlers(mockFastify);
+    const subjectsRoutes = require('../../src/routes/subjects');
+    subjectsRoutes(mockFastify, {});
+    const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+    return { mockFastify, handlers, mockReply };
+  };
+
+  describe('GET /subjects', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('returns all subjects for admin', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [
+        { id: SUBJECT_ID, name: 'COMP10001' },
+        { id: SUBJECT_ID_2, name: 'COMP20002' },
+      ];
+      Subject.findAll.mockResolvedValue(rows);
+      await handlers['/subjects_get']({ user: { id: ADMIN_ID, role: 'admin' } }, mockReply);
+      expect(Subject.findAll).toHaveBeenCalled();
+      expect(Subject.findForUser).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ subjects: rows });
+    });
+
+    it('filters subjects for assignment_manager to managed union member subjects', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [
+        { id: SUBJECT_ID, name: 'Managed' },
+        { id: SUBJECT_ID_2, name: 'Member' },
+        { id: '30000000-0000-4000-8000-000000000003', name: 'Other' },
+      ];
+      Subject.findAll.mockResolvedValue(rows);
+      Assignment.findManagedBy.mockResolvedValue([
+        { id: '40000000-0000-4000-8000-000000000001', subject_id: SUBJECT_ID },
+      ]);
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID_2, name: 'Member' }]);
+      await handlers['/subjects_get']({ user: { id: USER_ID, role: 'assignment_manager' } }, mockReply);
+      expect(Assignment.findManagedBy).toHaveBeenCalledWith(USER_ID);
+      expect(Subject.findForUser).toHaveBeenCalledWith(USER_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        subjects: [
+          { id: SUBJECT_ID, name: 'Managed' },
+          { id: SUBJECT_ID_2, name: 'Member' },
+        ],
+      });
+    });
+
+    it('filters subjects for regular user to member subjects only', async () => {
+      const { handlers, mockReply } = setup();
+      const rows = [
+        { id: SUBJECT_ID, name: 'Mine' },
+        { id: SUBJECT_ID_2, name: 'NotMine' },
+      ];
+      Subject.findAll.mockResolvedValue(rows);
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID, name: 'Mine' }]);
+      await handlers['/subjects_get']({ user: { id: USER_ID, role: 'user' } }, mockReply);
+      expect(Subject.findForUser).toHaveBeenCalledWith(USER_ID);
+      expect(Assignment.findManagedBy).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ subjects: [{ id: SUBJECT_ID, name: 'Mine' }] });
+    });
+
+    it('handles error when fetching subjects', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findAll.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects_get']({ user: { id: ADMIN_ID, role: 'admin' } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /subjects/:id', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'not-a-uuid' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+    });
+
+    it('returns 403 for non-member regular user', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'S' });
+      Subject.isMember.mockResolvedValue(false);
+      await handlers['/subjects/:id_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('returns 403 for assignment_manager who neither is member nor manages in subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'S' });
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+      await handlers['/subjects/:id_get'](
+        { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(Assignment.managesAnyInSubject).toHaveBeenCalledWith(USER_ID, SUBJECT_ID);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('allows member user and returns subject with assignments', async () => {
+      const { handlers, mockReply } = setup();
+      const subject = { id: SUBJECT_ID, name: 'S' };
+      const assignments = [{ id: '40000000-0000-4000-8000-000000000001', name: 'A1', subject_id: SUBJECT_ID }];
+      Subject.findById.mockResolvedValue(subject);
+      Subject.isMember.mockResolvedValue(true);
+      Assignment.findAll.mockResolvedValue(assignments);
+      await handlers['/subjects/:id_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(Assignment.findAll).toHaveBeenCalledWith({ subjectId: SUBJECT_ID });
+      expect(mockReply.send).toHaveBeenCalledWith({ subject, assignments });
+    });
+
+    it('allows assignment_manager who manages an assignment in the subject', async () => {
+      const { handlers, mockReply } = setup();
+      const subject = { id: SUBJECT_ID, name: 'S' };
+      Subject.findById.mockResolvedValue(subject);
+      Subject.isMember.mockResolvedValue(false);
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+      Assignment.findAll.mockResolvedValue([]);
+      await handlers['/subjects/:id_get'](
+        { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ subject, assignments: [] });
+    });
+
+    it('allows admin without membership checks', async () => {
+      const { handlers, mockReply } = setup();
+      const subject = { id: SUBJECT_ID, name: 'S' };
+      Subject.findById.mockResolvedValue(subject);
+      Assignment.findAll.mockResolvedValue([]);
+      await handlers['/subjects/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(Subject.isMember).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ subject, assignments: [] });
+    });
+
+    it('handles error when fetching subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('POST /subjects', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects_post_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/subjects_post_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('rejects invalid body', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects_post']({ body: {} }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+      expect(Subject.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects duplicate subject name', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findByName.mockResolvedValue({ id: SUBJECT_ID, name: 'COMP10001' });
+      await handlers['/subjects_post']({ body: { name: 'COMP10001' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'A subject with this name already exists' });
+      expect(Subject.create).not.toHaveBeenCalled();
+    });
+
+    it('creates subject successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findByName.mockResolvedValue(null);
+      const created = { id: SUBJECT_ID, name: 'COMP10001' };
+      Subject.create.mockResolvedValue(created);
+      await handlers['/subjects_post']({ body: { name: 'COMP10001' } }, mockReply);
+      expect(Subject.create).toHaveBeenCalledWith('COMP10001');
+      expect(mockReply.code).toHaveBeenCalledWith(201);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Subject created successfully', subject: created });
+    });
+
+    it('handles error when creating subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findByName.mockResolvedValue(null);
+      Subject.create.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects_post']({ body: { name: 'COMP10001' } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('PUT /subjects/:id', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_put_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'user' } };
+      const result = await handlers['/subjects/:id_put_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_put']({ params: { id: 'bad' }, body: { name: 'X' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('rejects invalid body', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: '' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: 'New' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+    });
+
+    it('rejects duplicate name owned by a different subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'Old' });
+      Subject.findByName.mockResolvedValue({ id: SUBJECT_ID_2, name: 'New' });
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: 'New' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'A subject with this name already exists' });
+      expect(Subject.update).not.toHaveBeenCalled();
+    });
+
+    it('allows rename when duplicate match is the same subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'old name' });
+      Subject.findByName.mockResolvedValue({ id: SUBJECT_ID, name: 'old name' });
+      const updated = { id: SUBJECT_ID, name: 'Old Name' };
+      Subject.update.mockResolvedValue(updated);
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: 'Old Name' } }, mockReply);
+      expect(Subject.update).toHaveBeenCalledWith(SUBJECT_ID, { name: 'Old Name' });
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Subject updated successfully', subject: updated });
+    });
+
+    it('updates subject successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'Old' });
+      Subject.findByName.mockResolvedValue(null);
+      const updated = { id: SUBJECT_ID, name: 'New' };
+      Subject.update.mockResolvedValue(updated);
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: 'New' } }, mockReply);
+      expect(Subject.update).toHaveBeenCalledWith(SUBJECT_ID, { name: 'New' });
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Subject updated successfully', subject: updated });
+    });
+
+    it('handles error when updating subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id_put']({ params: { id: SUBJECT_ID }, body: { name: 'New' } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('DELETE /subjects/:id', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_delete_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/subjects/:id_delete_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id_delete']({ params: { id: 'bad' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id_delete']({ params: { id: SUBJECT_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(Subject.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes subject successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'S' });
+      Subject.delete.mockResolvedValue({ id: SUBJECT_ID });
+      await handlers['/subjects/:id_delete']({ params: { id: SUBJECT_ID } }, mockReply);
+      expect(Subject.delete).toHaveBeenCalledWith(SUBJECT_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Subject deleted successfully' });
+    });
+
+    it('handles error when deleting subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'S' });
+      Subject.delete.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id_delete']({ params: { id: SUBJECT_ID } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('GET /subjects/:id/users', () => {
+    it('rejects unauthenticated request', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users_get_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: 'bad' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 403 for plain user', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: USER_ID, role: 'user' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(Subject.getMembers).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 for assignment_manager not managing in subject', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: USER_ID, role: 'assignment_manager' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+    });
+
+    it('returns members for managing assignment_manager', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+      const users = [{ id: USER_ID, username: 'u1' }];
+      Subject.getMembers.mockResolvedValue(users);
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: USER_ID_2, role: 'assignment_manager' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(Subject.getMembers).toHaveBeenCalledWith(SUBJECT_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({ users });
+    });
+
+    it('returns members for admin', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      const users = [{ id: USER_ID, username: 'u1' }];
+      Subject.getMembers.mockResolvedValue(users);
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ users });
+    });
+
+    it('handles error when fetching members', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id/users_get'](
+        { user: { id: ADMIN_ID, role: 'admin' }, params: { id: SUBJECT_ID } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('POST /subjects/:id/users', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users_post_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/subjects/:id/users_post_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users_post']({ params: { id: 'bad' }, body: { userIds: [USER_ID] } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('rejects invalid body (empty userIds)', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users_post']({ params: { id: SUBJECT_ID }, body: { userIds: [] } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+      expect(Subject.addUsers).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id/users_post'](
+        { params: { id: SUBJECT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 400 when one or more users do not exist', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      User.findByIds.mockResolvedValue([{ id: USER_ID }]);
+      await handlers['/subjects/:id/users_post'](
+        { params: { id: SUBJECT_ID }, body: { userIds: [USER_ID, USER_ID_2] } },
+        mockReply
+      );
+      expect(User.findByIds).toHaveBeenCalledWith([USER_ID, USER_ID_2]);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'One or more users do not exist' });
+      expect(Subject.addUsers).not.toHaveBeenCalled();
+    });
+
+    it('adds users to subject successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      User.findByIds.mockResolvedValue([{ id: USER_ID }, { id: USER_ID_2 }]);
+      Subject.addUsers.mockResolvedValue(2);
+      await handlers['/subjects/:id/users_post'](
+        { params: { id: SUBJECT_ID }, body: { userIds: [USER_ID, USER_ID_2] } },
+        mockReply
+      );
+      expect(Subject.addUsers).toHaveBeenCalledWith(SUBJECT_ID, [USER_ID, USER_ID_2]);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'Users added to subject', added: 2 });
+    });
+
+    it('handles error when adding users', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      User.findByIds.mockResolvedValue([{ id: USER_ID }]);
+      Subject.addUsers.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id/users_post'](
+        { params: { id: SUBJECT_ID }, body: { userIds: [USER_ID] } },
+        mockReply
+      );
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('DELETE /subjects/:id/users/:userId', () => {
+    it('rejects unauthenticated request in preHandler', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_delete_pre']({ user: null }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(401);
+    });
+
+    it('returns reply when requireAdmin fails in preHandler', async () => {
+      const { mockFastify, handlers, mockReply } = setup({ requireAdminResult: false });
+      const request = { user: { id: USER_ID, role: 'assignment_manager' } };
+      const result = await handlers['/subjects/:id/users/:userId_delete_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+    });
+
+    it('returns 400 for invalid subject UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: 'bad', userId: USER_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subject ID' });
+    });
+
+    it('returns 400 for invalid user UUID', async () => {
+      const { handlers, mockReply } = setup();
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: SUBJECT_ID, userId: 'bad' } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid user ID' });
+    });
+
+    it('returns 404 when subject not found', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue(null);
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: SUBJECT_ID, userId: USER_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+    });
+
+    it('returns 404 when user is not a member', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.removeUser.mockResolvedValue(false);
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: SUBJECT_ID, userId: USER_ID } }, mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+    });
+
+    it('removes user from subject successfully', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.removeUser.mockResolvedValue(true);
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: SUBJECT_ID, userId: USER_ID } }, mockReply);
+      expect(Subject.removeUser).toHaveBeenCalledWith(SUBJECT_ID, USER_ID);
+      expect(mockReply.send).toHaveBeenCalledWith({ message: 'User removed from subject' });
+    });
+
+    it('handles error when removing user', async () => {
+      const { handlers, mockReply } = setup();
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID });
+      Subject.removeUser.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+      await handlers['/subjects/:id/users/:userId_delete']({ params: { id: SUBJECT_ID, userId: USER_ID } }, mockReply);
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -90,17 +90,16 @@ describe('Users Routes', () => {
       expect(mockReply.code).toHaveBeenCalledWith(401);
     });
 
-    it('rejects user without admin/assignment_manager role', () => {
-      const mockFastify = createMockFastify({ checkRoleResult: false });
+    it('rejects non-admin callers (assignment managers included) via requireAdmin', async () => {
+      const mockFastify = createMockFastify({ requireAdminResult: false });
       const handlers = captureHandlers(mockFastify);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
-      handlers['/users_get_pre']({ user: { role: 'user' } }, mockReply);
-      expect(mockFastify.checkRole).toHaveBeenCalledWith({ user: { role: 'user' } }, mockReply, [
-        'admin',
-        'assignment_manager',
-      ]);
+      const request = { user: { role: 'assignment_manager' } };
+      const result = await handlers['/users_get_pre'](request, mockReply);
+      expect(mockFastify.requireAdmin).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
     });
 
     it('returns all users enriched with subjects and memberships (batch queries)', async () => {
@@ -250,20 +249,20 @@ describe('Users Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ users: [] });
     });
 
-    it('scopes results with managedBy for assignment_manager callers', async () => {
+    it('never sets managedBy — the route is admin-only since the AM authorization tightening', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findAll.mockResolvedValue([]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      // Even if a request with an AM role reached the handler, no scoping is applied
       await handlers['/users_get'](
         { user: { id: '00000000-0000-4000-8000-000000000042', role: 'assignment_manager' }, query: {} },
         mockReply
       );
-      expect(User.findAll).toHaveBeenCalledWith(
-        expect.objectContaining({ managedBy: '00000000-0000-4000-8000-000000000042' })
-      );
+      const filters = User.findAll.mock.calls[0][0];
+      expect(filters.managedBy).toBeUndefined();
     });
 
     it('does not set managedBy for admin callers', async () => {
@@ -1504,7 +1503,7 @@ describe('Users Routes', () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       setupGroupMocks();
-      const err = new Error('User is not a member of this subject');
+      const err = new Error('User is not an active member of this subject');
       err.statusCode = 403;
       UserGroup.assignUserToGroup.mockRejectedValue(err);
 
@@ -1518,7 +1517,7 @@ describe('Users Routes', () => {
       );
 
       expect(mockReply.code).toHaveBeenCalledWith(403);
-      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User is not an active member of this subject' });
     });
 
     it('maps 409 group-full error from assignUserToGroup', async () => {
@@ -1732,13 +1731,114 @@ describe('Users Routes', () => {
       });
     });
 
-    it('assignment_manager can update basic fields and enabled but not role/groupId', async () => {
+    it('assignment_manager can update basic fields of an in-scope user but not role/groupId', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID, name: 'Subject A', membership_enabled: false }]);
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+      User.update.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000002',
+        username: 'oldname',
+        email: 'new@test.com',
+      });
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id_put'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'assignment_manager' },
+          params: { id: '00000000-0000-4000-8000-000000000002' },
+          targetUser: {
+            id: '00000000-0000-4000-8000-000000000002',
+            username: 'oldname',
+            role_name: 'user',
+            status: 'active',
+          },
+          body: {
+            email: 'new@test.com',
+            firstName: undefined,
+            lastName: undefined,
+            studentId: undefined,
+            role: 'admin',
+            groupId: '10000000-0000-4000-8000-000000000005',
+          },
+        },
+        mockReply
+      );
+
+      // Scope check uses all enrolments, suspended included
+      expect(Subject.findForUser).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000002', {
+        includeDisabled: true,
+      });
+      expect(Assignment.managesAnyInSubject).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', SUBJECT_ID);
+      // role and groupId must be excluded
+      expect(User.update).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000002', {
+        email: 'new@test.com',
+        firstName: undefined,
+        lastName: undefined,
+        studentId: undefined,
+      });
+    });
+
+    it('assignment_manager editing a user outside their managed subjects gets 403', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID_2, name: 'Subject B', membership_enabled: true }]);
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id_put'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'assignment_manager' },
+          params: { id: '00000000-0000-4000-8000-000000000002' },
+          targetUser: { id: '00000000-0000-4000-8000-000000000002', username: 'victim', role_name: 'user' },
+          body: { email: 'new@test.com' },
+        },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Forbidden: user is not in a subject you manage' });
+      expect(User.update).not.toHaveBeenCalled();
+    });
+
+    it('assignment_manager editing a user with zero subject enrolments gets 403', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Subject.findForUser.mockResolvedValue([]);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id_put'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'assignment_manager' },
+          params: { id: '00000000-0000-4000-8000-000000000002' },
+          targetUser: { id: '00000000-0000-4000-8000-000000000002', username: 'nosubjects', role_name: 'user' },
+          body: { email: 'new@test.com' },
+        },
+        mockReply
+      );
+
+      expect(Assignment.managesAnyInSubject).not.toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Forbidden: user is not in a subject you manage' });
+      expect(User.update).not.toHaveBeenCalled();
+    });
+
+    it('assignment_manager self-edit skips the managed-subject scope check', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.update.mockResolvedValue({
         id: '00000000-0000-4000-8000-000000000001',
-        username: 'oldname',
-        email: 'new@test.com',
+        username: 'am1',
+        email: 'me@test.com',
       });
 
       const usersRoutes = require('../../src/routes/users');
@@ -1751,32 +1851,50 @@ describe('Users Routes', () => {
           params: { id: '00000000-0000-4000-8000-000000000001' },
           targetUser: {
             id: '00000000-0000-4000-8000-000000000001',
-            username: 'oldname',
-            role_name: 'user',
+            username: 'am1',
+            role_name: 'assignment_manager',
             status: 'active',
           },
-          body: {
-            email: 'new@test.com',
-            firstName: undefined,
-            lastName: undefined,
-            studentId: undefined,
-            role: 'admin',
-            groupId: '10000000-0000-4000-8000-000000000005',
-            enabled: false,
-          },
+          body: { email: 'me@test.com' },
         },
         mockReply
       );
 
-      // role and groupId must be excluded; enabled must be included with status sync
-      expect(User.update).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', {
-        email: 'new@test.com',
-        firstName: undefined,
-        lastName: undefined,
-        studentId: undefined,
-        enabled: false,
-        status: 'inactive',
-      });
+      expect(Subject.findForUser).not.toHaveBeenCalled();
+      expect(User.update).toHaveBeenCalledWith(
+        '00000000-0000-4000-8000-000000000001',
+        expect.objectContaining({ email: 'me@test.com' })
+      );
+    });
+
+    it('assignment_manager cannot set enabled — explicit 403 (admins only)', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Subject.findForUser.mockResolvedValue([{ id: SUBJECT_ID, name: 'Subject A', membership_enabled: true }]);
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id_put'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'assignment_manager' },
+          params: { id: '00000000-0000-4000-8000-000000000002' },
+          targetUser: {
+            id: '00000000-0000-4000-8000-000000000002',
+            username: 'oldname',
+            role_name: 'user',
+            status: 'active',
+          },
+          body: { email: 'new@test.com', enabled: false },
+        },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Only admins can enable or disable accounts' });
+      expect(User.update).not.toHaveBeenCalled();
     });
 
     it('regular user self-edit can update studentId', async () => {
@@ -1818,7 +1936,7 @@ describe('Users Routes', () => {
       expect(mockReply.code).not.toHaveBeenCalledWith(expect.stringMatching(/^4/));
     });
 
-    it('regular user self-edit cannot update role or enabled', async () => {
+    it('regular user self-edit cannot update role', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.update.mockResolvedValue({
@@ -1844,17 +1962,44 @@ describe('Users Routes', () => {
           body: {
             email: 'test@test.com',
             role: 'admin',
-            enabled: false,
           },
         },
         mockReply
       );
 
-      // role and enabled must not be passed through for a regular user caller
+      // role must not be passed through for a regular user caller
       expect(User.update).toHaveBeenCalledWith(
         '00000000-0000-4000-8000-000000000001',
         expect.not.objectContaining({ roleId: expect.anything(), enabled: expect.anything() })
       );
+    });
+
+    it('regular user self-edit with enabled in the body gets an explicit 403', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id_put'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'user' },
+          params: { id: '00000000-0000-4000-8000-000000000001' },
+          targetUser: {
+            id: '00000000-0000-4000-8000-000000000001',
+            username: 'testuser',
+            role_name: 'user',
+            status: 'active',
+          },
+          body: { email: 'test@test.com', enabled: false },
+        },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Only admins can enable or disable accounts' });
+      expect(User.update).not.toHaveBeenCalled();
     });
 
     it('handles error when updating user', async () => {
@@ -3887,6 +4032,118 @@ describe('Users Routes', () => {
       await handlers['/users/send-setup-emails_post']({ user: { id: 'admin1', role: 'admin' }, body: {} }, mockReply);
 
       expect(mockReply.code).toHaveBeenCalledWith(500);
+    });
+
+    it('AM can send to explicit targets when every target is enrolled in a managed subject', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const amId = '22222222-0000-4000-8000-000000000001';
+      const uid1 = '11111111-0000-4000-8000-000000000001';
+      Assignment.findManagedBy.mockResolvedValue([{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }]);
+      User.findByIds.mockResolvedValue([{ id: uid1, username: 'pending1', status: 'pending' }]);
+      Subject.findForUsers.mockResolvedValue([
+        { user_id: uid1, id: SUBJECT_ID, name: 'Subject A', membership_enabled: false },
+      ]);
+      PasswordResetToken.deleteStaleForUser.mockResolvedValue();
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok123' });
+      sendPasswordSetupEmail.mockResolvedValue();
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/send-setup-emails_post'](
+        { user: { id: amId, role: 'assignment_manager' }, body: { userIds: [uid1] } },
+        mockReply
+      );
+
+      expect(Assignment.findManagedBy).toHaveBeenCalledWith(amId);
+      expect(Subject.findForUsers).toHaveBeenCalledWith([uid1]);
+      expect(sendPasswordSetupEmail).toHaveBeenCalledTimes(1);
+      expect(mockReply.send).toHaveBeenCalledWith({ sent: 1, errors: [] });
+    });
+
+    it('AM with any out-of-scope explicit target gets 403 before any email is sent', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const amId = '22222222-0000-4000-8000-000000000001';
+      const uid1 = '11111111-0000-4000-8000-000000000001';
+      const uid2 = '11111111-0000-4000-8000-000000000002';
+      Assignment.findManagedBy.mockResolvedValue([{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }]);
+      User.findByIds.mockResolvedValue([
+        { id: uid1, username: 'pending1', status: 'pending' },
+        { id: uid2, username: 'outofscope', status: 'pending' },
+      ]);
+      Subject.findForUsers.mockResolvedValue([
+        { user_id: uid1, id: SUBJECT_ID, name: 'Subject A', membership_enabled: true },
+        { user_id: uid2, id: SUBJECT_ID_2, name: 'Subject B', membership_enabled: true },
+      ]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/send-setup-emails_post'](
+        { user: { id: amId, role: 'assignment_manager' }, body: { userIds: [uid1, uid2] } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Forbidden: user is not in a subject you manage' });
+      expect(sendPasswordSetupEmail).not.toHaveBeenCalled();
+    });
+
+    it('AM all-pending mode only sends to pending users of managed subjects', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const amId = '22222222-0000-4000-8000-000000000001';
+      const uid1 = '11111111-0000-4000-8000-000000000001';
+      const uid2 = '11111111-0000-4000-8000-000000000002';
+      Assignment.findManagedBy.mockResolvedValue([{ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID }]);
+      User.findAll.mockResolvedValue([
+        { id: uid1, username: 'managedpending', status: 'pending' },
+        { id: uid2, username: 'unmanagedpending', status: 'pending' },
+      ]);
+      Subject.findForUsers.mockResolvedValue([
+        { user_id: uid1, id: SUBJECT_ID, name: 'Subject A', membership_enabled: true },
+        { user_id: uid2, id: SUBJECT_ID_2, name: 'Subject B', membership_enabled: true },
+      ]);
+      PasswordResetToken.deleteStaleForUser.mockResolvedValue();
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok123' });
+      sendPasswordSetupEmail.mockResolvedValue();
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/send-setup-emails_post'](
+        { user: { id: amId, role: 'assignment_manager' }, body: {} },
+        mockReply
+      );
+
+      expect(User.findAll).toHaveBeenCalledWith({ status: 'pending' });
+      expect(sendPasswordSetupEmail).toHaveBeenCalledTimes(1);
+      expect(sendPasswordSetupEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ username: 'managedpending' }),
+        'tok123'
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ sent: 1, errors: [] });
+    });
+
+    it('admin all-pending mode is unscoped and never queries managed assignments', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const pendingUsers = [{ id: 'u1', username: 'pending1', status: 'pending' }];
+      User.findAll.mockResolvedValue(pendingUsers);
+      PasswordResetToken.deleteStaleForUser.mockResolvedValue();
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok123' });
+      sendPasswordSetupEmail.mockResolvedValue();
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/send-setup-emails_post']({ user: { id: 'admin1', role: 'admin' }, body: {} }, mockReply);
+
+      expect(Assignment.findManagedBy).not.toHaveBeenCalled();
+      expect(Subject.findForUsers).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ sent: 1, errors: [] });
     });
   });
 

--- a/backend/tests/unit/users.test.js
+++ b/backend/tests/unit/users.test.js
@@ -2,6 +2,9 @@
 jest.mock('../../src/models/User');
 jest.mock('../../src/models/Group');
 jest.mock('../../src/models/Role');
+jest.mock('../../src/models/Subject');
+jest.mock('../../src/models/Assignment');
+jest.mock('../../src/models/UserGroup');
 jest.mock('../../src/models/PasswordResetToken', () => ({
   create: jest.fn(),
   findByToken: jest.fn(),
@@ -27,10 +30,19 @@ jest.mock('../../src/utils/logger', () => ({
 const User = require('../../src/models/User');
 const Group = require('../../src/models/Group');
 const Role = require('../../src/models/Role');
+const Subject = require('../../src/models/Subject');
+const Assignment = require('../../src/models/Assignment');
+const UserGroup = require('../../src/models/UserGroup');
 const PasswordResetToken = require('../../src/models/PasswordResetToken');
 const { sendPasswordResetEmail, sendPasswordSetupEmail } = require('../../src/services/email');
 
 describe('Users Routes', () => {
+  const SUBJECT_ID = '30000000-0000-4000-8000-000000000001';
+  const SUBJECT_ID_2 = '30000000-0000-4000-8000-000000000002';
+  const ASSIGNMENT_ID = '40000000-0000-4000-8000-000000000001';
+  const ASSIGNMENT_ID_2 = '40000000-0000-4000-8000-000000000002';
+  const GROUP_ID = '10000000-0000-4000-8000-000000000001';
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -42,6 +54,8 @@ describe('Users Routes', () => {
     delete: jest.fn(),
     checkRole: jest.fn().mockResolvedValue(options.checkRoleResult ?? true),
     requireAdmin: jest.fn().mockResolvedValue(options.requireAdminResult ?? true),
+    requireAssignmentManager: jest.fn().mockResolvedValue(options.requireAssignmentManagerResult ?? true),
+    assertManagesAssignment: jest.fn().mockResolvedValue(options.assertManagesAssignmentResult ?? true),
   });
 
   const captureHandlers = (mockFastify) => {
@@ -89,20 +103,182 @@ describe('Users Routes', () => {
       ]);
     });
 
-    it('returns all users successfully', async () => {
+    it('returns all users enriched with subjects and memberships (batch queries)', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findAll.mockResolvedValue([
         { id: '00000000-0000-4000-8000-000000000001', username: 'user1', email: 'user1@test.com' },
+        { id: '00000000-0000-4000-8000-000000000002', username: 'user2', email: 'user2@test.com' },
+      ]);
+      Subject.findForUsers.mockResolvedValue([
+        { user_id: '00000000-0000-4000-8000-000000000001', id: SUBJECT_ID, name: 'Subject A' },
+      ]);
+      UserGroup.findMembershipsForUsers.mockResolvedValue([
+        {
+          user_id: '00000000-0000-4000-8000-000000000001',
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'A1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'Subject A',
+          group_id: GROUP_ID,
+          group_name: 'Team Alpha',
+        },
       ]);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
-      await handlers['/users_get']({}, mockReply);
+      await handlers['/users_get']({ user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' } }, mockReply);
       expect(User.findAll).toHaveBeenCalled();
+      expect(Subject.findForUsers).toHaveBeenCalledWith([
+        '00000000-0000-4000-8000-000000000001',
+        '00000000-0000-4000-8000-000000000002',
+      ]);
+      expect(UserGroup.findMembershipsForUsers).toHaveBeenCalledWith([
+        '00000000-0000-4000-8000-000000000001',
+        '00000000-0000-4000-8000-000000000002',
+      ]);
       expect(mockReply.send).toHaveBeenCalledWith({
-        users: [{ id: '00000000-0000-4000-8000-000000000001', username: 'user1', email: 'user1@test.com' }],
+        users: [
+          {
+            id: '00000000-0000-4000-8000-000000000001',
+            username: 'user1',
+            email: 'user1@test.com',
+            subjects: [{ id: SUBJECT_ID, name: 'Subject A' }],
+            memberships: [
+              {
+                assignment_id: ASSIGNMENT_ID,
+                assignment_name: 'A1',
+                subject_id: SUBJECT_ID,
+                subject_name: 'Subject A',
+                group_id: GROUP_ID,
+                group_name: 'Team Alpha',
+              },
+            ],
+          },
+          {
+            id: '00000000-0000-4000-8000-000000000002',
+            username: 'user2',
+            email: 'user2@test.com',
+            subjects: [],
+            memberships: [],
+          },
+        ],
       });
+    });
+
+    it('passes subjectId, assignmentId and groupId filters through to User.findAll', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      User.findAll.mockResolvedValue([]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' },
+          query: { subjectId: SUBJECT_ID, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID },
+        },
+        mockReply
+      );
+      expect(User.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ subjectId: SUBJECT_ID, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID })
+      );
+    });
+
+    it('rejects invalid subjectId filter', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' }, query: { subjectId: 'not-a-uuid' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid subjectId filter' });
+      expect(User.findAll).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid assignmentId filter', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' }, query: { assignmentId: 'nope' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid assignmentId filter' });
+      expect(User.findAll).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when groupId is 'none' without assignmentId", async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' }, query: { groupId: 'none' } },
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'assignmentId is required when filtering ungrouped users' });
+      expect(User.findAll).not.toHaveBeenCalled();
+    });
+
+    it("allows groupId 'none' when assignmentId is provided", async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      User.findAll.mockResolvedValue([]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' },
+          query: { groupId: 'none', assignmentId: ASSIGNMENT_ID },
+        },
+        mockReply
+      );
+      expect(User.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: 'none', assignmentId: ASSIGNMENT_ID })
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ users: [] });
+    });
+
+    it('scopes results with managedBy for assignment_manager callers', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      User.findAll.mockResolvedValue([]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        { user: { id: '00000000-0000-4000-8000-000000000042', role: 'assignment_manager' }, query: {} },
+        mockReply
+      );
+      expect(User.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ managedBy: '00000000-0000-4000-8000-000000000042' })
+      );
+    });
+
+    it('does not set managedBy for admin callers', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      User.findAll.mockResolvedValue([]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_get'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'admin' }, query: {} },
+        mockReply
+      );
+      const filters = User.findAll.mock.calls[0][0];
+      expect(filters.managedBy).toBeUndefined();
     });
 
     it('rejects invalid status filter', async () => {
@@ -170,7 +346,7 @@ describe('Users Routes', () => {
       expect(mockFastify.checkRole).toHaveBeenCalledWith(request, mockReply, ['admin', 'assignment_manager']);
     });
 
-    it('returns user by id', async () => {
+    it('returns user by id enriched with subjects and memberships', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       User.findById.mockResolvedValue({
@@ -179,13 +355,34 @@ describe('Users Routes', () => {
         email: 'test@test.com',
         password_hash: 'hash',
       });
+      const subjects = [{ id: SUBJECT_ID, name: 'Subject 1' }];
+      const memberships = [
+        {
+          assignment_id: ASSIGNMENT_ID,
+          assignment_name: 'Assignment 1',
+          subject_id: SUBJECT_ID,
+          subject_name: 'Subject 1',
+          group_id: GROUP_ID,
+          group_name: 'Group 1',
+        },
+      ];
+      Subject.findForUser.mockResolvedValue(subjects);
+      UserGroup.findMembershipsForUser.mockResolvedValue(memberships);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id_get']({ params: { id: '00000000-0000-4000-8000-000000000001' } }, mockReply);
       expect(User.findById).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
+      expect(Subject.findForUser).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
+      expect(UserGroup.findMembershipsForUser).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001');
       expect(mockReply.send).toHaveBeenCalledWith({
-        user: { id: '00000000-0000-4000-8000-000000000001', username: 'testuser', email: 'test@test.com' },
+        user: {
+          id: '00000000-0000-4000-8000-000000000001',
+          username: 'testuser',
+          email: 'test@test.com',
+          subjects,
+          memberships,
+        },
       });
     });
 
@@ -256,6 +453,16 @@ describe('Users Routes', () => {
   });
 
   describe('POST /users', () => {
+    beforeEach(() => {
+      User.findByUsername.mockResolvedValue(null);
+      User.findByEmail.mockResolvedValue(null);
+      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000003', name: 'user' });
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'Subject 1' });
+      Subject.addUsers.mockResolvedValue(1);
+      UserGroup.assignUserToGroup.mockResolvedValue();
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+    });
+
     it('rejects unauthenticated request in preHandler', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
@@ -295,6 +502,7 @@ describe('Users Routes', () => {
       email: 'new@test.com',
       firstName: 'Test',
       lastName: 'User',
+      subjectIds: ['30000000-0000-4000-8000-000000000001'],
     };
 
     it('rejects when firstName is missing', async () => {
@@ -414,9 +622,10 @@ describe('Users Routes', () => {
         firstName: 'Test',
         lastName: 'User',
         studentId: 'S123',
-        groupId: undefined,
         roleId: '20000000-0000-4000-8000-000000000003',
       });
+      // Enrols the new user in every selected subject
+      expect(Subject.addUsers).toHaveBeenCalledWith(SUBJECT_ID, ['00000000-0000-4000-8000-000000000001']);
       // Always sends setup email
       expect(PasswordResetToken.create).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', 'setup', 24);
       expect(sendPasswordSetupEmail).toHaveBeenCalled();
@@ -633,45 +842,196 @@ describe('Users Routes', () => {
       expect(User.create).not.toHaveBeenCalled();
     });
 
-    it('rejects creating user in a full group', async () => {
+    it('rejects role user without subjectIds', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000003', name: 'user' });
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Full Group',
-        max_members: 2,
-        member_count: 2,
-      });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
 
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      const { subjectIds: _subjectIds, ...bodyWithoutSubjects } = validCreateBody;
+      await handlers['/users_post']({ user: { role: 'admin' }, body: bodyWithoutSubjects }, mockReply);
+
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject is required' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects role user with empty subjectIds array', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users_post'](
-        { body: { ...validCreateBody, groupId: '10000000-0000-4000-8000-000000000001' } },
+        { user: { role: 'admin' }, body: { ...validCreateBody, subjectIds: [] } },
         mockReply
       );
 
       expect(mockReply.code).toHaveBeenCalledWith(400);
-      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group is full' });
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject is required' });
       expect(User.create).not.toHaveBeenCalled();
     });
 
-    it('allows creating user in a group with capacity', async () => {
+    it('returns 404 when a subject does not exist', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.findByUsername.mockResolvedValue(null);
-      User.findByEmail.mockResolvedValue(null);
-      Group.findById.mockResolvedValue({
-        id: '10000000-0000-4000-8000-000000000001',
-        name: 'Group',
-        max_members: 5,
-        member_count: 4,
+      Subject.findById.mockResolvedValue(null);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post']({ user: { role: 'admin' }, body: validCreateBody }, mockReply);
+
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when an assignment manager creates a user in a subject they do not manage', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'assignment_manager' }, body: validCreateBody },
+        mockReply
+      );
+
+      expect(Assignment.managesAnyInSubject).toHaveBeenCalledWith(
+        '00000000-0000-4000-8000-000000000099',
+        validCreateBody.subjectIds[0]
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        error: 'Forbidden: You do not manage any assignment in this subject',
       });
-      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000003', name: 'user' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('allows an assignment manager to create a user in a subject they manage', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+      User.create.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000001',
+        username: 'newuser',
+        email: 'new@test.com',
+      });
+      PasswordResetToken.create.mockResolvedValue({ token: 'setup-token' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { id: '00000000-0000-4000-8000-000000000099', role: 'assignment_manager' }, body: validCreateBody },
+        mockReply
+      );
+
+      expect(User.create).toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 400 when groupId is provided without assignmentId', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'assignmentId is required when groupId is provided' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the placement assignment does not exist', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue(null);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the assignment does not belong to the selected subjects', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID_2 });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Assignment does not belong to the selected subjects' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the placement group does not exist', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Group.findById.mockResolvedValue(null);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the group does not belong to the selected assignment', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Group.findById.mockResolvedValue({ id: GROUP_ID, assignment_id: ASSIGNMENT_ID_2 });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group does not belong to the selected assignment' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('creates user and places them in the requested group', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Group.findById.mockResolvedValue({ id: GROUP_ID, assignment_id: ASSIGNMENT_ID });
       User.create.mockResolvedValue({
         id: '00000000-0000-4000-8000-000000000001',
         username: 'newuser',
@@ -679,18 +1039,157 @@ describe('Users Routes', () => {
         student_id: null,
       });
       PasswordResetToken.create.mockResolvedValue({ token: 'tok' });
-
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users_post'](
-        { body: { ...validCreateBody, groupId: '10000000-0000-4000-8000-000000000001' } },
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
+        mockReply
+      );
+
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', GROUP_ID, {
+        replace: true,
+      });
+      expect(mockReply.code).toHaveBeenCalledWith(201);
+      expect(mockReply.send).toHaveBeenCalledWith(expect.not.objectContaining({ warning: expect.anything() }));
+    });
+
+    it('returns 201 with a warning when group placement fails', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Group.findById.mockResolvedValue({ id: GROUP_ID, assignment_id: ASSIGNMENT_ID });
+      User.create.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000001',
+        username: 'newuser',
+        email: 'new@test.com',
+        student_id: null,
+      });
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok' });
+      const fullErr = new Error('Group is full');
+      fullErr.statusCode = 409;
+      UserGroup.assignUserToGroup.mockRejectedValue(fullErr);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        { user: { role: 'admin' }, body: { ...validCreateBody, assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
         mockReply
       );
 
       expect(mockReply.code).toHaveBeenCalledWith(201);
-      expect(User.create).toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'User created successfully',
+          warning: 'User created but group placement failed: Group is full',
+        })
+      );
+    });
+
+    it('creates assignment manager with assignmentIds and calls Assignment.addManagers', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000002', name: 'assignment_manager' });
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID });
+      Assignment.addManagers.mockResolvedValue(1);
+      User.create.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000005',
+        username: 'newam',
+        email: 'am@test.com',
+        student_id: null,
+      });
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
+          body: {
+            username: 'newam',
+            email: 'am@test.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'assignment_manager',
+            assignmentIds: [ASSIGNMENT_ID],
+          },
+        },
+        mockReply
+      );
+
+      expect(Assignment.findById).toHaveBeenCalledWith(ASSIGNMENT_ID);
+      expect(Assignment.addManagers).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000005', [ASSIGNMENT_ID]);
+      expect(Subject.addUsers).not.toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 404 when an assignment manager assignmentId does not exist', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000002', name: 'assignment_manager' });
+      Assignment.findById.mockResolvedValue(null);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
+          body: {
+            username: 'newam',
+            email: 'am@test.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'assignment_manager',
+            assignmentIds: [ASSIGNMENT_ID],
+          },
+        },
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('ignores subjectIds and placement fields for assignment_manager role', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: '20000000-0000-4000-8000-000000000002', name: 'assignment_manager' });
+      User.create.mockResolvedValue({
+        id: '00000000-0000-4000-8000-000000000005',
+        username: 'newam',
+        email: 'am@test.com',
+        student_id: null,
+      });
+      PasswordResetToken.create.mockResolvedValue({ token: 'tok' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users_post'](
+        {
+          user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
+          body: {
+            username: 'newam',
+            email: 'am@test.com',
+            firstName: 'Test',
+            lastName: 'User',
+            role: 'assignment_manager',
+            subjectIds: [SUBJECT_ID],
+            assignmentId: ASSIGNMENT_ID,
+            groupId: GROUP_ID,
+          },
+        },
+        mockReply
+      );
+
+      expect(Subject.addUsers).not.toHaveBeenCalled();
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+      expect(mockReply.code).toHaveBeenCalledWith(201);
     });
 
     it('handles error when creating user', async () => {
@@ -735,6 +1234,7 @@ describe('Users Routes', () => {
             firstName: 'Test',
             lastName: 'User',
             studentId: 'S12345',
+            subjectIds: [SUBJECT_ID],
           },
         },
         mockReply
@@ -765,6 +1265,7 @@ describe('Users Routes', () => {
             password: 'password123',
             firstName: 'Test',
             lastName: 'User',
+            subjectIds: [SUBJECT_ID],
           },
         },
         mockReply
@@ -787,33 +1288,46 @@ describe('Users Routes', () => {
       expect(mockReply.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
     });
 
-    it('returns reply when role check fails in preHandler', async () => {
-      const mockFastify = createMockFastify({ checkRoleResult: false });
-      const handlers = captureHandlers(mockFastify);
-      const usersRoutes = require('../../src/routes/users');
-      usersRoutes(mockFastify, {});
-      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
-      const request = {
-        user: { id: '00000000-0000-4000-8000-000000000002', role: 'user' },
-        params: { id: '00000000-0000-4000-8000-000000000001' },
-      };
-      const result = await handlers['/users/:id/group_put_pre'](request, mockReply);
-      expect(mockFastify.checkRole).toHaveBeenCalledWith(request, mockReply, ['admin', 'assignment_manager']);
-      expect(result).toBe(mockReply);
+    const TARGET_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+    const makeGroupRequest = (body) => ({
+      user: { id: '00000000-0000-4000-8000-000000000009', role: 'assignment_manager' },
+      params: { id: TARGET_USER_ID },
+      body,
     });
 
-    it('returns 400 when groupId is missing', async () => {
+    const setupGroupMocks = () => {
+      User.findById.mockResolvedValue({ id: TARGET_USER_ID, username: 'test' });
+      Assignment.findById.mockResolvedValue({ id: ASSIGNMENT_ID, subject_id: SUBJECT_ID, name: 'Assignment 1' });
+      Group.findById.mockResolvedValue({ id: GROUP_ID, assignment_id: ASSIGNMENT_ID, name: 'Group 1' });
+      UserGroup.assignUserToGroup.mockResolvedValue();
+      UserGroup.remove.mockResolvedValue({ user_id: TARGET_USER_ID, assignment_id: ASSIGNMENT_ID });
+    };
+
+    it('returns 400 for invalid UUID in :id param', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        { params: { id: '00000000-0000-4000-8000-000000000001' }, body: {} },
+        { params: { id: 'not-a-uuid' }, body: { assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID } },
         mockReply
       );
       expect(mockReply.code).toHaveBeenCalledWith(400);
-      expect(mockReply.send).toHaveBeenCalledWith({ error: 'groupId is required' });
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid ID format' });
+    });
+
+    it('returns 400 when assignmentId is missing from the body', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id/group_put'](makeGroupRequest({ groupId: GROUP_ID }), mockReply);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: expect.any(String) });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
     it('returns 400 when groupId is a non-null non-UUID string', async () => {
@@ -823,19 +1337,18 @@ describe('Users Routes', () => {
       usersRoutes(mockFastify, {});
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: 'not-a-uuid' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: 'not-a-uuid' }),
         mockReply
       );
       expect(mockReply.code).toHaveBeenCalledWith(400);
-      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid groupId format' });
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Invalid group ID' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
-    it('returns 404 when user not found', async () => {
+    it('returns 404 when target user not found', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
       User.findById.mockResolvedValue(null);
 
       const usersRoutes = require('../../src/routes/users');
@@ -843,165 +1356,178 @@ describe('Users Routes', () => {
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000999' },
-          body: { groupId: '10000000-0000-4000-8000-000000000001' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
       expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User not found' });
     });
 
-    it('returns 404 when group not found (via assignUserToGroup)', async () => {
+    it('returns reply when requireAssignmentManager fails', async () => {
+      const mockFastify = createMockFastify({ requireAssignmentManagerResult: false });
+      const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      const request = makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID });
+      const result = await handlers['/users/:id/group_put'](request, mockReply);
+
+      expect(mockFastify.requireAssignmentManager).toHaveBeenCalledWith(request, mockReply);
+      expect(result).toBe(mockReply);
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('returns reply when assertManagesAssignment fails', async () => {
+      const mockFastify = createMockFastify({ assertManagesAssignmentResult: false });
+      const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      const request = makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID });
+      const result = await handlers['/users/:id/group_put'](request, mockReply);
+
+      expect(mockFastify.assertManagesAssignment).toHaveBeenCalledWith(request, mockReply, ASSIGNMENT_ID);
+      expect(result).toBe(mockReply);
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when assignment not found', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-      });
-      const notFoundErr = new Error('Group not found');
-      notFoundErr.statusCode = 404;
-      Group.assignUserToGroup.mockRejectedValue(notFoundErr);
+      setupGroupMocks();
+      Assignment.findById.mockResolvedValue(null);
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000999' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
-      expect(Group.assignUserToGroup).toHaveBeenCalledWith(
-        '00000000-0000-4000-8000-000000000001',
-        '10000000-0000-4000-8000-000000000999'
-      );
       expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Assignment not found' });
     });
 
-    it('updates user group successfully', async () => {
+    it('removes user from group when groupId is null', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      Group.assignUserToGroup.mockResolvedValue();
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-        group_id: '10000000-0000-4000-8000-000000000002',
-      });
+      setupGroupMocks();
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: null }),
         mockReply
       );
 
-      expect(Group.assignUserToGroup).toHaveBeenCalledWith(
-        '00000000-0000-4000-8000-000000000001',
-        '10000000-0000-4000-8000-000000000002'
-      );
-      expect(mockReply.send).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'User group updated successfully' })
-      );
+      expect(UserGroup.remove).toHaveBeenCalledWith(TARGET_USER_ID, ASSIGNMENT_ID);
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'User removed from group',
+        user: { id: TARGET_USER_ID, username: 'test', assignmentId: ASSIGNMENT_ID, groupId: null },
+      });
     });
 
-    it('sets user group to null', async () => {
+    it('returns 404 when group not found', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.updateGroup.mockResolvedValue();
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-        group_id: null,
-      });
+      setupGroupMocks();
+      Group.findById.mockResolvedValue(null);
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: null },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
-      expect(User.updateGroup).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000001', null);
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
-    it('rejects assigning user to a full group (via assignUserToGroup)', async () => {
+    it('returns 400 when group belongs to a different assignment', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-      });
-      const fullErr = new Error('Group is full');
-      fullErr.statusCode = 409;
-      Group.assignUserToGroup.mockRejectedValue(fullErr);
+      setupGroupMocks();
+      Group.findById.mockResolvedValue({ id: GROUP_ID, assignment_id: ASSIGNMENT_ID_2, name: 'Other Group' });
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
-      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group does not belong to the selected assignment' });
+      expect(UserGroup.assignUserToGroup).not.toHaveBeenCalled();
     });
 
-    it('allows assigning user to group with unlimited capacity', async () => {
+    it('assigns user to group successfully with replace semantics', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      Group.assignUserToGroup.mockResolvedValue();
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-        group_id: '10000000-0000-4000-8000-000000000002',
-      });
+      setupGroupMocks();
 
       const usersRoutes = require('../../src/routes/users');
       usersRoutes(mockFastify, {});
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
-      expect(Group.assignUserToGroup).toHaveBeenCalled();
-      expect(mockReply.send).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'User group updated successfully' })
-      );
+      expect(UserGroup.assignUserToGroup).toHaveBeenCalledWith(TARGET_USER_ID, GROUP_ID, { replace: true });
+      expect(mockReply.send).toHaveBeenCalledWith({
+        message: 'User group updated successfully',
+        user: { id: TARGET_USER_ID, username: 'test', assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID },
+      });
     });
 
-    it('handles error when updating group', async () => {
+    it('maps 403 subject-membership error from assignUserToGroup', async () => {
       const mockFastify = createMockFastify();
       const handlers = captureHandlers(mockFastify);
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-      });
-      Group.assignUserToGroup.mockRejectedValue(new Error('Database error'));
+      setupGroupMocks();
+      const err = new Error('User is not a member of this subject');
+      err.statusCode = 403;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id/group_put'](
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'User is not a member of this subject' });
+    });
+
+    it('maps 409 group-full error from assignUserToGroup', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
+      const err = new Error('Group is full');
+      err.statusCode = 409;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
       const { logger: mockLogger } = require('../../src/utils/logger');
 
       const usersRoutes = require('../../src/routes/users');
@@ -1009,15 +1535,55 @@ describe('Users Routes', () => {
 
       const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
       await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group is full' });
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('maps 404 error from assignUserToGroup', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
+      const err = new Error('Group not found');
+      err.statusCode = 404;
+      UserGroup.assignUserToGroup.mockRejectedValue(err);
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id/group_put'](
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
+        mockReply
+      );
+
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group not found' });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      setupGroupMocks();
+      UserGroup.assignUserToGroup.mockRejectedValue(new Error('Database error'));
+      const { logger: mockLogger } = require('../../src/utils/logger');
+
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/:id/group_put'](
+        makeGroupRequest({ assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }),
         mockReply
       );
 
       expect(mockLogger.error).toHaveBeenCalled();
       expect(mockReply.code).toHaveBeenCalledWith(500);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Failed to update user group' });
     });
   });
 
@@ -1160,7 +1726,6 @@ describe('Users Routes', () => {
         firstName: undefined,
         lastName: undefined,
         studentId: undefined,
-        groupId: undefined,
         roleId: 'a0000000-0000-0000-0000-000000000001',
         enabled: false,
         status: 'inactive',
@@ -1868,63 +2433,6 @@ describe('Users Routes', () => {
     });
   });
 
-  describe('PUT /users/:id/group - error handling', () => {
-    it('handles error when assigning user to group', async () => {
-      const mockFastify = createMockFastify();
-      const handlers = captureHandlers(mockFastify);
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-      });
-      Group.assignUserToGroup.mockRejectedValue(new Error('Database error'));
-      const { logger: mockLogger } = require('../../src/utils/logger');
-
-      const usersRoutes = require('../../src/routes/users');
-      usersRoutes(mockFastify, {});
-
-      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
-      await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
-        mockReply
-      );
-
-      expect(mockLogger.error).toHaveBeenCalled();
-      expect(mockReply.code).toHaveBeenCalledWith(500);
-    });
-
-    it('propagates a sub-500 statusCode error (e.g. 409 Group is full)', async () => {
-      const mockFastify = createMockFastify();
-      const handlers = captureHandlers(mockFastify);
-      User.findById.mockResolvedValue({
-        id: '00000000-0000-4000-8000-000000000001',
-        username: 'test',
-      });
-      const fullErr = new Error('Group is full');
-      fullErr.statusCode = 409;
-      Group.assignUserToGroup.mockRejectedValue(fullErr);
-      const { logger: mockLogger } = require('../../src/utils/logger');
-
-      const usersRoutes = require('../../src/routes/users');
-      usersRoutes(mockFastify, {});
-
-      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
-      await handlers['/users/:id/group_put'](
-        {
-          params: { id: '00000000-0000-4000-8000-000000000001' },
-          body: { groupId: '10000000-0000-4000-8000-000000000002' },
-        },
-        mockReply
-      );
-
-      expect(mockReply.code).toHaveBeenCalledWith(409);
-      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Group is full' });
-      expect(mockLogger.error).not.toHaveBeenCalled();
-    });
-  });
-
   describe('PUT /users/:id - error handling', () => {
     it('handles database error when fetching user in preHandler', async () => {
       const mockFastify = createMockFastify();
@@ -2279,15 +2787,190 @@ describe('Users Routes', () => {
   });
 
   describe('POST /users/import', () => {
-    const makeImportRequest = (body) => ({
-      user: { id: '00000000-0000-4000-8000-000000000001', role: 'admin' },
-      body,
+    const makeImportRequest = (body, user = { id: '00000000-0000-4000-8000-000000000001', role: 'admin' }) => ({
+      user,
+      body: { subjectId: SUBJECT_ID, ...body },
     });
 
     beforeEach(() => {
       User.findByUsernames.mockResolvedValue([]);
       User.findByEmails.mockResolvedValue([]);
       User.findByStudentIds.mockResolvedValue([]);
+      Subject.findById.mockResolvedValue({ id: SUBJECT_ID, name: 'Subject 1' });
+      Subject.addUsers.mockResolvedValue(0);
+      Assignment.managesAnyInSubject.mockResolvedValue(true);
+    });
+
+    it('returns 400 when subjectId is missing', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          subjectId: undefined,
+          users: [{ username: 'u', email: 'e@e.com', firstName: 'F', lastName: 'L' }],
+        }),
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject is required' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when subjectId is not a valid UUID', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          subjectId: 'not-a-uuid',
+          users: [{ username: 'u', email: 'e@e.com', firstName: 'F', lastName: 'L' }],
+        }),
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(400);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject is required' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the subject does not exist', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Subject.findById.mockResolvedValue(null);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/import_post'](
+        makeImportRequest({ users: [{ username: 'u', email: 'e@e.com', firstName: 'F', lastName: 'L' }] }),
+        mockReply
+      );
+      expect(mockReply.code).toHaveBeenCalledWith(404);
+      expect(mockReply.send).toHaveBeenCalledWith({ error: 'Subject not found' });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when assignment manager does not manage any assignment in the subject', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Assignment.managesAnyInSubject.mockResolvedValue(false);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      const amUser = { id: '00000000-0000-4000-8000-000000000042', role: 'assignment_manager' };
+      await handlers['/users/import_post'](
+        makeImportRequest({ users: [{ username: 'u', email: 'e@e.com', firstName: 'F', lastName: 'L' }] }, amUser),
+        mockReply
+      );
+      expect(Assignment.managesAnyInSubject).toHaveBeenCalledWith('00000000-0000-4000-8000-000000000042', SUBJECT_ID);
+      expect(mockReply.code).toHaveBeenCalledWith(403);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        error: 'Forbidden: You do not manage any assignment in this subject',
+      });
+      expect(User.create).not.toHaveBeenCalled();
+    });
+
+    it('allows assignment manager who manages an assignment in the subject', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.create.mockResolvedValue({ id: 'u2', username: 'newuser', email: 'new@test.com' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      const amUser = { id: '00000000-0000-4000-8000-000000000042', role: 'assignment_manager' };
+      await handlers['/users/import_post'](
+        makeImportRequest(
+          { users: [{ username: 'newuser', email: 'new@test.com', firstName: 'New', lastName: 'User' }] },
+          amUser
+        ),
+        mockReply
+      );
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: 0, errors: [] });
+    });
+
+    it('does not check subject management for admin callers', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.create.mockResolvedValue({ id: 'u2', username: 'newuser', email: 'new@test.com' });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [{ username: 'newuser', email: 'new@test.com', firstName: 'New', lastName: 'User' }],
+        }),
+        mockReply
+      );
+      expect(Assignment.managesAnyInSubject).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: 0, errors: [] });
+    });
+
+    it('enrols created and overwritten users in the subject with a single addUsers call', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      const existingUser = {
+        id: 'u-existing',
+        username: 'existing',
+        email: 'ex@test.com',
+        student_id: null,
+        role_name: 'user',
+      };
+      User.findByUsernames.mockResolvedValue([existingUser]);
+      User.create.mockResolvedValue({ id: 'u-new', username: 'newuser', email: 'new@test.com' });
+      User.update.mockResolvedValue({ ...existingUser });
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [
+            { username: 'newuser', email: 'new@test.com', firstName: 'New', lastName: 'User' },
+            { username: 'existing', email: 'ex@test.com', firstName: 'Ex', lastName: 'User' },
+          ],
+          conflictAction: 'overwrite',
+        }),
+        mockReply
+      );
+
+      expect(Subject.addUsers).toHaveBeenCalledTimes(1);
+      expect(Subject.addUsers).toHaveBeenCalledWith(SUBJECT_ID, ['u-new', 'u-existing']);
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 2, skipped: 0, errors: [] });
+    });
+
+    it('does not enrol users when nothing was imported', async () => {
+      const mockFastify = createMockFastify();
+      const handlers = captureHandlers(mockFastify);
+      Role.findByName.mockResolvedValue({ id: 'r1', name: 'user' });
+      User.findByUsernames.mockResolvedValue([
+        {
+          id: 'u-existing',
+          username: 'existing',
+          email: 'ex@test.com',
+          student_id: null,
+          role_name: 'user',
+        },
+      ]);
+      const usersRoutes = require('../../src/routes/users');
+      usersRoutes(mockFastify, {});
+      const mockReply = { code: jest.fn().mockReturnThis(), send: jest.fn() };
+
+      await handlers['/users/import_post'](
+        makeImportRequest({
+          users: [{ username: 'existing', email: 'ex@test.com', firstName: 'Ex', lastName: 'User' }],
+          conflictAction: 'skip',
+        }),
+        mockReply
+      );
+
+      expect(Subject.addUsers).not.toHaveBeenCalled();
+      expect(mockReply.send).toHaveBeenCalledWith({ imported: 0, skipped: 1, errors: [] });
     });
 
     it('rejects unauthenticated request', async () => {
@@ -2357,6 +3040,7 @@ describe('Users Routes', () => {
       expect(User.create).toHaveBeenCalledWith(
         expect.objectContaining({ username: 'newuser', email: 'new@test.com', password: null })
       );
+      expect(Subject.addUsers).toHaveBeenCalledWith(SUBJECT_ID, ['00000000-0000-4000-8000-000000000002']);
       expect(mockReply.send).toHaveBeenCalledWith({ imported: 1, skipped: 0, errors: [] });
     });
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,6 +8,13 @@ Authentication uses a Bearer token in the `Authorization` header:
 Authorization: Bearer <jwt-token>
 ```
 
+JWT tokens carry identity claims only: `{ id, username, email, role }`. Hierarchy data (subjects, group memberships,
+managed assignments) is returned by `POST /api/auth/login` and `GET /api/auth/me`, not embedded in the token.
+
+The data model is a Subject → Assignment → Group hierarchy: subjects contain assignments, assignments contain groups.
+Users enrol in subjects (many-to-many) and may belong to **at most one group per assignment**. A user can only be placed
+in a group if they are a member of the group's parent subject — this applies to every caller, including admins.
+
 ---
 
 ## Legend
@@ -18,6 +25,9 @@ Authorization: Bearer <jwt-token>
 | Auth   | Any authenticated user      |
 | AM+    | Assignment Manager or Admin |
 | Admin  | Admin only                  |
+
+Assignment Manager access is **scoped**: an AM can only act on assignments they manage (via the `assignment_managers`
+mapping). Where an endpoint says "Admin or managing AM", a non-managing AM receives `403`.
 
 ---
 
@@ -121,17 +131,21 @@ Rate limit: 5 req/min (production).
   "token": "<jwt>",
   "user": {
     "id": "uuid",
-    "username": "admin",
-    "email": "admin@example.com",
-    "firstName": "Admin",
-    "lastName": "",
-    "role": "admin",
-    "groupId": null,
-    "groupName": null,
-    "studentId": null
+    "username": "jsmith",
+    "email": "jsmith@example.com",
+    "firstName": "John",
+    "lastName": "Smith",
+    "role": "user",
+    "studentId": "S12345",
+    "subjects": [{ "id": "uuid", "name": "COMP10001" }],
+    "memberships": [{ "subject_id": "uuid", "assignment_id": "uuid", "group_id": "uuid", "group_name": "Group A" }],
+    "managedAssignments": []
   }
 }
 ```
+
+`subjects` lists the subjects the user is enrolled in, `memberships` lists their per-assignment group placements, and
+`managedAssignments` lists the assignments an assignment manager manages (always `[]` for other roles).
 
 **Errors**
 
@@ -158,7 +172,8 @@ Stateless logout (client discards the token).
 
 ### `GET /api/auth/me`
 
-Returns fresh user data from the database (not stale JWT claims).
+Returns fresh user data from the database (not stale JWT claims), including subject enrolments, group memberships, and
+managed assignments.
 
 | Access | Auth |
 | ------ | ---- |
@@ -174,9 +189,10 @@ Returns fresh user data from the database (not stale JWT claims).
     "firstName": "John",
     "lastName": "Smith",
     "role": "user",
-    "groupId": "uuid",
-    "groupName": "Group A",
-    "studentId": "S12345"
+    "studentId": "S12345",
+    "subjects": [{ "id": "uuid", "name": "COMP10001" }],
+    "memberships": [{ "subject_id": "uuid", "assignment_id": "uuid", "group_id": "uuid", "group_name": "Group A" }],
+    "managedAssignments": []
   }
 }
 ```
@@ -235,34 +251,456 @@ Rate limit: 10 req/min (production).
 
 ---
 
+## Subjects
+
+### `GET /api/subjects`
+
+List subjects, scoped to the caller's role: admins see all subjects; assignment managers see subjects containing an
+assignment they manage plus subjects they are a member of; regular users see only subjects they are enrolled in.
+
+| Access | Auth |
+| ------ | ---- |
+
+**Response `200`**
+
+```json
+{ "subjects": [{ "id": "uuid", "name": "COMP10001", "created_at": "...", "updated_at": "..." }] }
+```
+
+---
+
+### `GET /api/subjects/:id`
+
+Get a subject and its assignments.
+
+| Access | Auth — admin, subject member, or an AM managing an assignment in the subject |
+| ------ | ---------------------------------------------------------------------------- |
+
+**Response `200`**
+
+```json
+{
+  "subject": { "id": "uuid", "name": "COMP10001", ... },
+  "assignments": [{ "id": "uuid", "subject_id": "uuid", "name": "Assignment 1", ... }]
+}
+```
+
+**Errors**
+
+| Code | Reason                    |
+| ---- | ------------------------- |
+| 400  | Invalid subject ID        |
+| 403  | No access to this subject |
+| 404  | Subject not found         |
+
+---
+
+### `POST /api/subjects`
+
+Create a subject.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "name": "COMP10001" }
+```
+
+**Response `201`**
+
+```json
+{ "message": "Subject created successfully", "subject": { "id": "uuid", "name": "COMP10001", ... } }
+```
+
+**Errors**
+
+| Code | Reason                                  |
+| ---- | --------------------------------------- |
+| 409  | A subject with this name already exists |
+
+---
+
+### `PUT /api/subjects/:id`
+
+Rename a subject.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "name": "COMP10002" }
+```
+
+**Response `200`**
+
+```json
+{ "message": "Subject updated successfully", "subject": { ... } }
+```
+
+**Errors**
+
+| Code | Reason                                  |
+| ---- | --------------------------------------- |
+| 404  | Subject not found                       |
+| 409  | A subject with this name already exists |
+
+---
+
+### `DELETE /api/subjects/:id`
+
+Delete a subject. **Cascades**: all of the subject's assignments, their groups, and all related group memberships and
+enrolments are deleted. User accounts are never deleted.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Response `200`**
+
+```json
+{ "message": "Subject deleted successfully" }
+```
+
+---
+
+### `GET /api/subjects/:id/users`
+
+List the members (enrolled users) of a subject.
+
+| Access | Admin, or an AM managing an assignment in the subject |
+| ------ | ----------------------------------------------------- |
+
+**Response `200`**
+
+```json
+{ "users": [{ "id": "uuid", "username": "jsmith", ... }] }
+```
+
+---
+
+### `POST /api/subjects/:id/users`
+
+Enrol users in a subject.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "userIds": ["uuid1", "uuid2"] }
+```
+
+1–2000 user IDs per request. All IDs must refer to existing users.
+
+**Response `200`**
+
+```json
+{ "message": "Users added to subject", "added": 2 }
+```
+
+**Errors**
+
+| Code | Reason                         |
+| ---- | ------------------------------ |
+| 400  | One or more users do not exist |
+| 404  | Subject not found              |
+
+---
+
+### `DELETE /api/subjects/:id/users/:userId`
+
+Remove a user from a subject. Also removes the user's group memberships within that subject (transactionally). The user
+account itself is not deleted.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Response `200`**
+
+```json
+{ "message": "User removed from subject" }
+```
+
+**Errors**
+
+| Code | Reason                                |
+| ---- | ------------------------------------- |
+| 404  | Subject not found / user not a member |
+
+---
+
+## Assignments
+
+### `GET /api/assignments`
+
+List assignments, scoped to the caller's role: admins see all; assignment managers see assignments they manage plus
+assignments in subjects they belong to; regular users see assignments of subjects they are enrolled in.
+
+| Access | Auth |
+| ------ | ---- |
+
+**Query parameters**
+
+| Param       | Values | Description              |
+| ----------- | ------ | ------------------------ |
+| `subjectId` | UUID   | Filter by parent subject |
+
+**Response `200`**
+
+```json
+{ "assignments": [{ "id": "uuid", "subject_id": "uuid", "name": "Assignment 1", ... }] }
+```
+
+---
+
+### `GET /api/assignments/:id`
+
+Get a single assignment.
+
+| Access | Auth — admin, subject member, or the assignment's manager |
+| ------ | --------------------------------------------------------- |
+
+**Response `200`**
+
+```json
+{ "assignment": { "id": "uuid", "subject_id": "uuid", "name": "Assignment 1", ... } }
+```
+
+---
+
+### `POST /api/assignments`
+
+Create an assignment within a subject. Assignment names are unique per subject.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "subjectId": "uuid", "name": "Assignment 1" }
+```
+
+**Response `201`**
+
+```json
+{ "message": "Assignment created successfully", "assignment": { ... } }
+```
+
+**Errors**
+
+| Code | Reason                                                      |
+| ---- | ----------------------------------------------------------- |
+| 404  | Subject not found                                           |
+| 409  | An assignment with this name already exists in this subject |
+
+---
+
+### `PUT /api/assignments/:id`
+
+Rename an assignment.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "name": "Assignment 2" }
+```
+
+**Response `200`**
+
+```json
+{ "message": "Assignment updated successfully", "assignment": { ... } }
+```
+
+---
+
+### `DELETE /api/assignments/:id`
+
+Delete an assignment. **Cascades**: all of the assignment's groups and group memberships are deleted. User accounts are
+never deleted.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Response `200`**
+
+```json
+{ "message": "Assignment deleted successfully" }
+```
+
+---
+
+### `GET /api/assignments/:id/groups`
+
+List the groups of an assignment. Replaces the removed `GET /api/groups` and `GET /api/groups/enabled` endpoints.
+
+| Access | Auth — admin, subject member, or the assignment's manager |
+| ------ | --------------------------------------------------------- |
+
+**Query parameters**
+
+| Param     | Values | Description                |
+| --------- | ------ | -------------------------- |
+| `enabled` | `true` | Return only enabled groups |
+
+**Response `200`**
+
+```json
+{ "groups": [{ "id": "uuid", "name": "Group A", "enabled": true, "max_members": 5, "member_count": 3, ... }] }
+```
+
+---
+
+### `GET /api/assignments/:id/managers`
+
+List the assignment's managers.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Response `200`**
+
+```json
+{ "managers": [{ "id": "uuid", "username": "am1", ... }] }
+```
+
+---
+
+### `PUT /api/assignments/:id/managers`
+
+Replace the assignment's manager list. All listed users must have the `assignment_manager` role. Pass an empty array to
+remove all managers.
+
+| Access | Admin |
+| ------ | ----- |
+
+**Request body**
+
+```json
+{ "userIds": ["uuid1", "uuid2"] }
+```
+
+**Response `200`**
+
+```json
+{ "message": "Assignment managers updated successfully", "managers": [ ... ] }
+```
+
+**Errors**
+
+| Code | Reason                                                                  |
+| ---- | ----------------------------------------------------------------------- |
+| 400  | One or more users do not exist / not all have `assignment_manager` role |
+| 404  | Assignment not found                                                    |
+
+---
+
+### `GET /api/assignments/:id/export-mappings`
+
+Export the assignment's current user–group placements as `{ email, groupName }` pairs. Replaces the removed
+`GET /api/groups/export-mappings`.
+
+| Access | Admin, or the assignment's manager |
+| ------ | ---------------------------------- |
+
+**Response `200`**
+
+```json
+{ "mappings": [{ "email": "jsmith@example.com", "groupName": "Group A" }] }
+```
+
+---
+
+### `POST /api/assignments/:id/import-mappings`
+
+Bulk-assign users to this assignment's groups from a parsed CSV payload. Replaces the removed
+`POST /api/groups/import-mappings`. Group names are matched case-insensitively within the assignment; existing
+placements for the same assignment are replaced.
+
+| Access | Admin, or the assignment's manager |
+| ------ | ---------------------------------- |
+
+**Request body**
+
+```json
+{
+  "rows": [
+    { "email": "jsmith@example.com", "groupName": "Group A" },
+    { "action": "skip", "email": "other@example.com", "groupName": "Group B", "skipReason": "No match found" }
+  ]
+}
+```
+
+Up to 2000 rows. Rows with `action: "skip"` are recorded in the `skipped` summary but not processed. Rows are skipped
+(with a reason) when the user is not found, the user is an admin or assignment manager, the group is not found, the user
+is not a member of the assignment's subject, or the group is full.
+
+**Response `200`**
+
+```json
+{ "imported": 4, "skipped": [{ "email": "...", "groupName": "...", "reason": "..." }], "errors": [] }
+```
+
+**Errors**
+
+| Code | Reason                                                |
+| ---- | ----------------------------------------------------- |
+| 400  | No mappings / too many rows                           |
+| 403  | Caller does not manage this assignment                |
+| 404  | Assignment not found                                  |
+| 409  | Ambiguous group name (two groups differ only by case) |
+
+---
+
 ## Users
 
 ### `GET /api/users`
 
-List all users. Supports optional query filters.
+List users. Assignment managers only see users enrolled in subjects where they manage an assignment (plus admin/AM
+accounts per model scoping).
 
 | Access | AM+ |
 | ------ | --- |
 
 **Query parameters**
 
-| Param     | Values                                | Description      |
-| --------- | ------------------------------------- | ---------------- |
-| `role`    | `admin`, `assignment_manager`, `user` | Filter by role   |
-| `status`  | `active`, `inactive`, `pending`       | Filter by status |
-| `groupId` | UUID or `none`                        | Filter by group  |
+| Param          | Values                                | Description                                                                    |
+| -------------- | ------------------------------------- | ------------------------------------------------------------------------------ |
+| `role`         | `admin`, `assignment_manager`, `user` | Filter by role                                                                 |
+| `status`       | `active`, `inactive`, `pending`       | Filter by status                                                               |
+| `subjectId`    | UUID                                  | Users enrolled in the subject                                                  |
+| `assignmentId` | UUID                                  | Users in the assignment's subject                                              |
+| `groupId`      | UUID or `none`                        | Filter by group; `none` requires `assignmentId` (ungrouped in that assignment) |
 
 **Response `200`**
 
+Each user is enriched with their subject enrolments and per-assignment group memberships:
+
 ```json
-{ "users": [ { "id": "uuid", "username": "...", ... } ] }
+{
+  "users": [
+    {
+      "id": "uuid",
+      "username": "jsmith",
+      "subjects": [{ "id": "uuid", "name": "COMP10001" }],
+      "memberships": [{ "subject_id": "uuid", "assignment_id": "uuid", "group_id": "uuid", "group_name": "Group A" }]
+    }
+  ]
+}
 ```
 
 ---
 
 ### `GET /api/users/:id`
 
-Get a single user by ID.
+Get a single user by ID, enriched with `subjects` and `memberships`.
 
 | Access | Auth — users can view their own profile; AM+ can view any user |
 | ------ | -------------------------------------------------------------- |
@@ -270,14 +708,14 @@ Get a single user by ID.
 **Response `200`**
 
 ```json
-{ "user": { "id": "uuid", "username": "jsmith", "email": "...", "role": "user", ... } }
+{ "user": { "id": "uuid", "username": "jsmith", "role_name": "user", "subjects": [ ... ], "memberships": [ ... ] } }
 ```
 
 ---
 
 ### `POST /api/users`
 
-Create a new user. The account is created in `pending` status and an account-setup email is sent (unless
+Create a new user. The account is created in `pending` status and an account-setup email is sent (unless an Admin sets
 `sendSetupEmail: false`).
 
 | Access | AM+ (only Admin can create Admin or Assignment Manager accounts) |
@@ -292,22 +730,30 @@ Create a new user. The account is created in `pending` status and an account-set
   "firstName": "John",
   "lastName": "Smith",
   "studentId": "S12345",
-  "groupId": "uuid-or-null",
   "role": "user",
+  "subjectIds": ["uuid"],
+  "assignmentId": "uuid",
+  "groupId": "uuid",
+  "assignmentIds": [],
   "sendSetupEmail": true
 }
 ```
 
-| Field            | Type    | Required | Notes                                                                        |
-| ---------------- | ------- | :------: | ---------------------------------------------------------------------------- |
-| `username`       | string  |   Yes    |                                                                              |
-| `email`          | string  |   Yes    |                                                                              |
-| `firstName`      | string  |   Yes    |                                                                              |
-| `lastName`       | string  |   Yes    |                                                                              |
-| `studentId`      | string  |    No    | Only applies to `user` role                                                  |
-| `groupId`        | UUID    |    No    | Only applies to `user` role                                                  |
-| `role`           | string  |    No    | `user` (default), `assignment_manager`, `admin`                              |
-| `sendSetupEmail` | boolean |    No    | Default `true`; only Admin can set to `false` — AM always sends setup emails |
+| Field            | Type    |    Required     | Notes                                                                                               |
+| ---------------- | ------- | :-------------: | --------------------------------------------------------------------------------------------------- |
+| `username`       | string  |       Yes       |                                                                                                     |
+| `email`          | string  |       Yes       |                                                                                                     |
+| `firstName`      | string  |       Yes       |                                                                                                     |
+| `lastName`       | string  |       Yes       |                                                                                                     |
+| `studentId`      | string  |       No        | Only applies to `user` role                                                                         |
+| `role`           | string  |       No        | `user` (default), `assignment_manager`, `admin`                                                     |
+| `subjectIds`     | UUID[]  | For `user` role | Subjects to enrol in — at least one is required for regular users                                   |
+| `assignmentId`   | UUID    |       No        | Optional immediate group placement; must belong to one of `subjectIds`; required when `groupId` set |
+| `groupId`        | UUID    |       No        | Optional immediate group placement; must belong to `assignmentId`                                   |
+| `assignmentIds`  | UUID[]  |       No        | For `assignment_manager` role: assignments the new AM will manage                                   |
+| `sendSetupEmail` | boolean |       No        | Default `true`; only Admin can set to `false` — AMs always send setup emails                        |
+
+Assignment managers may only enrol new users into subjects containing an assignment they manage (`403` otherwise).
 
 **Response `201`**
 
@@ -318,11 +764,28 @@ Create a new user. The account is created in `pending` status and an account-set
 }
 ```
 
+If the optional group placement fails (e.g. the group filled up), the user is still created and enrolled, and the
+response includes a `warning` field:
+
+```json
+{ "message": "User created successfully", "user": { ... }, "warning": "User created but group placement failed: ..." }
+```
+
+**Errors**
+
+| Code | Reason                                                                    |
+| ---- | ------------------------------------------------------------------------- |
+| 400  | Validation error / missing `subjectIds` / assignment–subject mismatch     |
+| 403  | Role escalation attempt / AM does not manage an assignment in the subject |
+| 404  | Subject, assignment, or group not found                                   |
+| 409  | Duplicate username, email, or student ID                                  |
+
 ---
 
 ### `PUT /api/users/:id`
 
-Update a user's profile, role, or enabled status.
+Update a user's profile, role, or enabled status. Group placement is **not** part of this endpoint — use
+`PUT /api/users/:id/group`.
 
 | Access | Admin can edit any user; AM can edit non-admin users; users can edit their own profile |
 | ------ | -------------------------------------------------------------------------------------- |
@@ -336,8 +799,7 @@ Update a user's profile, role, or enabled status.
   "lastName": "Doe",
   "studentId": "S99999",
   "role": "assignment_manager",
-  "enabled": false,
-  "groupId": "uuid-or-null"
+  "enabled": false
 }
 ```
 
@@ -345,8 +807,7 @@ Update a user's profile, role, or enabled status.
 
 - `username` cannot be changed
 - `role` can only be changed by Admin
-- `enabled` can be changed by Admin or AM (AM cannot change admin users)
-- `groupId` can only be changed by Admin
+- `enabled` can be changed by Admin or AM (AM cannot edit admin users)
 - The built-in `admin` account cannot be disabled or have its role changed
 
 **Response `200`**
@@ -359,24 +820,38 @@ Update a user's profile, role, or enabled status.
 
 ### `PUT /api/users/:id/group`
 
-Assign or remove a user from a group.
+Set or remove a user's group placement **for one assignment**. The target user must be a member of the assignment's
+parent subject — this rule applies to admins too.
 
-| Access | AM+ |
-| ------ | --- |
+| Access | Admin, or an AM who manages the assignment |
+| ------ | ------------------------------------------ |
 
 **Request body**
 
 ```json
-{ "groupId": "uuid" }
+{ "assignmentId": "uuid", "groupId": "uuid" }
 ```
 
-Set `groupId` to `null` to remove the user from their current group.
+Set `groupId` to `null` to remove the user's placement for that assignment. When a `groupId` is given, any existing
+placement for the same assignment is replaced.
 
 **Response `200`**
 
 ```json
-{ "message": "User group updated successfully", "user": { "id": "uuid", "username": "...", "groupId": "uuid" } }
+{
+  "message": "User group updated successfully",
+  "user": { "id": "uuid", "username": "jsmith", "assignmentId": "uuid", "groupId": "uuid" }
+}
 ```
+
+**Errors**
+
+| Code | Reason                                                                   |
+| ---- | ------------------------------------------------------------------------ |
+| 400  | Group does not belong to the selected assignment                         |
+| 403  | Caller does not manage the assignment / user not a member of the subject |
+| 404  | User, assignment, or group not found                                     |
+| 409  | Group is full                                                            |
 
 ---
 
@@ -386,6 +861,8 @@ Change the current user's own password. Requires the current password.
 
 | Access | Auth — users can only change their own password |
 | ------ | ----------------------------------------------- |
+
+Rate limit: 10 req/15 min (production).
 
 **Request body**
 
@@ -443,15 +920,17 @@ Up to 2000 IDs per request. Cannot include your own account.
 
 ### `POST /api/users/import`
 
-Bulk-import users from a parsed CSV payload. Accounts are created in `pending` status.
+Bulk-import users from a parsed CSV payload into a target subject. Accounts are created in `pending` status; every
+created or overwritten user is enrolled in the target subject.
 
-| Access | AM+ |
-| ------ | --- |
+| Access | AM+ — AMs may only import into subjects containing an assignment they manage |
+| ------ | ---------------------------------------------------------------------------- |
 
 **Request body**
 
 ```json
 {
+  "subjectId": "uuid",
   "users": [
     {
       "username": "jsmith",
@@ -468,6 +947,7 @@ Bulk-import users from a parsed CSV payload. Accounts are created in `pending` s
 
 | Field            | Type    | Required | Notes                                             |
 | ---------------- | ------- | :------: | ------------------------------------------------- |
+| `subjectId`      | UUID    |   Yes    | Subject the imported users are enrolled in        |
 | `users`          | array   |   Yes    | Max 2000 rows                                     |
 | `conflictAction` | string  |    No    | `skip` (default) or `overwrite` on username match |
 | `sendSetupEmail` | boolean |    No    | Default `false`                                   |
@@ -477,6 +957,14 @@ Bulk-import users from a parsed CSV payload. Accounts are created in `pending` s
 ```json
 { "imported": 5, "skipped": 1, "errors": [] }
 ```
+
+**Errors**
+
+| Code | Reason                                                       |
+| ---- | ------------------------------------------------------------ |
+| 400  | Missing/invalid `subjectId`, empty payload, or too many rows |
+| 403  | AM does not manage an assignment in the subject              |
+| 404  | Subject not found                                            |
 
 ---
 
@@ -493,7 +981,7 @@ Send (or resend) account-setup emails to pending users.
 { "userIds": ["uuid1", "uuid2"] }
 ```
 
-Omit `userIds` to send to all pending users.
+Omit `userIds` to send to all pending users. Max 500 IDs per request.
 
 **Response `200`**
 
@@ -505,43 +993,34 @@ Omit `userIds` to send to all pending users.
 
 ## Groups
 
-### `GET /api/groups`
-
-List all groups (enabled and disabled).
-
-| Access | Auth |
-| ------ | ---- |
-
-**Response `200`**
-
-```json
-{ "groups": [ { "id": "uuid", "name": "Group A", "enabled": true, "maxMembers": 5, "memberCount": 3, ... } ] }
-```
-
----
-
-### `GET /api/groups/enabled`
-
-List only enabled groups. Used for assignment dropdowns.
-
-| Access | Auth |
-| ------ | ---- |
-
----
+Groups always belong to an assignment. To list groups, use `GET /api/assignments/:id/groups` — the old flat
+`GET /api/groups` and `GET /api/groups/enabled` endpoints have been removed.
 
 ### `GET /api/groups/:id`
 
 Get a group and its members.
 
-| Access | Auth |
-| ------ | ---- |
+| Access | Auth — admin, member of the parent subject, or the assignment's manager |
+| ------ | ----------------------------------------------------------------------- |
 
 **Response `200`**
 
 ```json
 {
-  "group": { "id": "uuid", "name": "Group A", "enabled": true, "maxMembers": 5, "memberCount": 3, ... },
-  "members": [ { "id": "uuid", "username": "jsmith", ... } ]
+  "group": {
+    "id": "uuid",
+    "name": "Group A",
+    "enabled": true,
+    "maxMembers": 5,
+    "memberCount": 3,
+    "assignmentId": "uuid",
+    "assignmentName": "Assignment 1",
+    "subjectId": "uuid",
+    "subjectName": "COMP10001",
+    "createdAt": "...",
+    "updatedAt": "..."
+  },
+  "members": [{ "id": "uuid", "username": "jsmith", ... }]
 }
 ```
 
@@ -549,48 +1028,61 @@ Get a group and its members.
 
 ### `POST /api/groups`
 
-Create a single group.
+Create a single group within an assignment. Group names are unique per assignment.
 
-| Access | Admin |
-| ------ | ----- |
+| Access | Admin, or an AM who manages the assignment |
+| ------ | ------------------------------------------ |
 
 **Request body**
 
 ```json
-{ "name": "Group A", "enabled": true, "maxMembers": 5 }
+{ "assignmentId": "uuid", "name": "Group A", "enabled": true, "maxMembers": 5 }
 ```
 
-| Field        | Type    | Required | Notes              |
-| ------------ | ------- | :------: | ------------------ |
-| `name`       | string  |   Yes    | Must be unique     |
-| `enabled`    | boolean |    No    | Default `true`     |
-| `maxMembers` | number  |    No    | `null` = unlimited |
+| Field          | Type    | Required | Notes                    |
+| -------------- | ------- | :------: | ------------------------ |
+| `assignmentId` | UUID    |   Yes    | Parent assignment        |
+| `name`         | string  |   Yes    | Unique within assignment |
+| `enabled`      | boolean |    No    | Default `true`           |
+| `maxMembers`   | number  |    No    | `null` = unlimited       |
 
 **Response `201`**
 
 ```json
-{ "message": "Group created successfully", "group": { ... } }
+{ "message": "Group created successfully", "group": { "id": "uuid", "name": "Group A", "assignmentId": "uuid", ... } }
 ```
+
+**Errors**
+
+| Code | Reason                                 |
+| ---- | -------------------------------------- |
+| 403  | Caller does not manage this assignment |
+| 404  | Assignment not found                   |
+| 409  | Group name already exists              |
 
 ---
 
 ### `POST /api/groups/bulk`
 
-Create multiple groups in one request.
+Create multiple groups in one assignment.
 
-| Access | Admin |
-| ------ | ----- |
+| Access | Admin, or an AM who manages the assignment |
+| ------ | ------------------------------------------ |
 
-**Request body** — array of group objects (max 2000 per request)
+**Request body**
 
 ```json
-[
-  { "name": "Group A", "enabled": true, "maxMembers": 5 },
-  { "name": "Group B", "maxMembers": null }
-]
+{
+  "assignmentId": "uuid",
+  "groups": [
+    { "name": "Group A", "enabled": true, "maxMembers": 5 },
+    { "name": "Group B", "maxMembers": null }
+  ]
+}
 ```
 
-No duplicate names within the batch (case-insensitive).
+Max 2000 groups per request. No duplicate names within the batch (case-insensitive), and no names that already exist
+within the assignment.
 
 **Response `201`**
 
@@ -604,8 +1096,8 @@ No duplicate names within the batch (case-insensitive).
 
 Update a group's name, enabled status, or member cap.
 
-| Access | Admin |
-| ------ | ----- |
+| Access | Admin, or an AM who manages the group's assignment |
+| ------ | -------------------------------------------------- |
 
 **Request body** (all fields optional)
 
@@ -625,10 +1117,10 @@ Cannot lower `maxMembers` below the current member count.
 
 ### `DELETE /api/groups/:id`
 
-Delete a single group.
+Delete a single group. Its memberships are removed; user accounts are unaffected.
 
-| Access | Admin |
-| ------ | ----- |
+| Access | Admin, or an AM who manages the group's assignment |
+| ------ | -------------------------------------------------- |
 
 **Response `200`**
 
@@ -640,10 +1132,10 @@ Delete a single group.
 
 ### `DELETE /api/groups/bulk`
 
-Delete multiple groups.
+Delete multiple groups. Assignment managers may only include groups of assignments they manage.
 
-| Access | Admin |
-| ------ | ----- |
+| Access | AM+ (scoped) |
+| ------ | ------------ |
 
 **Request body**
 
@@ -663,23 +1155,33 @@ Up to 2000 IDs per request.
 
 ### `POST /api/groups/:id/join`
 
-Join a group as the currently authenticated user.
+Join a group as the currently authenticated user (for the group's assignment).
 
 | Access | Auth |
 | ------ | ---- |
 
 **Conditions**
 
-- The group must be enabled
-- The user must not already be in a group
-- The group must not be full
-- Group join must not be locked (unless the user is Admin or AM)
+- The caller's account must be enabled (re-checked against the database, not the JWT)
+- The group must be enabled and not full
+- The caller must be a member of the group's parent subject
+- The caller must not already be in a group for the same assignment
+- Group join must not be locked (the lock does not apply to Admins or AMs)
 
 **Response `200`**
 
 ```json
 { "message": "Successfully joined group", "groupId": "uuid", "groupName": "Group A" }
 ```
+
+**Errors**
+
+| Code | Reason                                                            |
+| ---- | ----------------------------------------------------------------- |
+| 400  | Group is disabled                                                 |
+| 403  | Join lock active / account disabled / not a member of the subject |
+| 404  | Group or user not found                                           |
+| 409  | Already in a group for this assignment / group is full            |
 
 ---
 
@@ -692,56 +1194,14 @@ Leave a group as the currently authenticated user.
 
 **Conditions**
 
-- The user must be a member of the specified group
-- Group join must not be locked (unless the user is Admin or AM)
+- The caller's account must be enabled
+- The caller must be a member of the specified group
+- Group join must not be locked (the lock does not apply to Admins or AMs)
 
 **Response `200`**
 
 ```json
 { "message": "Successfully left group" }
-```
-
----
-
-### `POST /api/groups/import-mappings`
-
-Bulk-assign users to groups from a parsed CSV payload.
-
-| Access | AM+ |
-| ------ | --- |
-
-**Request body**
-
-```json
-{
-  "rows": [
-    { "email": "jsmith@example.com", "groupName": "Group A" },
-    { "action": "skip", "email": "other@example.com", "groupName": "Group B", "skipReason": "No match found" }
-  ]
-}
-```
-
-Up to 2000 rows. Rows with `action: "skip"` are recorded in the `skipped` summary but not processed.
-
-**Response `200`**
-
-```json
-{ "imported": 4, "skipped": [{ "email": "...", "groupName": "...", "reason": "..." }], "errors": [] }
-```
-
----
-
-### `GET /api/groups/export-mappings`
-
-Export current user–group assignments as a list of `{ email, groupName }` pairs.
-
-| Access | AM+ |
-| ------ | --- |
-
-**Response `200`**
-
-```json
-{ "mappings": [{ "email": "jsmith@example.com", "groupName": "Group A" }] }
 ```
 
 ---
@@ -801,15 +1261,15 @@ Update a system config value. Currently the only supported key is `group_join_lo
 
 ## Common Error Responses
 
-| Code | Meaning                                                |
-| ---- | ------------------------------------------------------ |
-| 400  | Validation error or bad request                        |
-| 401  | Missing or invalid token / invalid credentials         |
-| 403  | Authenticated but insufficient role                    |
-| 404  | Resource not found                                     |
-| 409  | Conflict (duplicate username, email, student ID, etc.) |
-| 429  | Rate limit exceeded                                    |
-| 500  | Internal server error                                  |
+| Code | Meaning                                        |
+| ---- | ---------------------------------------------- |
+| 400  | Validation error or bad request                |
+| 401  | Missing or invalid token / invalid credentials |
+| 403  | Authenticated but insufficient role or scope   |
+| 404  | Resource not found                             |
+| 409  | Conflict (duplicate name, group full, etc.)    |
+| 429  | Rate limit exceeded                            |
+| 500  | Internal server error                          |
 
 Error responses always include an `error` field:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -145,7 +145,9 @@ Rate limit: 5 req/min (production).
 ```
 
 `subjects` lists the subjects the user is enrolled in, `memberships` lists their per-assignment group placements, and
-`managedAssignments` lists the assignments an assignment manager manages (always `[]` for other roles).
+`managedAssignments` lists the assignments an assignment manager manages (always `[]` for other roles). Suspended
+subject memberships (see `PUT /api/subjects/:id/users/:userId`) are excluded — a suspended member does not see that
+subject in their own session.
 
 **Errors**
 
@@ -368,7 +370,8 @@ enrolments are deleted. User accounts are never deleted.
 
 ### `GET /api/subjects/:id/users`
 
-List the members (enrolled users) of a subject.
+List the members (enrolled users) of a subject. Suspended members are included, tagged with `membership_enabled: false`
+— staff always see them here even though the member no longer sees the subject themselves.
 
 | Access | Admin, or an AM managing an assignment in the subject |
 | ------ | ----------------------------------------------------- |
@@ -376,7 +379,7 @@ List the members (enrolled users) of a subject.
 **Response `200`**
 
 ```json
-{ "users": [{ "id": "uuid", "username": "jsmith", ... }] }
+{ "users": [{ "id": "uuid", "username": "jsmith", "membership_enabled": true, ... }] }
 ```
 
 ---
@@ -408,6 +411,45 @@ Enrol users in a subject.
 | ---- | ------------------------------ |
 | 400  | One or more users do not exist |
 | 404  | Subject not found              |
+
+---
+
+### `PUT /api/subjects/:id/users/:userId`
+
+Suspend or re-enable a user's membership in a subject. Suspending (`enabled: false`) also removes the user's group
+memberships within that subject's assignments (transactionally). **Re-enabling restores subject access but does NOT
+restore group memberships** — the user must be re-assigned or re-join.
+
+While suspended, the user is treated as a non-member of the subject everywhere: the subject disappears from their own
+session (`POST /api/auth/login`, `GET /api/auth/me`, dashboard), subject/assignment/group scope checks fail, and group
+placement is rejected with `User is not an active member of this subject`. Staff still see the user in
+`GET /api/subjects/:id/users` with `membership_enabled: false`.
+
+| Access | Admin, or an AM managing an assignment in the subject |
+| ------ | ----------------------------------------------------- |
+
+**Request body**
+
+```json
+{ "enabled": false }
+```
+
+**Response `200`**
+
+```json
+{ "message": "Member suspended", "membershipEnabled": false }
+```
+
+`message` is `"Member enabled"` when re-enabling.
+
+**Errors**
+
+| Code | Reason                                                        |
+| ---- | ------------------------------------------------------------- |
+| 400  | Invalid subject/user ID, or `enabled` missing / not a boolean |
+| 401  | Not authenticated                                             |
+| 403  | Not admin and not an AM managing an assignment in the subject |
+| 404  | Subject not found / user is not a member of this subject      |
 
 ---
 
@@ -663,11 +705,10 @@ is not a member of the assignment's subject, or the group is full.
 
 ### `GET /api/users`
 
-List users. Assignment managers only see users enrolled in subjects where they manage an assignment (plus admin/AM
-accounts per model scoping).
+List users. Admin only — assignment managers manage members through `GET /api/subjects/:id/users` instead.
 
-| Access | AM+ |
-| ------ | --- |
+| Access | Admin |
+| ------ | ----- |
 
 **Query parameters**
 
@@ -681,7 +722,8 @@ accounts per model scoping).
 
 **Response `200`**
 
-Each user is enriched with their subject enrolments and per-assignment group memberships:
+Each user is enriched with their subject enrolments and per-assignment group memberships. `subjects` includes suspended
+enrolments, each entry tagged with `membership_enabled`:
 
 ```json
 {
@@ -689,7 +731,7 @@ Each user is enriched with their subject enrolments and per-assignment group mem
     {
       "id": "uuid",
       "username": "jsmith",
-      "subjects": [{ "id": "uuid", "name": "COMP10001" }],
+      "subjects": [{ "id": "uuid", "name": "COMP10001", "membership_enabled": true }],
       "memberships": [{ "subject_id": "uuid", "assignment_id": "uuid", "group_id": "uuid", "group_name": "Group A" }]
     }
   ]
@@ -787,8 +829,8 @@ response includes a `warning` field:
 Update a user's profile, role, or enabled status. Group placement is **not** part of this endpoint — use
 `PUT /api/users/:id/group`.
 
-| Access | Admin can edit any user; AM can edit non-admin users; users can edit their own profile |
-| ------ | -------------------------------------------------------------------------------------- |
+| Access | Admin can edit any user; AMs can edit non-admin users in subjects they manage; users can edit their own profile |
+| ------ | --------------------------------------------------------------------------------------------------------------- |
 
 **Request body** (all fields optional)
 
@@ -807,7 +849,10 @@ Update a user's profile, role, or enabled status. Group placement is **not** par
 
 - `username` cannot be changed
 - `role` can only be changed by Admin
-- `enabled` can be changed by Admin or AM (AM cannot edit admin users)
+- `enabled` can only be changed by Admin — anyone else sending `enabled` receives `403`
+- AMs may only edit users enrolled (in any enabled state) in a subject containing an assignment they manage — `403`
+  otherwise; an AM editing their own profile is exempt from this check
+- AMs cannot edit admin users
 - The built-in `admin` account cannot be disabled or have its role changed
 
 **Response `200`**
@@ -972,8 +1017,8 @@ created or overwritten user is enrolled in the target subject.
 
 Send (or resend) account-setup emails to pending users.
 
-| Access | AM+ |
-| ------ | --- |
+| Access | AM+ — AM targets must be enrolled in a subject where the AM manages an assignment |
+| ------ | --------------------------------------------------------------------------------- |
 
 **Request body**
 
@@ -982,6 +1027,10 @@ Send (or resend) account-setup emails to pending users.
 ```
 
 Omit `userIds` to send to all pending users. Max 500 IDs per request.
+
+For assignment managers, every explicit target must be enrolled (in any enabled state) in a subject containing an
+assignment they manage — a single out-of-scope ID rejects the whole request with `403` before any email is sent. When
+`userIds` is omitted, an AM's "all pending users" is likewise filtered to those subjects.
 
 **Response `200`**
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -103,8 +103,8 @@ enableGroupJoinLock(page); // Login as admin, navigate to /settings, enable lock
 ```js
 cleanDatabase()                              // DELETE all groups, non-admin users, config
 createUser({ username, email, ... })         // Insert user directly (bypasses email flow)
-createGroup({ name, enabled, ... })          // Insert group directly
-assignUserToGroup(username, groupId)         // Set group_id on user row
+createGroup({ assignmentId, name, enabled, ... }) // Insert group directly under an assignment
+assignUserToGroup(username, groupId)         // Insert user_groups membership row for the group's assignment
 createPasswordResetToken(email, opts)        // Insert hashed reset token; returns raw token for URLs
 closePool()                                  // Close the DB connection pool
 ```

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -25,7 +25,7 @@ backend/
     │   └── setupEnv.js                     # Set process.env from container config (runs before modules load)
     ├── helpers/
     │   ├── server.js                       # buildTestServer() / closeTestServer() helpers
-    │   └── db.js                           # cleanDatabase(), createUser(), createGroup(), loginAs(), getPool()
+    │   └── db.js                           # cleanDatabase(), createUser(), createSubject(), createAssignment(), createGroup({ assignmentId, ... }), addUserToSubject(), assignManager(), addUserToGroup(), loginAs(), getPool()
     ├── auth.test.js
     ├── users.test.js
     ├── groups.test.js

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,16 +31,17 @@ including admins.
 
 ## Roles overview
 
-| Role                   | What they can do                                                                                                                                                        |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Admin**              | Everything — full control over subjects, assignments, groups, users, enrolments, and system config                                                                      |
-| **Assignment Manager** | Scoped to the assignments they manage: create/edit/delete groups and assign subject members to groups in those assignments; create and import users into those subjects |
-| **User** (student)     | View their own profile and enrolled subjects; self-join or leave one group per assignment (when joining is unlocked)                                                    |
+| Role                   | What they can do                                                                                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Admin**              | Everything — full control over subjects, assignments, groups, users, enrolments, membership suspension, and system config                                                                               |
+| **Assignment Manager** | Scoped to the assignments they manage: create/edit/delete groups and assign subject members to groups in those assignments; manage members (create, suspend/enable, setup emails) inside those subjects |
+| **User** (student)     | View their own profile and enrolled subjects; self-join or leave one group per assignment (when joining is unlocked)                                                                                    |
 
 > **Assignment Manager scoping:** each AM is linked to specific assignments by an Admin. An AM can only manage groups
-> and group placements **within assignments they manage**, only sees users enrolled in subjects where they manage an
-> assignment, and can only create or import users into those subjects. Subjects and assignments themselves are
-> Admin-only.
+> and group placements **within assignments they manage**, and manages users **per subject**: from the page of a subject
+> where they manage an assignment, the **Members** section lets them create users, suspend or re-enable memberships,
+> assign groups, and send setup emails. The global **Users** page is Admin-only, and subjects and assignments themselves
+> are Admin-only.
 
 ---
 
@@ -83,7 +84,8 @@ out). Click the link in the email to set your password.
 If you did not receive the email:
 
 - Check your spam folder
-- Ask an admin or AM to resend it (Users page → select user → Send Setup Email)
+- Ask an admin or AM to resend it (admins: Users page → select user → Send Setup Email; AMs: the subject's Members
+  section → envelope icon)
 - If SMTP is not configured (development only), the admin can find the link in the backend logs; in production SMTP must
   be configured for emails to be sent
 
@@ -107,11 +109,14 @@ If you did not receive the email:
 After logging in you land on the **Dashboard**. What you see depends on your role:
 
 - **All roles** — your profile: name, username, email, role, student ID, and the subjects you are enrolled in
-- **Students** — one **card per enrolled subject**, each listing the subject's assignments; for every assignment you
-  either see your current group (with a **Leave Group** button) or the list of joinable groups (with **Join** buttons
-  and an **I'm Feeling Lucky** random-join button)
-- **Admins and Assignment Managers** — an **Administration** panel with links to **Users**, **Subjects & Assignments**,
-  and **Settings**
+- **Students** — the dashboard shows **one subject at a time**. If you are enrolled in more than one subject you first
+  land on a **subject picker**; your choice is remembered for the session and a **Switch subject** button lets you
+  change it at any time. If you are enrolled in a single subject you go straight to it. The subject card lists its
+  assignments; for every assignment you either see your current group (with a **Leave Group** button) or the list of
+  joinable groups (with **Join** buttons and an **I'm Feeling Lucky** random-join button)
+- **Admins** — an **Administration** panel with links to **Users**, **Subjects & Assignments**, and **Settings**
+- **Assignment Managers** — the same **Administration** panel without the **Users** link — AMs manage members inside
+  each subject's page instead
 
 ---
 
@@ -266,16 +271,21 @@ Deleting a group unassigns all its members; their accounts and subject enrolment
 
 ### Managing users
 
-Navigate to **Users** from the **Administration** panel on the Dashboard.
+Where you manage users depends on your role:
 
-> **Assignment Manager scope:** AMs only see users enrolled in subjects where they manage an assignment, and can only
-> create or import users into those subjects.
+- **Admins** use the global **Users** page (Administration panel → **Users**). The Users page and the user import wizard
+  are **Admin-only**.
+- **Assignment Managers** manage members inside a subject: open **Subjects** → the subject → the **Members** section. It
+  lists the subject's members and offers **Suspend/Enable**, **Assign Group**, **Create User**, and **Send Setup Email**
+  actions for subjects where the AM manages an assignment. Admins see the same section, plus an **Add Existing User**
+  button to enrol an already-existing account.
 
-#### Viewing and filtering users
+#### Viewing and filtering users (Admin only)
 
 The Users page groups accounts into three sections: **Administrators** (admins and AMs), **Users without a subject**,
 and **Users in subjects**. Each user row shows their subject enrolments and group memberships as
-`Subject › Assignment › Group`. Use the filter bar to narrow the list:
+`Subject › Assignment › Group`; suspended subject memberships are shown struck through with a **(suspended)** suffix.
+Use the filter bar to narrow the list:
 
 - **Role** — filter by `Admin`, `Assignment Manager`, or `User`
 - **Status** — filter by `Active`, `Inactive`, or `Pending`
@@ -285,6 +295,9 @@ and **Users in subjects**. Each user row shows their subject enrolments and grou
 Each section has its own **Export** button to download the listed users as CSV.
 
 #### Creating a user
+
+Admins create users from the Users page as described below. Assignment Managers use **+ Create User** in a subject's
+**Members** section instead — the form is the same, but the new user is automatically enrolled in that subject.
 
 1. Click **Add User** (top-right).
 2. Fill in the required fields (username, email, first name, last name).
@@ -313,13 +326,16 @@ warning tells you to place them manually.
 
 **What can be edited**
 
-| Field             | Who can change it                    |
-| ----------------- | ------------------------------------ |
-| Email             | Admin, AM, the user themselves       |
-| First / last name | Admin, AM, the user themselves       |
-| Student ID        | Admin, AM, the user themselves       |
-| Role              | Admin only                           |
-| Enabled           | Admin and AM (AM cannot edit admins) |
+| Field             | Who can change it              |
+| ----------------- | ------------------------------ |
+| Email             | Admin, AM, the user themselves |
+| First / last name | Admin, AM, the user themselves |
+| Student ID        | Admin, AM, the user themselves |
+| Role              | Admin only                     |
+| Enabled           | Admin only                     |
+
+> **Assignment Manager scope:** AMs can only edit users enrolled in a subject where they manage an assignment (editing
+> their own profile is always allowed), and cannot edit admin accounts.
 
 Subject enrolment and group placement are managed separately — see **Manage Subjects** and **Assign Group** below.
 
@@ -331,10 +347,28 @@ Subject enrolment and group placement are managed separately — see **Manage Su
 > Removing a user from a subject also removes their group memberships within that subject. The modal warns you when a
 > removal affects existing memberships.
 
-#### Enabling / disabling a user
+#### Enabling / disabling a user (Admin only)
 
 Toggle the **Enabled** field in the edit modal. Disabling a user sets their status to `inactive` and prevents login;
-disabled accounts are also rejected when trying to join or leave groups, even with a still-valid session.
+disabled accounts are also rejected when trying to join or leave groups, even with a still-valid session. This disables
+the whole account — to cut off a single subject only, use membership suspension below.
+
+#### Suspending / re-enabling a subject membership
+
+Suspension is **per subject**: it removes a student's access to one subject without touching their account or their
+other subjects. It is available to Admins and to AMs managing an assignment in the subject.
+
+1. Open **Subjects** → the subject → **Members** section.
+2. Click the **Suspend** (ban) icon on the member's row and confirm in the warning dialog.
+3. To re-enable, click the **Enable** (restore) icon on the suspended member's row.
+
+> **Warning — group memberships are not restored.** Suspending a member immediately **deletes their group memberships
+> within that subject's assignments**. Re-enabling restores their subject access but does **not** restore their groups —
+> they must re-join or be re-assigned.
+
+While suspended, the member no longer sees the subject on their own dashboard, cannot join or be placed in its groups,
+and is treated as a non-member by every access check. Staff still see them in the subject's member list with a
+**Suspended** badge, and Admins see the enrolment struck through as **(suspended)** on the Users page.
 
 #### Deleting users
 
@@ -345,10 +379,14 @@ disabled accounts are also rejected when trying to join or leave groups, even wi
 
 #### Sending setup emails
 
-To (re)send account-setup emails to pending users:
+To (re)send account-setup emails to pending users from the Users page (Admin):
 
 - **Selected users** — select users using checkboxes, then click the **Send Setup Email** icon and confirm.
 - **All pending users** — click the **envelope** icon in the toolbar (with no selection) and confirm.
+
+Assignment Managers send setup emails from a subject's **Members** section — pending members show a **Send Setup Email**
+(envelope) icon on their row. AMs can only send to users enrolled in subjects where they manage an assignment, and an
+AM's "all pending users" send is limited to those subjects as well.
 
 ---
 
@@ -378,16 +416,17 @@ existing members.
 
 ### CSV import and export
 
-#### Importing users (Users page)
+#### Importing users (Users page, Admin only)
 
-The user import wizard imports accounts **into a target subject** — every imported user is enrolled in that subject.
+The user import wizard imports accounts **into a target subject** — every imported user is enrolled in that subject. The
+wizard lives on the Admin-only Users page; Assignment Managers create users individually from a subject's Members
+section instead.
 
 1. Click the **Import** (upload) icon in the toolbar on the Users page.
 2. Upload a CSV file. Required columns: `username`, `email`, `firstName` (or `first_name`), `lastName` (or `last_name`).
    Optional: `studentId`.
 3. Review the column mapping and preview.
-4. Select the **target subject** the users will be enrolled in. AMs can only choose subjects where they manage an
-   assignment.
+4. Select the **target subject** the users will be enrolled in.
 5. Choose a **conflict action**:
    - **Skip** — skip rows where the username already exists
    - **Overwrite** — update existing users with the new data (and enrol them in the target subject)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,6 +2,11 @@
 
 This guide covers all features of the G.A.P. (Group Assignment Portal) from the perspective of each role.
 
+G.A.P. organises everything in a **Subject → Assignment → Group** hierarchy: subjects contain assignments, and each
+assignment has its own set of groups. Users are enrolled in subjects, and can be in **at most one group per
+assignment**. A user can only be placed in a group of a subject they are enrolled in — this rule applies to everyone,
+including admins.
+
 ---
 
 ## Table of Contents
@@ -12,26 +17,30 @@ This guide covers all features of the G.A.P. (Group Assignment Portal) from the 
 4. [Password reset](#password-reset)
 5. [Dashboard](#dashboard)
 6. [User features (all roles)](#user-features-all-roles)
-7. [Admin and Assignment Manager features](#admin-and-assignment-manager-features)
-   - [Managing users](#managing-users)
+7. [Admin workflow](#admin-workflow)
+8. [Admin and Assignment Manager features](#admin-and-assignment-manager-features)
+   - [Managing subjects and assignments](#managing-subjects-and-assignments)
    - [Managing groups](#managing-groups)
+   - [Managing users](#managing-users)
    - [Assigning users to groups](#assigning-users-to-groups)
    - [CSV import and export](#csv-import-and-export)
    - [System config](#system-config)
-8. [Admin-only features](#admin-only-features)
+9. [Admin-only features](#admin-only-features)
 
 ---
 
 ## Roles overview
 
-| Role                   | What they can do                                                                           |
-| ---------------------- | ------------------------------------------------------------------------------------------ |
-| **Admin**              | Everything — full control over users, groups, assignments, and system config               |
-| **Assignment Manager** | Create and edit users; assign users to groups; CSV import/export; lock group joining       |
-| **User**               | View their own profile; view groups; self-join or leave a group (when joining is unlocked) |
+| Role                   | What they can do                                                                                                                                                        |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Admin**              | Everything — full control over subjects, assignments, groups, users, enrolments, and system config                                                                      |
+| **Assignment Manager** | Scoped to the assignments they manage: create/edit/delete groups and assign subject members to groups in those assignments; create and import users into those subjects |
+| **User** (student)     | View their own profile and enrolled subjects; self-join or leave one group per assignment (when joining is unlocked)                                                    |
 
-> **Group management note:** Creating, editing, enabling/disabling, and deleting groups are **Admin-only** actions.
-> Assignment Managers can assign users to groups and import/export mappings, but cannot create or delete groups.
+> **Assignment Manager scoping:** each AM is linked to specific assignments by an Admin. An AM can only manage groups
+> and group placements **within assignments they manage**, only sees users enrolled in subjects where they manage an
+> assignment, and can only create or import users into those subjects. Subjects and assignments themselves are
+> Admin-only.
 
 ---
 
@@ -63,7 +72,8 @@ On success you are redirected to the **Dashboard**.
 4. You will receive an **account setup email** with a link to set your password.
 5. Click the link, enter and confirm your password, then log in.
 
-> Registration creates a `user` role account only. Admin and Assignment Manager accounts must be created by an Admin.
+> Registration creates a `user` role account only, and self-registered accounts are not enrolled in any subject — an
+> Admin must enrol you before you can join groups. Admin and Assignment Manager accounts must be created by an Admin.
 
 ### Account created by an admin or assignment manager
 
@@ -94,11 +104,14 @@ If you did not receive the email:
 
 ## Dashboard
 
-After logging in you land on the **Dashboard**, which shows:
+After logging in you land on the **Dashboard**. What you see depends on your role:
 
-- Your profile — name, username, email, role, student ID
-- Your current group assignment (if any)
-- Available groups (for users who have not yet joined a group)
+- **All roles** — your profile: name, username, email, role, student ID, and the subjects you are enrolled in
+- **Students** — one **card per enrolled subject**, each listing the subject's assignments; for every assignment you
+  either see your current group (with a **Leave Group** button) or the list of joinable groups (with **Join** buttons
+  and an **I'm Feeling Lucky** random-join button)
+- **Admins and Assignment Managers** — an **Administration** panel with links to **Users**, **Subjects & Assignments**,
+  and **Settings**
 
 ---
 
@@ -124,49 +137,170 @@ You cannot change your username.
 
 ### Joining a group
 
-Joining is available when the group-join lock is **off** and you are not already in a group.
+You join groups **per assignment** — you can be in one group for Assignment 1 and a different group for Assignment 2,
+but never two groups in the same assignment. Joining is available when the group-join lock is **off** and you are not
+already in a group for that assignment.
 
-1. On the **Dashboard**, the available groups panel lists enabled groups that still have capacity.
-2. Click **Join** next to the group you want to join.
+1. On the **Dashboard**, open the card for the subject.
+2. Under the assignment, the list shows enabled groups that still have capacity.
+3. Click **Join** next to the group you want, or **I'm Feeling Lucky** to join a random available group.
 
 > If the group-join lock is on, a message will indicate that joining is locked. Contact your admin or AM.
 
 ### Leaving a group
 
-1. On the **Dashboard**, your current group is shown.
-2. Click **Leave Group**.
+1. On the **Dashboard**, your current group for each assignment is shown on the subject card.
+2. Click **Leave Group** next to the assignment you want to leave.
 
 > If the group-join lock is on, you cannot leave either. Contact your admin or AM.
 
 ---
 
+## Admin workflow
+
+Setting up a new teaching period follows this order:
+
+1. **Create a subject** — Subjects page → **+ Create Subject**.
+2. **Create its assignments** — open the subject and add assignments (e.g. "Assignment 1", "Project").
+3. **Create groups** — open each assignment and create or bulk-create its groups.
+4. **Enrol users** — create users or import them from CSV into the subject, or enrol existing users via **Manage
+   Subjects** on the Users page.
+5. **Assign users to groups** — let students self-join from their Dashboard, assign them manually, or import a CSV of
+   user→group mappings per assignment.
+
+Optionally, create **Assignment Manager** accounts and give them assignments to manage — they can then run steps 3–5 for
+their assignments.
+
+---
+
 ## Admin and Assignment Manager features
+
+### Managing subjects and assignments
+
+Navigate to **Subjects** (📚 Subjects & Assignments) from the **Administration** panel on the Dashboard.
+
+The Subjects page lists the subjects you can see: Admins see all subjects; Assignment Managers see subjects containing
+assignments they manage (plus subjects they belong to). Click a subject to drill into its assignments, and click an
+assignment to open its groups.
+
+#### Creating a subject (Admin only)
+
+1. On the **Subjects** page, click **+ Create Subject**.
+2. Enter the subject name (must be unique).
+3. Click **Create**.
+
+#### Creating an assignment (Admin only)
+
+1. Open the subject.
+2. Click **+ Create Assignment**.
+3. Enter the assignment name (unique within the subject).
+4. Click **Create**.
+
+#### Deleting a subject or assignment (Admin only) — typed confirmation
+
+Deleting a subject or assignment is destructive: deleting a **subject** permanently removes all of its assignments,
+their groups, and every group membership within them; deleting an **assignment** removes its groups and memberships.
+User accounts are never deleted.
+
+Because of this, deletion uses a **two-step typed confirmation**:
+
+1. Click the **Delete** (trash) icon on the subject or assignment. A warning shows what will be deleted (e.g. "3
+   assignments and 120 members will be permanently deleted").
+2. **Step 1** — type the exact name of the subject/assignment to continue.
+3. **Step 2** — type the word `delete` to confirm permanently.
+
+> There is no undo. Export group mappings first if you may need them again.
+
+---
+
+### Managing groups
+
+Groups live **inside an assignment**. Navigate to **Subjects** → open a subject → open an assignment to reach its Groups
+page.
+
+> Group create, edit, enable/disable, and delete are available to **Admins** and to **Assignment Managers who manage
+> that assignment**. AMs who do not manage the assignment can view groups but not change them.
+
+#### Creating a group
+
+1. On the assignment's Groups page, click **New Group**.
+2. Enter the group name (unique within the assignment).
+3. Optionally set a **Max Members** limit (leave blank for unlimited).
+4. Click **Create**.
+
+#### Bulk creating groups
+
+1. Click **Bulk Create**.
+2. Enter a **name prefix** (e.g. `Group`) and a **count** (e.g. `10`), and optionally a max-members limit.
+3. Groups will be named `Group 1` through `Group 10`.
+4. Click **Create**.
+
+#### Editing a group
+
+Click the **Edit** (pencil) icon on a group's row to rename it or change the max members limit.
+
+> You cannot lower `maxMembers` below the group's current member count.
+
+#### Enabling / disabling a group
+
+Click the **power** icon on a group's row. Disabled groups are hidden from the join list and cannot receive new members.
+
+#### Setting a member limit
+
+Click the **gauge** icon on a group's row (or select multiple groups and set a limit in bulk). Enter the new limit and
+confirm.
+
+#### Removing a user from a group
+
+Expand a group row to see its members. Click the **remove** icon next to a member to unassign them from the group for
+this assignment.
+
+#### Deleting groups
+
+- **Single delete** — click the **Delete** (trash) icon on a row and confirm.
+- **Bulk delete** — select groups using checkboxes, then click **Delete Selected** and confirm.
+
+Deleting a group unassigns all its members; their accounts and subject enrolments are unaffected.
+
+---
 
 ### Managing users
 
-Navigate to **Users** from the **Administration** panel on the Dashboard (or via the top navigation if visible).
+Navigate to **Users** from the **Administration** panel on the Dashboard.
+
+> **Assignment Manager scope:** AMs only see users enrolled in subjects where they manage an assignment, and can only
+> create or import users into those subjects.
 
 #### Viewing and filtering users
 
-The users table shows all accounts. Use the filter bar to narrow the list:
+The Users page groups accounts into three sections: **Administrators** (admins and AMs), **Users without a subject**,
+and **Users in subjects**. Each user row shows their subject enrolments and group memberships as
+`Subject › Assignment › Group`. Use the filter bar to narrow the list:
 
 - **Role** — filter by `Admin`, `Assignment Manager`, or `User`
 - **Status** — filter by `Active`, `Inactive`, or `Pending`
-- **Group** — filter by a specific group or `No group`
+- **Subject** — show only users enrolled in a specific subject
 - **Search** — full-text search across name, username, email, and student ID
+
+Each section has its own **Export** button to download the listed users as CSV.
 
 #### Creating a user
 
 1. Click **Add User** (top-right).
 2. Fill in the required fields (username, email, first name, last name).
-3. Optionally set student ID, group assignment, and role.
-4. Toggle **Send setup email** if you want the user to receive an account-setup email immediately (only Admins can
+3. For a regular user, select at least one **Subject** — subject enrolment is required. Optionally pick an
+   **Assignment** and **Group** for immediate group placement (the assignment must belong to a selected subject).
+4. For an **Assignment Manager**, optionally select the assignments they will manage.
+5. Toggle **Send setup email** if you want the user to receive an account-setup email immediately (only Admins can
    suppress this; Assignment Managers always send the email).
-5. Click **Create**.
+6. Click **Create**.
 
-The account is created in `pending` status. The user must set a password via the email link before logging in.
+The account is created in `pending` status. The user must set a password via the email link before logging in. If the
+optional group placement fails (e.g. the group filled up in the meantime), the user is still created and enrolled — a
+warning tells you to place them manually.
 
-> Only Admins can create Admin or Assignment Manager accounts.
+> Only Admins can create Admin or Assignment Manager accounts. AMs can only enrol new users into subjects where they
+> manage an assignment.
 >
 > If SMTP is not configured (development only), setup links are printed to the backend logs instead of being emailed. In
 > production, SMTP must be configured for emails to be delivered.
@@ -186,18 +320,28 @@ The account is created in `pending` status. The user must set a password via the
 | Student ID        | Admin, AM, the user themselves       |
 | Role              | Admin only                           |
 | Enabled           | Admin and AM (AM cannot edit admins) |
-| Group             | Admin only (via edit modal)          |
+
+Subject enrolment and group placement are managed separately — see **Manage Subjects** and **Assign Group** below.
+
+#### Managing a user's subject enrolments (Admin only)
+
+1. Click **Manage Subjects** on a user's row.
+2. Tick or untick subjects and save.
+
+> Removing a user from a subject also removes their group memberships within that subject. The modal warns you when a
+> removal affects existing memberships.
 
 #### Enabling / disabling a user
 
-Toggle the **Enabled** field in the edit modal. Disabling a user sets their status to `inactive` and prevents login.
+Toggle the **Enabled** field in the edit modal. Disabling a user sets their status to `inactive` and prevents login;
+disabled accounts are also rejected when trying to join or leave groups, even with a still-valid session.
 
 #### Deleting users
 
 - **Single delete** — click the **Delete** (trash) icon on a row and confirm.
 - **Bulk delete** — select users using the checkboxes, then click **Delete Selected** and confirm.
 
-> You cannot delete your own account.
+> You cannot delete your own account. Deleting users is Admin-only.
 
 #### Sending setup emails
 
@@ -208,69 +352,25 @@ To (re)send account-setup emails to pending users:
 
 ---
 
-### Managing groups
-
-> All group create, edit, and delete operations are **Admin only**. Assignment Managers can view groups and use the
-> import/export mappings tools, but cannot create or modify groups.
-
-Navigate to **Groups** from the **Administration** panel on the Dashboard (or via the top navigation if visible).
-
-#### Creating a group
-
-1. Click **New Group**.
-2. Enter the group name.
-3. Optionally set a **Max Members** limit (leave blank for unlimited).
-4. Click **Create**.
-
-#### Bulk creating groups
-
-1. Click **Bulk Create**.
-2. Enter a **name prefix** (e.g. `Group`) and a **count** (e.g. `10`).
-3. Groups will be named `Group 1` through `Group 10`.
-4. Click **Create**.
-
-#### Editing a group
-
-Click the **Edit** (pencil) icon on a group's row to rename it or change the max members limit.
-
-> You cannot lower `maxMembers` below the group's current member count.
-
-#### Enabling / disabling a group
-
-Click the **power** icon on a group's row. Disabled groups are hidden from the join list and cannot receive new members.
-
-#### Setting a member limit
-
-Click the **gauge** icon on a group's row. Enter the new limit and confirm.
-
-#### Removing a user from a group
-
-Expand a group row to see its members. Click the **remove** icon next to a member to unassign them.
-
-#### Deleting groups
-
-- **Single delete** — click the **Delete** (trash) icon on a row and confirm.
-- **Bulk delete** — select groups using checkboxes, then click **Delete Selected** and confirm.
-
-Deleting a group unassigns all its members.
-
----
-
 ### Assigning users to groups
+
+Remember the placement rules: the user must be enrolled in the group's **parent subject** (this applies to Admins too),
+and a user can hold only **one group per assignment** — assigning a new group for the same assignment replaces the old
+one. AMs can only place users within assignments they manage.
 
 There are three ways to assign users to groups:
 
 #### 1. From the Users page
 
-1. Select a user row by clicking the checkbox.
-2. Use the **Group** dropdown that appears and select a group.
-3. Click **Assign**.
+1. Click **Assign Group** on the user's row.
+2. In the modal, pick the **Subject → Assignment → Group** using the cascading dropdowns (only subjects the user is
+   enrolled in are offered).
+3. Save. If the user already has a group for that assignment, it is replaced.
 
-Alternatively, edit the user and set the **Group** field (Admin only via the edit modal).
+#### 2. From the assignment's Groups page
 
-#### 2. From the Groups page
-
-Expand a group row to see members. Use the user assignment controls there.
+Expand a group row to see members. Use the assignment controls there to add a subject member to the group or remove
+existing members.
 
 #### 3. CSV import (see below)
 
@@ -280,25 +380,31 @@ Expand a group row to see members. Use the user assignment controls there.
 
 #### Importing users (Users page)
 
-1. Click the **Import** (upload) icon in the toolbar.
+The user import wizard imports accounts **into a target subject** — every imported user is enrolled in that subject.
+
+1. Click the **Import** (upload) icon in the toolbar on the Users page.
 2. Upload a CSV file. Required columns: `username`, `email`, `firstName` (or `first_name`), `lastName` (or `last_name`).
    Optional: `studentId`.
 3. Review the column mapping and preview.
-4. Choose a **conflict action**:
+4. Select the **target subject** the users will be enrolled in. AMs can only choose subjects where they manage an
+   assignment.
+5. Choose a **conflict action**:
    - **Skip** — skip rows where the username already exists
-   - **Overwrite** — update existing users with the new data
-5. Toggle **Send setup email** if new users should receive setup links.
-6. Click **Import**.
+   - **Overwrite** — update existing users with the new data (and enrol them in the target subject)
+6. Toggle **Send setup email** if new users should receive setup links.
+7. Click **Import**.
 
 A results summary shows how many were imported, skipped, and any row-level errors.
 
 #### Importing group mappings (Import Group Mappings page)
 
-This wizard assigns existing users to existing groups from a CSV file.
+This wizard assigns existing users to existing groups **within one target assignment** from a CSV file.
 
 **Step 1 — Upload**
 
-1. Navigate to **Import Group Mappings** (from the Groups page toolbar or the nav menu).
+1. Navigate to **Import Mappings** from an assignment's Groups page toolbar (the target subject and assignment are
+   pre-selected), or open the wizard directly and pick the **Target Assignment** using the Subject → Assignment
+   dropdowns.
 2. Upload or drag-and-drop a CSV file.
 3. The wizard auto-detects `email` and `group name` columns. Adjust if needed.
 
@@ -306,7 +412,9 @@ This wizard assigns existing users to existing groups from a CSV file.
 
 - The wizard shows a preview of each row: user found/not found, group found/not found, and whether the assignment is
   valid.
-- Rows with issues are flagged — review them before proceeding.
+- Rows with issues are flagged — review them before proceeding. Typical skip reasons: user not found, group not found in
+  the target assignment, user not enrolled in the subject, group full, or the user is an admin/AM (they cannot be placed
+  in groups).
 
 **Step 3 — Import**
 
@@ -323,12 +431,12 @@ adoe@example.com,Group B
 ```
 
 Column headers are flexible — the wizard recognises common synonyms (`email`, `e-mail`, `user email`; `group name`,
-`group`, `team name`, etc.).
+`group`, `team name`, etc.). Group names are matched within the target assignment only.
 
-#### Exporting group mappings (Groups page)
+#### Exporting group mappings (assignment's Groups page)
 
-Click the **Export** icon in the Groups toolbar to download a CSV of all current user–group assignments. The file
-contains `email` and `group name` columns, ready to re-import after editing.
+Click **Export Mappings** in the toolbar of an assignment's Groups page to download a CSV of that assignment's current
+user–group placements. The file contains `email` and `group name` columns, ready to re-import after editing.
 
 ---
 
@@ -336,18 +444,24 @@ contains `email` and `group name` columns, ready to re-import after editing.
 
 #### Locking / unlocking group joining
 
-When group joining is **locked**, regular users cannot join or leave groups. Admins and AMs are unaffected.
+When group joining is **locked**, regular users cannot join or leave groups in any assignment. Admins and AMs are
+unaffected.
 
 To toggle the lock:
 
-1. On the **Groups** page, click the **lock/unlock** icon in the toolbar.
-2. Confirm the action.
+1. Navigate to **Settings** from the Administration panel.
+2. Toggle **Lock group joining** and confirm.
 
 Use the lock when you want to freeze assignments after a deadline (e.g. after group registration closes).
 
 ---
 
 ## Admin-only features
+
+### Subjects, assignments, and enrolments
+
+Creating, renaming, and deleting subjects and assignments, enrolling users in subjects, removing users from subjects,
+and setting which assignments an Assignment Manager manages are all Admin-only operations.
 
 ### Changing a user's role
 
@@ -366,10 +480,10 @@ This is not permitted — the built-in `admin` account cannot be disabled to pre
 To completely wipe the database and start fresh:
 
 ```bash
-cd backend && npm run migrate:reset
+pnpm --filter gap-backend migrate:reset
 ```
 
-This requires typing a confirmation phrase. In production (Docker), run:
+This requires typing a confirmation phrase in production. In production (Docker), run:
 
 ```bash
 docker compose exec backend npm run migrate:reset

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -16,4 +16,4 @@ RUN pnpm install --frozen-lockfile --filter gap-frontend
 EXPOSE 3000
 
 WORKDIR /app/frontend
-CMD ["pnpm", "run", "dev", "--", "--host", "0.0.0.0"]
+CMD ["pnpm", "run", "dev", "--host", "0.0.0.0"]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -73,11 +73,11 @@ function AppRoutes() {
         }
       />
 
-      {/* Admin/Assignment Manager Routes */}
+      {/* Admin-only Routes */}
       <Route
         path="/users"
         element={
-          <ProtectedRoute requireAssignmentManager>
+          <ProtectedRoute requireAdmin>
             <Users />
           </ProtectedRoute>
         }
@@ -85,7 +85,7 @@ function AppRoutes() {
       <Route
         path="/users/import"
         element={
-          <ProtectedRoute requireAssignmentManager>
+          <ProtectedRoute requireAdmin>
             <ImportUsers />
           </ProtectedRoute>
         }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,8 @@ import ImportUsers from './pages/ImportUsers.jsx';
 import Groups from './pages/Groups.jsx';
 import ImportGroupMappings from './pages/ImportGroupMappings.jsx';
 import Settings from './pages/Settings.jsx';
+import Subjects from './pages/Subjects.jsx';
+import SubjectDetail from './pages/SubjectDetail.jsx';
 
 function PublicRoute({ children }) {
   const { user } = useAuth();
@@ -89,15 +91,34 @@ function AppRoutes() {
         }
       />
 
-      {/* Admin Only Routes */}
+      {/* Subject / Assignment hierarchy */}
       <Route
-        path="/groups"
+        path="/subjects"
         element={
-          <ProtectedRoute requireAdmin>
+          <ProtectedRoute requireAssignmentManager>
+            <Subjects />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/subjects/:subjectId"
+        element={
+          <ProtectedRoute requireAssignmentManager>
+            <SubjectDetail />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/subjects/:subjectId/assignments/:assignmentId"
+        element={
+          <ProtectedRoute requireAssignmentManager>
             <Groups />
           </ProtectedRoute>
         }
       />
+
+      {/* Legacy groups routes — keep bookmark compatibility */}
+      <Route path="/groups" element={<Navigate to="/subjects" replace />} />
       <Route
         path="/groups/import"
         element={

--- a/frontend/src/components/AssignGroupModal.jsx
+++ b/frontend/src/components/AssignGroupModal.jsx
@@ -41,7 +41,7 @@ function AssignGroupModal({ user, subjects, onClose, onAssigned }) {
   const handleRemove = () => submitGroupChange(null);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Assign Group — {user.username}</h3>
         {error && (

--- a/frontend/src/components/AssignGroupModal.jsx
+++ b/frontend/src/components/AssignGroupModal.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import api from '@/utils/api';
+import CascadingAssignmentSelect from './CascadingAssignmentSelect.jsx';
+import { API_BASE } from '../config.js';
+
+/**
+ * Modal for assigning a user to a group within a subject/assignment, or
+ * removing them from their current group for the selected assignment.
+ * A user may only be placed in groups of subjects they belong to, so the
+ * cascade offers only the target user's subjects.
+ */
+function AssignGroupModal({ user, subjects, onClose, onAssigned }) {
+  const [selection, setSelection] = useState({ subjectId: '', assignmentId: '', groupId: '' });
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const membershipSubjectIds = new Set((user.memberships || []).map((m) => m.subject_id).filter(Boolean));
+  const availableSubjects = user.subjects || (subjects || []).filter((s) => membershipSubjectIds.has(s.id));
+
+  const hasMembershipForAssignment =
+    selection.assignmentId && (user.memberships || []).some((m) => m.assignment_id === selection.assignmentId);
+
+  const submitGroupChange = async (groupId) => {
+    setError('');
+    setSaving(true);
+    try {
+      await api.put(`${API_BASE}/users/${user.id}/group`, {
+        assignmentId: selection.assignmentId,
+        groupId,
+      });
+      onAssigned();
+      onClose();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to update group');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAssign = () => submitGroupChange(selection.groupId);
+  const handleRemove = () => submitGroupChange(null);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Assign Group — {user.username}</h3>
+        {error && (
+          <div className="mb-3 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">{error}</div>
+        )}
+        <CascadingAssignmentSelect
+          subjects={availableSubjects}
+          value={selection}
+          onChange={setSelection}
+          disabled={saving}
+        />
+        {hasMembershipForAssignment && (
+          <button
+            type="button"
+            onClick={handleRemove}
+            disabled={saving}
+            className="mb-3 px-4 py-2 text-sm text-red-600 border border-red-300 rounded-md hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Remove from group
+          </button>
+        )}
+        <div className="flex justify-end space-x-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleAssign}
+            disabled={saving || !selection.subjectId || !selection.assignmentId || !selection.groupId}
+            className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Assigning...' : 'Assign'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AssignGroupModal;

--- a/frontend/src/components/CascadingAssignmentSelect.jsx
+++ b/frontend/src/components/CascadingAssignmentSelect.jsx
@@ -1,0 +1,158 @@
+import { useState, useEffect, useRef, useId } from 'react';
+import api from '@/utils/api';
+import { API_BASE } from '../config.js';
+
+const SELECT_CLASS =
+  'w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500';
+
+/**
+ * Cascading Subject -> Assignment -> Group selects.
+ * Fetches assignments for the selected subject and groups for the selected
+ * assignment, caching responses per id so re-selecting doesn't refetch.
+ */
+function CascadingAssignmentSelect({ subjects, value, onChange, showGroup = true, disabled = false, labels = {} }) {
+  const [assignments, setAssignments] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [error, setError] = useState('');
+  const assignmentsCacheRef = useRef(new Map());
+  const groupsCacheRef = useRef(new Map());
+  const idPrefix = useId();
+
+  const subjectLabel = labels.subject || 'Subject';
+  const assignmentLabel = labels.assignment || 'Assignment';
+  const groupLabel = labels.group || 'Group';
+
+  useEffect(() => {
+    if (!value.subjectId) {
+      setAssignments([]);
+      return undefined;
+    }
+    const cached = assignmentsCacheRef.current.get(value.subjectId);
+    if (cached) {
+      setAssignments(cached);
+      return undefined;
+    }
+    let cancelled = false;
+    setError('');
+    api
+      .get(`${API_BASE}/subjects/${value.subjectId}`)
+      .then((res) => {
+        const fetched = res.data.assignments || [];
+        assignmentsCacheRef.current.set(value.subjectId, fetched);
+        if (!cancelled) {
+          setAssignments(fetched);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAssignments([]);
+          setError('Failed to load options');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.subjectId]);
+
+  useEffect(() => {
+    if (!value.assignmentId || !showGroup) {
+      setGroups([]);
+      return undefined;
+    }
+    const cached = groupsCacheRef.current.get(value.assignmentId);
+    if (cached) {
+      setGroups(cached);
+      return undefined;
+    }
+    let cancelled = false;
+    setError('');
+    api
+      .get(`${API_BASE}/assignments/${value.assignmentId}/groups`)
+      .then((res) => {
+        const fetched = res.data.groups || [];
+        groupsCacheRef.current.set(value.assignmentId, fetched);
+        if (!cancelled) {
+          setGroups(fetched);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setGroups([]);
+          setError('Failed to load options');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.assignmentId, showGroup]);
+
+  const groupOptionLabel = (group) =>
+    group.max_members ? `${group.name} (${group.member_count}/${group.max_members})` : group.name;
+
+  return (
+    <div>
+      <div className="mb-3">
+        <label htmlFor={`${idPrefix}-subject`} className="block text-sm font-medium text-gray-700 mb-1">
+          {subjectLabel}
+        </label>
+        <select
+          id={`${idPrefix}-subject`}
+          value={value.subjectId}
+          onChange={(e) => onChange({ subjectId: e.target.value, assignmentId: '', groupId: '' })}
+          disabled={disabled}
+          className={SELECT_CLASS}
+        >
+          <option value="">Select subject</option>
+          {subjects.map((subject) => (
+            <option key={subject.id} value={subject.id}>
+              {subject.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
+        <label htmlFor={`${idPrefix}-assignment`} className="block text-sm font-medium text-gray-700 mb-1">
+          {assignmentLabel}
+        </label>
+        <select
+          id={`${idPrefix}-assignment`}
+          value={value.assignmentId}
+          onChange={(e) => onChange({ ...value, assignmentId: e.target.value, groupId: '' })}
+          disabled={disabled || !value.subjectId}
+          className={SELECT_CLASS}
+        >
+          <option value="">Select assignment</option>
+          {assignments.map((assignment) => (
+            <option key={assignment.id} value={assignment.id}>
+              {assignment.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {showGroup && (
+        <div className="mb-3">
+          <label htmlFor={`${idPrefix}-group`} className="block text-sm font-medium text-gray-700 mb-1">
+            {groupLabel}
+          </label>
+          <select
+            id={`${idPrefix}-group`}
+            value={value.groupId}
+            onChange={(e) => onChange({ ...value, groupId: e.target.value })}
+            disabled={disabled || !value.assignmentId}
+            className={SELECT_CLASS}
+          >
+            <option value="">Select group</option>
+            {groups.map((group) => (
+              <option key={group.id} value={group.id}>
+                {groupOptionLabel(group)}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}
+
+export default CascadingAssignmentSelect;

--- a/frontend/src/components/IconBtn.jsx
+++ b/frontend/src/components/IconBtn.jsx
@@ -1,0 +1,19 @@
+function IconBtn({ onClick, label, className, children }) {
+  return (
+    <div className="relative group/tip">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        className={`p-1.5 rounded transition-colors ${className}`}
+      >
+        {children}
+      </button>
+      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover/tip:opacity-100 transition-opacity z-20">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default IconBtn;

--- a/frontend/src/components/SubjectMembersSection.jsx
+++ b/frontend/src/components/SubjectMembersSection.jsx
@@ -1,0 +1,564 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import api from '@/utils/api';
+import { UserPlus, Mail, Ban, RotateCcw } from 'lucide-react';
+import IconBtn from './IconBtn.jsx';
+import AssignGroupModal from './AssignGroupModal.jsx';
+import { parseBody, createUserSchema } from '../utils/schemas.js';
+import { API_BASE } from '../config.js';
+
+const emptyNewUser = { username: '', email: '', firstName: '', lastName: '', studentId: '' };
+
+const SUSPEND_WARNING =
+  'Suspending removes their group memberships in this subject. Re-enabling will NOT restore groups.';
+
+/**
+ * "Members" section for the subject detail page.
+ * Lists the subject's members with per-subject suspension controls, group
+ * assignment, setup emails, and (for managers) user creation. Admins can also
+ * enrol existing users. All actions are gated by `canManage` (admin or an
+ * assignment manager managing an assignment in this subject).
+ */
+function SubjectMembersSection({ subject, isAdmin, canManage }) {
+  const [members, setMembers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Suspend confirmation modal — holds the member to suspend
+  const [suspendModal, setSuspendModal] = useState(null);
+  const [suspending, setSuspending] = useState(false);
+
+  // Assign group modal — holds the member to assign
+  const [assignModalUser, setAssignModalUser] = useState(null);
+
+  // Create user modal
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newUser, setNewUser] = useState({ ...emptyNewUser });
+  const [formError, setFormError] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  // Add existing user modal (admin only)
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [allUsers, setAllUsers] = useState([]);
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [addError, setAddError] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  const successTimeoutRef = useRef(null);
+  const errorTimeoutRef = useRef(null);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      const response = await api.get(`${API_BASE}/subjects/${subject.id}/users`);
+      setMembers(response.data.users || []);
+      setLoadError('');
+    } catch (err) {
+      setLoadError(err.response?.data?.error || 'Failed to load members');
+    } finally {
+      setLoading(false);
+    }
+  }, [subject.id]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const showSuccess = (msg) => {
+    if (successTimeoutRef.current) {
+      clearTimeout(successTimeoutRef.current);
+    }
+    setSuccess(msg);
+    successTimeoutRef.current = setTimeout(() => setSuccess(''), 2000);
+  };
+
+  const showError = (msg) => {
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+    }
+    setError(msg);
+    errorTimeoutRef.current = setTimeout(() => setError(''), 3000);
+  };
+
+  const setMembershipEnabled = async (memberId, enabled) => {
+    await api.put(`${API_BASE}/subjects/${subject.id}/users/${memberId}`, { enabled });
+  };
+
+  const handleSuspendConfirmed = async () => {
+    setSuspending(true);
+    try {
+      await setMembershipEnabled(suspendModal.id, false);
+      showSuccess('Member suspended');
+      fetchMembers();
+    } catch (err) {
+      showError(err.response?.data?.error || 'Failed to suspend member');
+    } finally {
+      setSuspending(false);
+      setSuspendModal(null);
+    }
+  };
+
+  const handleEnable = async (member) => {
+    try {
+      await setMembershipEnabled(member.id, true);
+      showSuccess('Member enabled');
+      fetchMembers();
+    } catch (err) {
+      showError(err.response?.data?.error || 'Failed to enable member');
+    }
+  };
+
+  const handleSendSetupEmail = async (member) => {
+    try {
+      await api.post(`${API_BASE}/users/send-setup-emails`, { userIds: [member.id] });
+      showSuccess('Setup email sent');
+    } catch (err) {
+      showError(err.response?.data?.error || 'Failed to send setup email');
+    }
+  };
+
+  const handleCreateUser = async (e) => {
+    e.preventDefault();
+    setFormError('');
+    const { data: body, error: validationError } = parseBody(createUserSchema, {
+      username: newUser.username,
+      email: newUser.email,
+      firstName: newUser.firstName,
+      lastName: newUser.lastName,
+      studentId: newUser.studentId,
+      role: 'user',
+      subjectIds: [subject.id],
+    });
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+    setCreating(true);
+    try {
+      await api.post(`${API_BASE}/users`, {
+        username: body.username,
+        email: body.email,
+        firstName: body.firstName,
+        lastName: body.lastName,
+        studentId: body.studentId || undefined,
+        role: 'user',
+        subjectIds: [subject.id],
+      });
+      showSuccess('User created successfully');
+      setNewUser({ ...emptyNewUser });
+      setShowCreateModal(false);
+      fetchMembers();
+    } catch (err) {
+      setFormError(err.response?.data?.error || 'Failed to create user');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openAddModal = async () => {
+    setAddError('');
+    setSelectedUserId('');
+    setAllUsers([]);
+    setShowAddModal(true);
+    try {
+      const response = await api.get(`${API_BASE}/users`);
+      setAllUsers(response.data.users || []);
+    } catch (err) {
+      setAddError(err.response?.data?.error || 'Failed to load users');
+    }
+  };
+
+  const handleAddExisting = async (e) => {
+    e.preventDefault();
+    setAddError('');
+    setAdding(true);
+    try {
+      await api.post(`${API_BASE}/subjects/${subject.id}/users`, { userIds: [selectedUserId] });
+      showSuccess('User added to subject');
+      setShowAddModal(false);
+      fetchMembers();
+    } catch (err) {
+      setAddError(err.response?.data?.error || 'Failed to add user');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const memberIds = new Set(members.map((m) => m.id));
+  const addCandidates = allUsers.filter((u) => u.role_name === 'user' && !memberIds.has(u.id));
+
+  const renderStatusBadges = (member) => (
+    <div className="flex items-center gap-1">
+      <span
+        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full whitespace-nowrap ${
+          member.status === 'pending' ? 'bg-yellow-100 text-yellow-800' : 'bg-green-100 text-green-800'
+        }`}
+      >
+        {member.status === 'pending' ? 'Pending' : 'Active'}
+      </span>
+      {member.membership_enabled === false && (
+        <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full whitespace-nowrap bg-gray-100 text-gray-800">
+          Suspended
+        </span>
+      )}
+    </div>
+  );
+
+  const renderRowActions = (member) => {
+    if (!canManage || member.role_name !== 'user') {
+      return null;
+    }
+    return (
+      <div className="flex items-center gap-0.5">
+        {member.membership_enabled === false ? (
+          <IconBtn
+            label="Enable Member"
+            onClick={() => handleEnable(member)}
+            className="text-gray-500 hover:text-green-600 hover:bg-green-50"
+          >
+            <RotateCcw className="h-4 w-4" />
+          </IconBtn>
+        ) : (
+          <IconBtn
+            label="Suspend Member"
+            onClick={() => setSuspendModal(member)}
+            className="text-gray-500 hover:text-red-600 hover:bg-red-50"
+          >
+            <Ban className="h-4 w-4" />
+          </IconBtn>
+        )}
+        <IconBtn
+          label="Assign Group"
+          onClick={() => setAssignModalUser({ ...member, subjects: [subject], memberships: member.memberships || [] })}
+          className="text-gray-500 hover:text-primary-600 hover:bg-primary-50"
+        >
+          <UserPlus className="h-4 w-4" />
+        </IconBtn>
+        {member.status === 'pending' && (
+          <IconBtn
+            label="Send Setup Email"
+            onClick={() => handleSendSetupEmail(member)}
+            className="text-gray-500 hover:text-primary-600 hover:bg-primary-50"
+          >
+            <Mail className="h-4 w-4" />
+          </IconBtn>
+        )}
+      </div>
+    );
+  };
+
+  const renderBody = () => {
+    if (loading) {
+      return (
+        <div className="flex justify-center py-12">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600" />
+        </div>
+      );
+    }
+    if (loadError) {
+      return (
+        <div className="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">{loadError}</div>
+      );
+    }
+    if (members.length === 0) {
+      return (
+        <div className="text-center py-12 bg-white rounded-lg shadow">
+          <p className="text-gray-500">No members yet</p>
+        </div>
+      );
+    }
+    return (
+      <div className="bg-white shadow overflow-x-auto rounded-lg">
+        <table className="w-full min-w-[680px] divide-y divide-gray-200 table-fixed">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="w-[22%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="w-[20%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Username
+              </th>
+              <th className="w-[26%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="w-[16%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Status
+              </th>
+              <th className="w-[16%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {members.map((member) => (
+              <tr key={member.id}>
+                <td className="px-4 py-4 overflow-hidden">
+                  <div
+                    className="text-sm text-gray-900 truncate"
+                    title={`${member.first_name || ''} ${member.last_name || ''}`.trim()}
+                  >
+                    {`${member.first_name || ''} ${member.last_name || ''}`.trim()}
+                  </div>
+                </td>
+                <td className="px-4 py-4 overflow-hidden">
+                  <div className="text-sm font-medium text-gray-900 truncate" title={member.username}>
+                    {member.username}
+                  </div>
+                  {member.student_id && (
+                    <div className="text-sm text-gray-500 truncate" title={member.student_id}>
+                      {member.student_id}
+                    </div>
+                  )}
+                </td>
+                <td className="px-4 py-4 overflow-hidden">
+                  <div className="text-sm text-gray-900 truncate" title={member.email}>
+                    {member.email}
+                  </div>
+                </td>
+                <td className="px-4 py-4">{renderStatusBadges(member)}</td>
+                <td className="px-4 py-4">{renderRowActions(member)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  return (
+    <div className="mt-10">
+      <div className="mb-4 flex justify-between items-center">
+        <div>
+          <h3 className="text-xl font-bold text-gray-900">Members</h3>
+          <p className="text-gray-600 mt-1">Users enrolled in this subject</p>
+        </div>
+        {canManage && (
+          <div className="flex items-center gap-2">
+            {isAdmin && (
+              <button
+                onClick={openAddModal}
+                className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                + Add Existing User
+              </button>
+            )}
+            <button
+              onClick={() => {
+                setFormError('');
+                setNewUser({ ...emptyNewUser });
+                setShowCreateModal(true);
+              }}
+              className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
+            >
+              + Create User
+            </button>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">{error}</div>
+      )}
+      {success && (
+        <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-md text-sm">
+          {success}
+        </div>
+      )}
+
+      {renderBody()}
+
+      {/* Suspend Confirmation Modal */}
+      {suspendModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+            <h3 className="text-lg font-semibold text-gray-900 mb-3">Suspend {suspendModal.username}?</h3>
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-md px-3 py-2 text-sm text-yellow-800">
+              {SUSPEND_WARNING}
+            </div>
+            <div className="flex justify-end space-x-3">
+              <button
+                type="button"
+                onClick={() => setSuspendModal(null)}
+                className="px-4 py-2 text-gray-700 hover:text-gray-900"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSuspendConfirmed}
+                disabled={suspending}
+                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {suspending ? 'Suspending...' : 'Suspend'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Assign Group Modal */}
+      {assignModalUser && (
+        <AssignGroupModal
+          user={assignModalUser}
+          subjects={[subject]}
+          onClose={() => setAssignModalUser(null)}
+          onAssigned={() => {
+            showSuccess('User group updated successfully');
+            fetchMembers();
+          }}
+        />
+      )}
+
+      {/* Create User Modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New User</h3>
+            <form onSubmit={handleCreateUser}>
+              {formError && (
+                <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+                  {formError}
+                </div>
+              )}
+              <div className="mb-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Username <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={newUser.username}
+                  onChange={(e) => setNewUser({ ...newUser, username: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter username"
+                />
+              </div>
+              <div className="mb-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="email"
+                  required
+                  value={newUser.email}
+                  onChange={(e) => setNewUser({ ...newUser, email: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter email"
+                />
+              </div>
+              <div className="mb-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  First Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={newUser.firstName}
+                  onChange={(e) => setNewUser({ ...newUser, firstName: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter first name"
+                />
+              </div>
+              <div className="mb-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Last Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={newUser.lastName}
+                  onChange={(e) => setNewUser({ ...newUser, lastName: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter last name"
+                />
+              </div>
+              <div className="mb-3">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Student ID (Optional)</label>
+                <input
+                  type="text"
+                  value={newUser.studentId}
+                  onChange={(e) => setNewUser({ ...newUser, studentId: e.target.value })}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter student ID"
+                />
+              </div>
+              <div className="mb-3 text-sm text-gray-500 bg-blue-50 border border-blue-200 rounded-md px-3 py-2">
+                The user will be enrolled in {subject.name}. Use Assign Group afterwards to place them in a group.
+              </div>
+              <div className="flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCreateModal(false);
+                    setNewUser({ ...emptyNewUser });
+                  }}
+                  className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={creating}
+                  className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {creating ? 'Creating...' : 'Create'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Add Existing User Modal (admin only) */}
+      {showAddModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Add Existing User</h3>
+            <form onSubmit={handleAddExisting}>
+              {addError && (
+                <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+                  {addError}
+                </div>
+              )}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">User</label>
+                <select
+                  aria-label="Select user"
+                  value={selectedUserId}
+                  onChange={(e) => setSelectedUserId(e.target.value)}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                >
+                  <option value="">Select user</option>
+                  {addCandidates.map((u) => (
+                    <option key={u.id} value={u.id}>
+                      {u.username} ({u.email})
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => setShowAddModal(false)}
+                  className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={adding || !selectedUserId}
+                  className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {adding ? 'Adding...' : 'Add'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SubjectMembersSection;

--- a/frontend/src/components/SubjectMembershipModal.jsx
+++ b/frontend/src/components/SubjectMembershipModal.jsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import api from '@/utils/api';
+import { API_BASE } from '../config.js';
+
+/**
+ * Modal for managing which subjects a user belongs to.
+ * Shows a checkbox per subject (pre-checked for current subjects). On save it
+ * diffs against the original enrolment and issues POST /subjects/:id/users for
+ * additions and DELETE /subjects/:id/users/:userId for removals.
+ */
+function SubjectMembershipModal({ user, subjects, onClose, onChanged }) {
+  const originalIds = new Set((user.subjects || []).map((s) => s.id));
+  const [selectedIds, setSelectedIds] = useState(() => new Set(originalIds));
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const additions = (subjects || []).map((s) => s.id).filter((id) => selectedIds.has(id) && !originalIds.has(id));
+  const removals = [...originalIds].filter((id) => !selectedIds.has(id));
+
+  const membershipSubjectIds = new Set((user.memberships || []).map((m) => m.subject_id).filter(Boolean));
+  const removalAffectsMemberships = removals.some((id) => membershipSubjectIds.has(id));
+
+  const toggle = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (additions.length === 0 && removals.length === 0) {
+      onClose();
+      return;
+    }
+    setError('');
+    setSaving(true);
+    try {
+      for (const id of additions) {
+        await api.post(`${API_BASE}/subjects/${id}/users`, { userIds: [user.id] });
+      }
+      for (const id of removals) {
+        await api.delete(`${API_BASE}/subjects/${id}/users/${user.id}`);
+      }
+      onChanged();
+      onClose();
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to update subjects');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Manage Subjects — {user.username}</h3>
+        {error && (
+          <div className="mb-3 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">{error}</div>
+        )}
+        <div className="mb-3 space-y-2">
+          {(subjects || []).map((subject) => (
+            <label key={subject.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selectedIds.has(subject.id)}
+                onChange={() => toggle(subject.id)}
+                disabled={saving}
+                className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <span className="text-sm text-gray-700">{subject.name}</span>
+            </label>
+          ))}
+          {(subjects || []).length === 0 && <p className="text-sm text-gray-500">No subjects available.</p>}
+        </div>
+        {removalAffectsMemberships && (
+          <div className="mb-3 bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-md text-sm">
+            {"Removing a subject also removes the user's group memberships in it."}
+          </div>
+        )}
+        <div className="flex justify-end space-x-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 text-gray-700 hover:text-gray-900"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SubjectMembershipModal;

--- a/frontend/src/components/SubjectMembershipModal.jsx
+++ b/frontend/src/components/SubjectMembershipModal.jsx
@@ -56,7 +56,7 @@ function SubjectMembershipModal({ user, subjects, onClose, onChanged }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
         <h3 className="text-lg font-semibold text-gray-900 mb-4">Manage Subjects — {user.username}</h3>
         {error && (

--- a/frontend/src/components/TypedDeleteConfirmModal.jsx
+++ b/frontend/src/components/TypedDeleteConfirmModal.jsx
@@ -15,7 +15,7 @@ function TypedDeleteConfirmModal({ entityLabel, entityName, warning = null, dele
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg p-6 w-full max-w-md">
         <h3 className="text-lg font-semibold text-gray-900 mb-3">Delete {entityLabel}</h3>
         {step === 1 ? (

--- a/frontend/src/components/TypedDeleteConfirmModal.jsx
+++ b/frontend/src/components/TypedDeleteConfirmModal.jsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+/**
+ * Two-step typed confirmation modal for destructive deletes.
+ * Step 1: the user must type the entity name exactly to continue.
+ * Step 2: the user must type the word "delete" to confirm permanently.
+ */
+function TypedDeleteConfirmModal({ entityLabel, entityName, warning = null, deleting = false, onConfirm, onCancel }) {
+  const [step, setStep] = useState(1);
+  const [input, setInput] = useState('');
+
+  const handleContinue = () => {
+    setStep(2);
+    setInput('');
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md">
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">Delete {entityLabel}</h3>
+        {step === 1 ? (
+          <>
+            {warning && (
+              <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-md px-3 py-2 text-sm text-yellow-800">
+                {warning}
+              </div>
+            )}
+            <p className="text-sm text-gray-600 mb-3">
+              To continue, type <span className="font-semibold text-gray-900">{entityName}</span> below.
+            </p>
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              aria-label="Confirmation name"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
+              placeholder={entityName}
+            />
+            <div className="flex justify-end space-x-3">
+              <button type="button" onClick={onCancel} className="px-4 py-2 text-gray-700 hover:text-gray-900">
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleContinue}
+                disabled={input !== entityName}
+                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Continue
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-gray-600 mb-3">
+              This action cannot be undone. To permanently delete, type{' '}
+              <span className="font-semibold text-gray-900">delete</span> below.
+            </p>
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              aria-label="Confirmation word"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500 mb-4"
+              placeholder="delete"
+            />
+            <div className="flex justify-end space-x-3">
+              <button type="button" onClick={onCancel} className="px-4 py-2 text-gray-700 hover:text-gray-900">
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={input !== 'delete' || deleting}
+                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {deleting ? 'Deleting...' : 'Delete'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default TypedDeleteConfirmModal;

--- a/frontend/src/components/UserMenu.jsx
+++ b/frontend/src/components/UserMenu.jsx
@@ -181,7 +181,7 @@ function UserMenu() {
 
       {/* Edit Profile Modal */}
       {modal === 'editProfile' && profileForm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 w-full max-w-md">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Edit Profile</h3>
             {profileSuccess && (
@@ -278,7 +278,7 @@ function UserMenu() {
 
       {/* Change Password Modal */}
       {modal === 'changePassword' && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 w-full max-w-md">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Change Password</h3>
             {passwordSuccess && (

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -4,11 +4,14 @@ import { API_BASE } from '../config.js';
 
 const AuthContext = createContext(null);
 
+const CURRENT_SUBJECT_KEY = 'gap.currentSubject';
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState(localStorage.getItem('token'));
   const [registrationEnabled, setRegistrationEnabled] = useState(false);
+  const [currentSubjectId, setCurrentSubjectId] = useState(() => sessionStorage.getItem(CURRENT_SUBJECT_KEY));
 
   // Fetch server config on mount
   useEffect(() => {
@@ -41,6 +44,35 @@ export function AuthProvider({ children }) {
 
     checkAuth();
   }, [token]);
+
+  // Validate the current subject selection whenever the user changes:
+  // auto-select the only subject, and drop a stored id that no longer exists.
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+    const subjects = user.subjects ?? [];
+    if (subjects.length === 1) {
+      if (currentSubjectId !== subjects[0].id) {
+        setCurrentSubjectId(subjects[0].id);
+        sessionStorage.setItem(CURRENT_SUBJECT_KEY, subjects[0].id);
+      }
+      return;
+    }
+    if (currentSubjectId !== null && !subjects.some((subject) => subject.id === currentSubjectId)) {
+      setCurrentSubjectId(null);
+      sessionStorage.removeItem(CURRENT_SUBJECT_KEY);
+    }
+  }, [user, currentSubjectId]);
+
+  const setCurrentSubject = (id) => {
+    setCurrentSubjectId(id);
+    if (id === null || id === undefined) {
+      sessionStorage.removeItem(CURRENT_SUBJECT_KEY);
+    } else {
+      sessionStorage.setItem(CURRENT_SUBJECT_KEY, id);
+    }
+  };
 
   const login = async (username, password) => {
     try {
@@ -92,8 +124,11 @@ export function AuthProvider({ children }) {
       // Ignore errors on logout
     } finally {
       localStorage.removeItem('token');
+      // Clear the remembered subject so it can't leak to the next user in this tab
+      sessionStorage.removeItem(CURRENT_SUBJECT_KEY);
       setToken(null);
       setUser(null);
+      setCurrentSubjectId(null);
     }
   };
 
@@ -123,6 +158,8 @@ export function AuthProvider({ children }) {
     registrationEnabled,
     memberships: user?.memberships ?? [],
     managedAssignmentIds: (user?.managedAssignments ?? []).map((a) => a.id),
+    currentSubjectId,
+    setCurrentSubject,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -121,6 +121,8 @@ export function AuthProvider({ children }) {
     isAdmin: user?.role === 'admin',
     isAssignmentManager: user?.role === 'assignment_manager' || user?.role === 'admin',
     registrationEnabled,
+    memberships: user?.memberships ?? [],
+    managedAssignmentIds: (user?.managedAssignments ?? []).map((a) => a.id),
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/design-system.js
+++ b/frontend/src/design-system.js
@@ -1,0 +1,11 @@
+// Design-system entry for the claude.ai/design sync (.design-sync/config.json).
+// Exports the reusable presentational components; app plumbing (ProtectedRoute,
+// ErrorBoundary, Header, UserMenu) is deliberately excluded.
+export { default as IconBtn } from './components/IconBtn.jsx';
+export { default as IndeterminateCheckbox } from './components/IndeterminateCheckbox.jsx';
+export { default as TypedDeleteConfirmModal } from './components/TypedDeleteConfirmModal.jsx';
+export { default as CsvDropzone } from './components/CsvDropzone.jsx';
+export { default as Footer } from './components/Footer.jsx';
+export { default as CascadingAssignmentSelect } from './components/CascadingAssignmentSelect.jsx';
+export { default as AssignGroupModal } from './components/AssignGroupModal.jsx';
+export { default as SubjectMembershipModal } from './components/SubjectMembershipModal.jsx';

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import api from '@/utils/api';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
@@ -6,28 +6,54 @@ import { Link } from 'react-router-dom';
 import { formatRoleName } from '../utils/formatting.js';
 import { API_BASE } from '../config.js';
 
+const LOCKED_MESSAGE = 'Group joining is locked. Please contact the teaching staff to join or leave a group.';
+
+function Spinner() {
+  return (
+    <div className="flex justify-center py-4">
+      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
+    </div>
+  );
+}
+
+function MemberList({ loading, members, currentUserId }) {
+  if (loading) {
+    return <Spinner />;
+  }
+  if (members.length === 0) {
+    return <p className="text-sm text-gray-500 py-2">No members yet</p>;
+  }
+  return (
+    <ul className="divide-y divide-gray-100 border border-gray-100 rounded-md">
+      {members.map((member) => (
+        <li key={member.id} className="flex items-center gap-3 px-4 py-2">
+          <div className="min-w-0 flex-1">
+            <span className="text-sm font-medium text-gray-900">
+              {member.first_name && member.last_name
+                ? `${member.first_name.charAt(0)}. ${member.last_name}`
+                : member.username}
+            </span>
+            {member.id === currentUserId && <span className="ml-2 text-xs text-primary-600 font-medium">(you)</span>}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function Dashboard() {
-  const { user, isAdmin, isAssignmentManager, refreshUser } = useAuth();
-  const [availableGroups, setAvailableGroups] = useState([]);
-  const [groupsLoading, setGroupsLoading] = useState(false);
+  const { user, isAdmin, isAssignmentManager, refreshUser, memberships = [] } = useAuth();
+  const [subjectData, setSubjectData] = useState(new Map()); // subjectId -> { loading, error, assignments }
+  const [assignmentGroups, setAssignmentGroups] = useState(new Map()); // assignmentId -> { loading, error, groups }
+  const [expandedAssignments, setExpandedAssignments] = useState(new Map()); // assignmentId -> boolean
+  const [groupMembers, setGroupMembers] = useState(new Map()); // groupId -> { loading, members }
   const [groupError, setGroupError] = useState('');
   const [groupSuccess, setGroupSuccess] = useState('');
-  const [groupMembers, setGroupMembers] = useState([]);
-  const [membersLoading, setMembersLoading] = useState(false);
   const [joiningGroup, setJoiningGroup] = useState(false);
   const [leavingGroup, setLeavingGroup] = useState(false);
   const [groupJoinLocked, setGroupJoinLocked] = useState(false);
   const isNormalUser = !isAdmin && !isAssignmentManager;
-
-  useEffect(() => {
-    if (isNormalUser && !user?.groupId) {
-      fetchAvailableGroups();
-      setGroupMembers([]);
-    }
-    if (isNormalUser && user?.groupId) {
-      fetchGroupMembers(user.groupId);
-    }
-  }, [isNormalUser, user?.groupId]);
+  const subjects = useMemo(() => user?.subjects ?? [], [user]);
 
   useEffect(() => {
     if (isNormalUser) {
@@ -42,32 +68,84 @@ function Dashboard() {
     }
   }, [isNormalUser]);
 
-  const fetchGroupMembers = async (groupId) => {
-    setMembersLoading(true);
-    setGroupMembers([]);
+  const fetchSubject = useCallback(async (subjectId) => {
+    setSubjectData((prev) => new Map(prev).set(subjectId, { loading: true, error: '', assignments: [] }));
+    try {
+      const response = await api.get(`${API_BASE}/subjects/${subjectId}`);
+      setSubjectData((prev) =>
+        new Map(prev).set(subjectId, {
+          loading: false,
+          error: '',
+          assignments: response.data.assignments || [],
+        })
+      );
+    } catch (_err) {
+      setSubjectData((prev) =>
+        new Map(prev).set(subjectId, {
+          loading: false,
+          error: 'Failed to load subject details',
+          assignments: [],
+        })
+      );
+    }
+  }, []);
+
+  const fetchAssignmentGroups = useCallback(async (assignmentId) => {
+    setAssignmentGroups((prev) => new Map(prev).set(assignmentId, { loading: true, error: '', groups: [] }));
+    try {
+      const response = await api.get(`${API_BASE}/assignments/${assignmentId}/groups?enabled=true`);
+      const groups = (response.data.groups || []).filter(
+        (g) => g.max_members === null || g.max_members === undefined || g.member_count < g.max_members
+      );
+      setAssignmentGroups((prev) => new Map(prev).set(assignmentId, { loading: false, error: '', groups }));
+    } catch (_err) {
+      setAssignmentGroups((prev) =>
+        new Map(prev).set(assignmentId, {
+          loading: false,
+          error: 'Failed to load available groups',
+          groups: [],
+        })
+      );
+    }
+  }, []);
+
+  const fetchGroupMembers = useCallback(async (groupId) => {
+    setGroupMembers((prev) => new Map(prev).set(groupId, { loading: true, members: [] }));
     try {
       const response = await api.get(`${API_BASE}/groups/${groupId}`);
-      setGroupMembers(response.data.members || []);
+      setGroupMembers((prev) => new Map(prev).set(groupId, { loading: false, members: response.data.members || [] }));
     } catch (_err) {
       // silently ignore — members list is supplementary info
-    } finally {
-      setMembersLoading(false);
+      setGroupMembers((prev) => new Map(prev).set(groupId, { loading: false, members: [] }));
     }
-  };
+  }, []);
 
-  const fetchAvailableGroups = async () => {
-    setGroupsLoading(true);
-    try {
-      const response = await api.get(`${API_BASE}/groups/enabled`);
-      const groups = response.data.groups || [];
-      setAvailableGroups(groups.filter((g) => g.max_members === null || g.member_count < g.max_members));
-    } catch (_err) {
-      setGroupError('Failed to load available groups');
-      setTimeout(() => setGroupError(''), 3000);
-    } finally {
-      setGroupsLoading(false);
+  // Fetch each subject's assignments once
+  useEffect(() => {
+    if (!isNormalUser) {
+      return;
     }
-  };
+    subjects.forEach((subject) => {
+      if (!subjectData.has(subject.id)) {
+        fetchSubject(subject.id);
+      }
+    });
+  }, [isNormalUser, subjects, subjectData, fetchSubject]);
+
+  // Fetch joinable groups for assignments the user has no membership in
+  useEffect(() => {
+    if (!isNormalUser) {
+      return;
+    }
+    subjectData.forEach((data) => {
+      data.assignments.forEach((assignment) => {
+        const hasMembership = memberships.some((m) => m.assignment_id === assignment.id);
+        if (!hasMembership && !assignmentGroups.has(assignment.id)) {
+          fetchAssignmentGroups(assignment.id);
+        }
+      });
+    });
+  }, [isNormalUser, subjectData, memberships, assignmentGroups, fetchAssignmentGroups]);
 
   const handleJoinGroup = async (groupId) => {
     setJoiningGroup(true);
@@ -84,7 +162,8 @@ function Dashboard() {
     }
   };
 
-  const handleFeelingLucky = async () => {
+  const handleFeelingLucky = async (assignmentId) => {
+    const availableGroups = assignmentGroups.get(assignmentId)?.groups ?? [];
     if (availableGroups.length === 0) {
       setGroupError('No available group to join');
       setTimeout(() => setGroupError(''), 3000);
@@ -96,15 +175,19 @@ function Dashboard() {
     await handleJoinGroup(randomGroup.id);
   };
 
-  const handleLeaveGroup = async () => {
-    if (!user?.groupId) {
-      return;
-    }
+  const handleLeaveGroup = async (assignmentId, groupId) => {
     setLeavingGroup(true);
     try {
-      await api.post(`${API_BASE}/groups/${user.groupId}/leave`);
+      await api.post(`${API_BASE}/groups/${groupId}/leave`);
       setGroupSuccess('Successfully left group');
       await refreshUser();
+      setExpandedAssignments((prev) => new Map(prev).set(assignmentId, false));
+      setGroupMembers((prev) => {
+        const next = new Map(prev);
+        next.delete(groupId);
+        return next;
+      });
+      await fetchAssignmentGroups(assignmentId);
       setTimeout(() => setGroupSuccess(''), 2000);
     } catch (err) {
       setGroupError(err.response?.data?.error || 'Failed to leave group');
@@ -112,6 +195,148 @@ function Dashboard() {
     } finally {
       setLeavingGroup(false);
     }
+  };
+
+  const toggleMembers = (assignmentId, groupId) => {
+    const expanded = !expandedAssignments.get(assignmentId);
+    setExpandedAssignments((prev) => new Map(prev).set(assignmentId, expanded));
+    if (expanded && !groupMembers.has(groupId)) {
+      fetchGroupMembers(groupId);
+    }
+  };
+
+  const renderMembershipAssignment = (assignment, membership) => {
+    const expanded = expandedAssignments.get(assignment.id) === true;
+    const membersState = groupMembers.get(membership.group_id);
+    return (
+      <div>
+        <div className="flex items-center justify-between bg-primary-50 rounded-md px-4 py-3 mb-2">
+          <p className="text-sm font-medium text-gray-900">
+            Your group: <span className="text-primary-700">{membership.group_name}</span>
+          </p>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => toggleMembers(assignment.id, membership.group_id)}
+              className="text-sm text-primary-600 hover:text-primary-800 font-medium"
+            >
+              {expanded ? 'Hide Members' : 'Show Members'}
+            </button>
+            {!groupJoinLocked && (
+              <button
+                onClick={() => handleLeaveGroup(assignment.id, membership.group_id)}
+                disabled={leavingGroup}
+                className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {leavingGroup ? 'Leaving...' : 'Leave Group'}
+              </button>
+            )}
+          </div>
+        </div>
+        {groupJoinLocked && (
+          <div className="mb-2 bg-yellow-50 border border-yellow-200 text-yellow-800 px-3 py-2 rounded-md text-sm">
+            {LOCKED_MESSAGE}
+          </div>
+        )}
+        {expanded && (
+          <MemberList
+            loading={membersState?.loading !== false}
+            members={membersState?.members ?? []}
+            currentUserId={user?.id}
+          />
+        )}
+      </div>
+    );
+  };
+
+  const renderJoinableAssignment = (assignment) => {
+    if (groupJoinLocked) {
+      return (
+        <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-3 py-2 rounded-md text-sm">
+          {LOCKED_MESSAGE}
+        </div>
+      );
+    }
+    const groupsState = assignmentGroups.get(assignment.id);
+    if (!groupsState || groupsState.loading) {
+      return <Spinner />;
+    }
+    if (groupsState.error) {
+      return (
+        <div className="bg-red-50 border border-red-200 text-red-600 px-3 py-2 rounded-md text-sm">
+          {groupsState.error}
+        </div>
+      );
+    }
+    return (
+      <>
+        <button
+          onClick={() => handleFeelingLucky(assignment.id)}
+          disabled={joiningGroup}
+          className="mb-3 w-full px-4 py-2 bg-yellow-500 text-white rounded-md hover:bg-yellow-600 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {joiningGroup ? 'Joining...' : "🍀 I'm Feeling Lucky"}
+        </button>
+        {groupsState.groups.length === 0 ? (
+          <p className="text-sm text-gray-500 py-2">No available groups to join</p>
+        ) : (
+          <ul className="divide-y divide-gray-200">
+            {groupsState.groups.map((group) => (
+              <li key={group.id} className="flex items-center justify-between py-3">
+                <div>
+                  <span className="text-sm font-medium text-gray-900">{group.name}</span>
+                  <span className="ml-2 text-sm text-gray-500">
+                    ({group.member_count}
+                    {group.max_members !== null && group.max_members !== undefined
+                      ? ` / ${group.max_members}`
+                      : ''}{' '}
+                    members)
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleJoinGroup(group.id)}
+                  disabled={joiningGroup}
+                  className="text-sm bg-primary-600 text-white px-3 py-1 rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {joiningGroup ? 'Joining...' : 'Join'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </>
+    );
+  };
+
+  const renderSubjectCard = (subject) => {
+    const data = subjectData.get(subject.id);
+    return (
+      <div key={subject.id} className="bg-white overflow-hidden shadow rounded-lg mb-6">
+        <div className="px-4 py-5 sm:p-6">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">{subject.name}</h3>
+          {!data || data.loading ? (
+            <Spinner />
+          ) : data.error ? (
+            <div className="bg-red-50 border border-red-200 text-red-600 px-3 py-2 rounded-md text-sm">
+              {data.error}
+            </div>
+          ) : data.assignments.length === 0 ? (
+            <p className="text-sm text-gray-500 py-2">No assignments yet</p>
+          ) : (
+            data.assignments.map((assignment) => {
+              const membership = memberships.find((m) => m.assignment_id === assignment.id);
+              return (
+                <div key={assignment.id} className="mb-5 last:mb-0">
+                  <h4 className="text-sm font-medium text-gray-700 mb-2">{assignment.name}</h4>
+                  {membership
+                    ? renderMembershipAssignment(assignment, membership)
+                    : renderJoinableAssignment(assignment)}
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -149,12 +374,10 @@ function Dashboard() {
                   <dt className="text-sm font-medium text-gray-500">Role</dt>
                   <dd className="mt-1 text-sm text-gray-900">{formatRoleName(user?.role)}</dd>
                 </div>
-                {isNormalUser && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Group</dt>
-                    <dd className="mt-1 text-sm text-gray-900">{user?.groupName || 'Not assigned'}</dd>
-                  </div>
-                )}
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Subjects</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{subjects.map((s) => s.name).join(', ') || '—'}</dd>
+                </div>
                 {user?.studentId && (
                   <div>
                     <dt className="text-sm font-medium text-gray-500">Student ID</dt>
@@ -179,12 +402,12 @@ function Dashboard() {
                       👥 Manage Users
                     </Link>
                   )}
-                  {isAdmin && (
+                  {isAssignmentManager && (
                     <Link
-                      to="/groups"
+                      to="/subjects"
                       className="block w-full text-left px-4 py-2 bg-primary-50 text-primary-700 rounded-md hover:bg-primary-100 transition-colors"
                     >
-                      📁 Manage Groups
+                      📚 Subjects & Assignments
                     </Link>
                   )}
                   <Link
@@ -198,128 +421,33 @@ function Dashboard() {
             </div>
           )}
 
-          {/* Normal User Group Section */}
+          {/* Normal User Subject/Assignment Group Section */}
           {isNormalUser && (
-            <div className="bg-white overflow-hidden shadow rounded-lg mb-6">
-              <div className="px-4 py-5 sm:p-6">
-                <h3 className="text-lg font-medium text-gray-900 mb-4">My Group</h3>
+            <>
+              {groupError && (
+                <div className="mb-3 bg-red-50 border border-red-200 text-red-600 px-3 py-2 rounded-md text-sm">
+                  {groupError}
+                </div>
+              )}
 
-                {groupError && (
-                  <div className="mb-3 bg-red-50 border border-red-200 text-red-600 px-3 py-2 rounded-md text-sm">
-                    {groupError}
-                  </div>
-                )}
+              {groupSuccess && (
+                <div className="mb-3 bg-green-50 border border-green-200 text-green-600 px-3 py-2 rounded-md text-sm">
+                  {groupSuccess}
+                </div>
+              )}
 
-                {groupSuccess && (
-                  <div className="mb-3 bg-green-50 border border-green-200 text-green-600 px-3 py-2 rounded-md text-sm">
-                    {groupSuccess}
+              {subjects.length === 0 ? (
+                <div className="bg-white overflow-hidden shadow rounded-lg mb-6">
+                  <div className="px-4 py-5 sm:p-6">
+                    <p className="text-sm text-gray-500">
+                      You are not enrolled in any subject yet. Contact your administrator.
+                    </p>
                   </div>
-                )}
-
-                {user?.groupId ? (
-                  <div>
-                    <div className="flex items-center justify-between bg-primary-50 rounded-md px-4 py-3 mb-4">
-                      <p className="text-sm font-medium text-gray-900">
-                        You are in: <span className="text-primary-700">{user.groupName}</span>
-                      </p>
-                      {!groupJoinLocked && (
-                        <button
-                          onClick={handleLeaveGroup}
-                          disabled={leavingGroup}
-                          className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {leavingGroup ? 'Leaving...' : 'Leave Group'}
-                        </button>
-                      )}
-                    </div>
-                    {groupJoinLocked && (
-                      <div className="mb-4 bg-yellow-50 border border-yellow-200 text-yellow-800 px-3 py-2 rounded-md text-sm">
-                        Group joining is locked. Please contact the teaching staff to join or leave a group.
-                      </div>
-                    )}
-
-                    <h4 className="text-sm font-medium text-gray-700 mb-2">Group Members</h4>
-                    {membersLoading ? (
-                      <div className="flex justify-center py-4">
-                        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
-                      </div>
-                    ) : groupMembers.length === 0 ? (
-                      <p className="text-sm text-gray-500 py-2">No members yet</p>
-                    ) : (
-                      <ul className="divide-y divide-gray-100 border border-gray-100 rounded-md">
-                        {groupMembers.map((member) => (
-                          <li key={member.id} className="flex items-center gap-3 px-4 py-2">
-                            <div className="min-w-0 flex-1">
-                              <span className="text-sm font-medium text-gray-900">
-                                {member.first_name && member.last_name
-                                  ? `${member.first_name.charAt(0)}. ${member.last_name}`
-                                  : member.username}
-                              </span>
-                              {member.id === user.id && (
-                                <span className="ml-2 text-xs text-primary-600 font-medium">(you)</span>
-                              )}
-                            </div>
-                            <span className="text-sm text-gray-500 truncate">{member.email}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
-                ) : (
-                  <div>
-                    {groupJoinLocked ? (
-                      <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 px-3 py-2 rounded-md text-sm">
-                        Group joining is locked. Please contact the teaching staff to join or leave a group.
-                      </div>
-                    ) : (
-                      <>
-                        <p className="text-sm text-gray-600 mb-3">
-                          You are not assigned to any group. Join an available group below:
-                        </p>
-                        <button
-                          onClick={handleFeelingLucky}
-                          disabled={joiningGroup || groupsLoading}
-                          className="mb-4 w-full px-4 py-2 bg-yellow-500 text-white rounded-md hover:bg-yellow-600 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                          {joiningGroup ? 'Joining...' : "🍀 I'm Feeling Lucky"}
-                        </button>
-                        {groupsLoading ? (
-                          <div className="flex justify-center py-4">
-                            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
-                          </div>
-                        ) : availableGroups.length === 0 ? (
-                          <p className="text-sm text-gray-500 py-2">No available groups to join</p>
-                        ) : (
-                          <ul className="divide-y divide-gray-200">
-                            {availableGroups.map((group) => (
-                              <li key={group.id} className="flex items-center justify-between py-3">
-                                <div>
-                                  <span className="text-sm font-medium text-gray-900">{group.name}</span>
-                                  <span className="ml-2 text-sm text-gray-500">
-                                    ({group.member_count}
-                                    {group.max_members !== null && group.max_members !== undefined
-                                      ? ` / ${group.max_members}`
-                                      : ''}{' '}
-                                    members)
-                                  </span>
-                                </div>
-                                <button
-                                  onClick={() => handleJoinGroup(group.id)}
-                                  disabled={joiningGroup}
-                                  className="text-sm bg-primary-600 text-white px-3 py-1 rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                                >
-                                  {joiningGroup ? 'Joining...' : 'Join'}
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
+                </div>
+              ) : (
+                subjects.map(renderSubjectCard)
+              )}
+            </>
           )}
         </div>
       </main>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -42,7 +42,15 @@ function MemberList({ loading, members, currentUserId }) {
 }
 
 function Dashboard() {
-  const { user, isAdmin, isAssignmentManager, refreshUser, memberships = [] } = useAuth();
+  const {
+    user,
+    isAdmin,
+    isAssignmentManager,
+    refreshUser,
+    memberships = [],
+    currentSubjectId,
+    setCurrentSubject,
+  } = useAuth();
   const [subjectData, setSubjectData] = useState(new Map()); // subjectId -> { loading, error, assignments }
   const [assignmentGroups, setAssignmentGroups] = useState(new Map()); // assignmentId -> { loading, error, groups }
   const [expandedAssignments, setExpandedAssignments] = useState(new Map()); // assignmentId -> boolean
@@ -54,6 +62,14 @@ function Dashboard() {
   const [groupJoinLocked, setGroupJoinLocked] = useState(false);
   const isNormalUser = !isAdmin && !isAssignmentManager;
   const subjects = useMemo(() => user?.subjects ?? [], [user]);
+  // The one subject whose card is shown; single-subject users land straight on theirs.
+  const selectedSubject = useMemo(() => {
+    const match = subjects.find((subject) => subject.id === currentSubjectId);
+    if (match) {
+      return match;
+    }
+    return subjects.length === 1 ? subjects[0] : null;
+  }, [subjects, currentSubjectId]);
 
   useEffect(() => {
     if (isNormalUser) {
@@ -394,7 +410,7 @@ function Dashboard() {
               <div className="px-4 py-5 sm:p-6">
                 <h3 className="text-lg font-medium text-gray-900 mb-4">Administration</h3>
                 <div className="space-y-3">
-                  {isAssignmentManager && (
+                  {isAdmin && (
                     <Link
                       to="/users"
                       className="block w-full text-left px-4 py-2 bg-primary-50 text-primary-700 rounded-md hover:bg-primary-100 transition-colors"
@@ -408,6 +424,9 @@ function Dashboard() {
                       className="block w-full text-left px-4 py-2 bg-primary-50 text-primary-700 rounded-md hover:bg-primary-100 transition-colors"
                     >
                       📚 Subjects & Assignments
+                      {!isAdmin && (
+                        <span className="block text-xs text-primary-600 mt-1">Manage users within your subjects.</span>
+                      )}
                     </Link>
                   )}
                   <Link
@@ -444,8 +463,47 @@ function Dashboard() {
                     </p>
                   </div>
                 </div>
+              ) : selectedSubject ? (
+                <>
+                  {subjects.length > 1 && (
+                    <div className="flex items-center justify-between bg-white shadow rounded-lg px-4 py-3 mb-4">
+                      <span className="text-sm font-medium text-gray-700">{selectedSubject.name}</span>
+                      <button
+                        onClick={() => setCurrentSubject(null)}
+                        className="text-sm text-primary-600 hover:text-primary-800 font-medium"
+                      >
+                        Switch subject
+                      </button>
+                    </div>
+                  )}
+                  {renderSubjectCard(selectedSubject)}
+                </>
               ) : (
-                subjects.map(renderSubjectCard)
+                <div className="bg-white overflow-hidden shadow rounded-lg mb-6">
+                  <div className="px-4 py-5 sm:p-6">
+                    <h3 className="text-lg font-medium text-gray-900 mb-4">Select your subject</h3>
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                      {subjects.map((subject) => {
+                        const data = subjectData.get(subject.id);
+                        const assignmentCount = data && !data.loading && !data.error ? data.assignments.length : null;
+                        return (
+                          <button
+                            key={subject.id}
+                            onClick={() => setCurrentSubject(subject.id)}
+                            className="text-left px-4 py-4 border border-gray-200 rounded-lg hover:border-primary-400 hover:bg-primary-50 transition-colors"
+                          >
+                            <span className="block text-sm font-medium text-gray-900">{subject.name}</span>
+                            {assignmentCount !== null && (
+                              <span className="block text-xs text-gray-500 mt-1">
+                                {assignmentCount} assignment{assignmentCount === 1 ? '' : 's'}
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
               )}
             </>
           )}

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -857,7 +857,7 @@ function Groups() {
 
       {/* Create Group Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New Group</h3>
             <form onSubmit={handleCreateGroup}>
@@ -912,7 +912,7 @@ function Groups() {
 
       {/* Edit Group Modal */}
       {editingGroup && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Edit Group</h3>
             <form onSubmit={handleEditGroup}>
@@ -966,7 +966,7 @@ function Groups() {
 
       {/* Bulk Create Modal */}
       {bulkCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Bulk Create Groups</h3>
             <form onSubmit={handleBulkCreate}>
@@ -1041,7 +1041,7 @@ function Groups() {
 
       {/* Set Limit Modal (single or bulk) */}
       {limitModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-sm max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-2">Set Member Limit</h3>
             {limitModal.groupIds.length > 1 && (
@@ -1081,7 +1081,7 @@ function Groups() {
 
       {/* Delete Confirmation Modal (single or bulk) */}
       {deleteModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg w-full max-w-md max-h-[90vh] flex flex-col">
             <div className="p-6 pb-0 flex-shrink-0">
               <h3 className="text-lg font-semibold text-gray-900 mb-3">

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -1,35 +1,23 @@
-import { useState, useEffect, useRef } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import api from '@/utils/api';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
 import { formatRoleName } from '../utils/formatting.js';
 import { Power, Gauge, Trash2, UserMinus, ChevronDown, ChevronRight, Check, Pencil } from 'lucide-react';
 import IndeterminateCheckbox from '../components/IndeterminateCheckbox.jsx';
+import IconBtn from '../components/IconBtn.jsx';
 import { parseBody, createGroupSchema, updateGroupSchema } from '../utils/schemas.js';
 import { downloadCsv } from '../utils/csv.js';
 import { API_BASE } from '../config.js';
 
-function IconBtn({ onClick, label, className, children }) {
-  return (
-    <div className="relative group/tip">
-      <button
-        type="button"
-        onClick={onClick}
-        aria-label={label}
-        className={`p-1.5 rounded transition-colors ${className}`}
-      >
-        {children}
-      </button>
-      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover/tip:opacity-100 transition-opacity z-20">
-        {label}
-      </span>
-    </div>
-  );
-}
-
 function Groups() {
-  const { isAssignmentManager } = useAuth();
+  const { subjectId, assignmentId } = useParams();
+  const { isAdmin, user } = useAuth();
+  // Admins manage everything; AMs manage only the assignments listed on their profile.
+  const canManage = isAdmin || (user?.managedAssignments || []).some((a) => a.id === assignmentId);
+
+  const [assignment, setAssignment] = useState(null);
   const [groups, setGroups] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -44,7 +32,7 @@ function Groups() {
   const [newGroupMaxMembers, setNewGroupMaxMembers] = useState('');
 
   // Bulk create modal
-  const [bulkCreateModal, setBulkCreateModal] = useState(null); // { prefix, count }
+  const [bulkCreateModal, setBulkCreateModal] = useState(null); // { prefix, count, maxMembers }
 
   // Set limit modal — single or bulk ({ groupIds: string[], value: string })
   const [limitModal, setLimitModal] = useState(null);
@@ -68,7 +56,7 @@ function Groups() {
   // Expanded row state
   const [expandedGroup, setExpandedGroup] = useState(null);
   const [groupMembers, setGroupMembers] = useState([]);
-  const [allUsers, setAllUsers] = useState([]);
+  const [subjectUsers, setSubjectUsers] = useState([]);
   const [membersLoading, setMembersLoading] = useState(false);
   const [selectedUserId, setSelectedUserId] = useState('');
 
@@ -78,37 +66,42 @@ function Groups() {
 
   const location = useLocation();
 
-  // Re-fetch whenever this page is navigated to (location.key changes on each navigation).
-  useEffect(() => {
-    fetchGroups();
-  }, [location.key]);
-
-  // Re-fetch when the browser tab becomes visible again (multi-tab scenario).
-  useEffect(() => {
-    const handler = () => {
-      if (!document.hidden) {
-        fetchGroups();
-      }
-    };
-    document.addEventListener('visibilitychange', handler);
-    return () => document.removeEventListener('visibilitychange', handler);
-  }, []);
-
-  const fetchGroups = async () => {
+  const fetchData = useCallback(async () => {
     try {
-      const response = await api.get(`${API_BASE}/groups`);
-      setGroups(response.data.groups || []);
+      const [assignmentRes, groupsRes] = await Promise.all([
+        api.get(`${API_BASE}/assignments/${assignmentId}`),
+        api.get(`${API_BASE}/assignments/${assignmentId}/groups`),
+      ]);
+      setAssignment(assignmentRes.data.assignment || null);
+      setGroups(groupsRes.data.groups || []);
     } catch (_err) {
       setError('Failed to load groups');
     } finally {
       setLoading(false);
     }
-  };
+  }, [assignmentId]);
+
+  // Re-fetch whenever this page is navigated to (location.key changes on each
+  // navigation) or the route's assignment changes (fetchData identity).
+  useEffect(() => {
+    fetchData();
+  }, [location.key, fetchData]);
+
+  // Re-fetch when the browser tab becomes visible again (multi-tab scenario).
+  useEffect(() => {
+    const handler = () => {
+      if (!document.hidden) {
+        fetchData();
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [fetchData]);
 
   const handleExportMappings = async () => {
     setExporting(true);
     try {
-      const response = await api.get(`${API_BASE}/groups/export-mappings`);
+      const response = await api.get(`${API_BASE}/assignments/${assignmentId}/export-mappings`);
       const { mappings } = response.data;
       const today = new Date().toISOString().slice(0, 10);
       downloadCsv(mappings, ['groupName', 'email'], `group-mappings-${today}.csv`);
@@ -166,15 +159,17 @@ function Groups() {
   const handleCreateGroup = async (e) => {
     e.preventDefault();
     setCreateFormError('');
-    const { data: body, error: validationError } = parseBody(createGroupSchema, { name: newGroupName });
+    const { data: body, error: validationError } = parseBody(createGroupSchema, {
+      assignmentId,
+      name: newGroupName,
+    });
     if (validationError) {
       setCreateFormError(validationError);
       return;
     }
-    const body_name = body.name;
     setCreating(true);
     try {
-      const requestBody = { name: body_name };
+      const requestBody = { assignmentId: body.assignmentId, name: body.name };
       if (newGroupMaxMembers !== '') {
         requestBody.maxMembers = parseInt(newGroupMaxMembers, 10);
       }
@@ -183,7 +178,7 @@ function Groups() {
       setNewGroupName('');
       setNewGroupMaxMembers('');
       setShowCreateModal(false);
-      fetchGroups();
+      fetchData();
     } catch (err) {
       setCreateFormError(err.response?.data?.error || 'Failed to create group');
     } finally {
@@ -228,7 +223,7 @@ function Groups() {
       });
       showSuccess('Group updated successfully');
       setEditingGroup(null);
-      fetchGroups();
+      fetchData();
     } catch (err) {
       setEditFormError(err.response?.data?.error || 'Failed to update group');
     } finally {
@@ -241,7 +236,7 @@ function Groups() {
     try {
       await api.put(`${API_BASE}/groups/${groupId}`, { enabled: !currentEnabled });
       showSuccess(`Group ${currentEnabled ? 'disabled' : 'enabled'} successfully`);
-      fetchGroups();
+      fetchData();
     } catch (err) {
       showError(err.response?.data?.error || 'Failed to update group');
     }
@@ -275,7 +270,7 @@ function Groups() {
       await Promise.all(groupIds.map((id) => api.put(`${API_BASE}/groups/${id}`, { maxMembers })));
       showSuccess(groupIds.length === 1 ? 'Group limit updated' : `Updated limit for ${groupIds.length} groups`);
       setLimitModal(null);
-      fetchGroups();
+      fetchData();
     } catch (err) {
       showError(err.response?.data?.error || 'Failed to update limit');
     }
@@ -317,7 +312,7 @@ function Groups() {
     for (let batchIndex = 0; batchIndex < allGroups.length; batchIndex += BULK_BATCH_SIZE) {
       const batch = allGroups.slice(batchIndex, batchIndex + BULK_BATCH_SIZE);
       try {
-        await api.post(`${API_BASE}/groups/bulk`, batch);
+        await api.post(`${API_BASE}/groups/bulk`, { assignmentId, groups: batch });
         totalCreated += batch.length;
       } catch (err) {
         if (firstError === null) {
@@ -336,7 +331,7 @@ function Groups() {
     }
 
     setBulkCreateModal(null);
-    fetchGroups();
+    fetchData();
   };
 
   const bulkCreatePreview = () => {
@@ -382,7 +377,7 @@ function Groups() {
         return next;
       });
       setDeleteModal(null);
-      fetchGroups();
+      fetchData();
     } catch (err) {
       showError(err.response?.data?.error || 'Failed to delete group');
     } finally {
@@ -398,13 +393,13 @@ function Groups() {
     try {
       const [groupRes, usersRes] = await Promise.all([
         api.get(`${API_BASE}/groups/${groupId}`),
-        isAssignmentManager ? api.get(`${API_BASE}/users`) : Promise.resolve({ data: { users: [] } }),
+        canManage ? api.get(`${API_BASE}/subjects/${subjectId}/users`) : Promise.resolve({ data: { users: [] } }),
       ]);
       if (expandedGroupRef.current !== groupId) {
         return;
       }
       setGroupMembers(groupRes.data.members || []);
-      setAllUsers(usersRes.data.users || []);
+      setSubjectUsers(usersRes.data.users || []);
     } catch (_err) {
       if (expandedGroupRef.current !== groupId) {
         return;
@@ -421,7 +416,7 @@ function Groups() {
     if (expandedGroup === groupId) {
       setExpandedGroup(null);
       setGroupMembers([]);
-      setAllUsers([]);
+      setSubjectUsers([]);
       setSelectedUserId('');
       return;
     }
@@ -433,12 +428,12 @@ function Groups() {
   const handleRemoveMember = async (userId) => {
     const groupId = expandedGroup;
     try {
-      await api.put(`${API_BASE}/users/${userId}/group`, { groupId: null });
+      await api.put(`${API_BASE}/users/${userId}/group`, { assignmentId, groupId: null });
       showSuccess('Member removed successfully');
       if (groupId) {
         fetchGroupMembers(groupId);
       }
-      fetchGroups();
+      fetchData();
     } catch (err) {
       showError(err.response?.data?.error || 'Failed to remove member');
     }
@@ -450,20 +445,25 @@ function Groups() {
     }
     const groupId = expandedGroup;
     try {
-      await api.put(`${API_BASE}/users/${selectedUserId}/group`, { groupId });
+      await api.put(`${API_BASE}/users/${selectedUserId}/group`, { assignmentId, groupId });
       showSuccess('Member added successfully');
       setSelectedUserId('');
       if (groupId) {
         fetchGroupMembers(groupId);
       }
-      fetchGroups();
+      fetchData();
     } catch (err) {
+      // Backend is authoritative: surfaces 403 (not a subject member) and
+      // 409 (group full / already in a group for this assignment) errors.
       showError(err.response?.data?.error || 'Failed to add member');
     }
   };
 
+  // Candidates come from the parent subject's members. Users already in the
+  // currently expanded group are excluded client-side; membership in another
+  // group of this assignment is enforced by the backend (409 surfaces above).
   const availableForGroup = () =>
-    allUsers.filter((u) => !groupMembers.some((m) => m.id === u.id) && u.role_name === 'user');
+    subjectUsers.filter((u) => !groupMembers.some((m) => m.id === u.id) && u.role_name === 'user');
 
   // ── Search ──────────────────────────────────────────────────────────────
   const [searchTerm, setSearchTerm] = useState('');
@@ -497,7 +497,7 @@ function Groups() {
               Created
             </th>
             <th className="w-[14%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Actions
+              {canManage ? 'Actions' : ''}
             </th>
           </tr>
         </thead>
@@ -522,13 +522,15 @@ function Groups() {
                 }}
               >
                 <td className="px-3 py-4" onClick={(e) => e.stopPropagation()}>
-                  <input
-                    type="checkbox"
-                    checked={selectedIds.has(group.id)}
-                    onChange={() => toggleSelect(group.id)}
-                    aria-label={`Select ${group.name}`}
-                    className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                  />
+                  {canManage && (
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(group.id)}
+                      onChange={() => toggleSelect(group.id)}
+                      aria-label={`Select ${group.name}`}
+                      className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                    />
+                  )}
                 </td>
                 <td className="px-1 py-4 text-gray-400">
                   {isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
@@ -544,40 +546,42 @@ function Groups() {
                 </td>
                 <td className="px-4 py-4 text-sm text-gray-500">{new Date(group.created_at).toLocaleDateString()}</td>
                 <td className="px-4 py-4">
-                  <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
-                    <IconBtn
-                      label="Edit Group"
-                      onClick={(e) => openEditModal(e, group)}
-                      className="text-gray-500 hover:text-primary-600 hover:bg-primary-50"
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </IconBtn>
-                    <IconBtn
-                      label={group.enabled ? 'Disable Group' : 'Enable Group'}
-                      onClick={(e) => handleToggleEnabled(e, group.id, group.enabled)}
-                      className={
-                        group.enabled
-                          ? 'text-yellow-500 hover:text-yellow-700 hover:bg-yellow-50'
-                          : 'text-green-500 hover:text-green-700 hover:bg-green-50'
-                      }
-                    >
-                      <Power className="h-4 w-4" />
-                    </IconBtn>
-                    <IconBtn
-                      label="Set Member Limit"
-                      onClick={(e) => openLimitModal(e, group)}
-                      className="text-blue-500 hover:text-blue-700 hover:bg-blue-50"
-                    >
-                      <Gauge className="h-4 w-4" />
-                    </IconBtn>
-                    <IconBtn
-                      label="Delete Group"
-                      onClick={(e) => handleDeleteGroup(e, group.id)}
-                      className="text-red-500 hover:text-red-700 hover:bg-red-50"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </IconBtn>
-                  </div>
+                  {canManage && (
+                    <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+                      <IconBtn
+                        label="Edit Group"
+                        onClick={(e) => openEditModal(e, group)}
+                        className="text-gray-500 hover:text-primary-600 hover:bg-primary-50"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </IconBtn>
+                      <IconBtn
+                        label={group.enabled ? 'Disable Group' : 'Enable Group'}
+                        onClick={(e) => handleToggleEnabled(e, group.id, group.enabled)}
+                        className={
+                          group.enabled
+                            ? 'text-yellow-500 hover:text-yellow-700 hover:bg-yellow-50'
+                            : 'text-green-500 hover:text-green-700 hover:bg-green-50'
+                        }
+                      >
+                        <Power className="h-4 w-4" />
+                      </IconBtn>
+                      <IconBtn
+                        label="Set Member Limit"
+                        onClick={(e) => openLimitModal(e, group)}
+                        className="text-blue-500 hover:text-blue-700 hover:bg-blue-50"
+                      >
+                        <Gauge className="h-4 w-4" />
+                      </IconBtn>
+                      <IconBtn
+                        label="Delete Group"
+                        onClick={(e) => handleDeleteGroup(e, group.id)}
+                        className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </IconBtn>
+                    </div>
+                  )}
                 </td>
               </tr>,
 
@@ -627,7 +631,7 @@ function Groups() {
                                     <span className="text-xs text-gray-400 truncate">ID: {member.student_id}</span>
                                   )}
                                 </div>
-                                {isAssignmentManager && (
+                                {canManage && (
                                   <button
                                     onClick={() => handleRemoveMember(member.id)}
                                     aria-label={`Remove ${member.username}`}
@@ -641,7 +645,7 @@ function Groups() {
                           </ul>
                         )}
 
-                        {isAssignmentManager && available.length > 0 && canAddMore && (
+                        {canManage && available.length > 0 && canAddMore && (
                           <div className="flex items-center gap-2 max-w-sm">
                             <select
                               value={selectedUserId}
@@ -692,18 +696,20 @@ function Groups() {
       <div className="mb-8">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <IndeterminateCheckbox
-              checked={allSelected}
-              indeterminate={someSelected}
-              onChange={() => toggleSectionAll(sectionGroups, allSelected)}
-              aria-label={`Select all ${title}`}
-              className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-            />
+            {canManage && (
+              <IndeterminateCheckbox
+                checked={allSelected}
+                indeterminate={someSelected}
+                onChange={() => toggleSectionAll(sectionGroups, allSelected)}
+                aria-label={`Select all ${title}`}
+                className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+            )}
             <h3 className="text-base font-semibold text-gray-700">
               {title} <span className="text-sm font-normal text-gray-400">({sectionGroups.length})</span>
             </h3>
           </div>
-          {sectionSelectedIds.length > 0 && (
+          {canManage && sectionSelectedIds.length > 0 && (
             <button
               onClick={() => openBulkLimitModal(sectionSelectedIds)}
               className="flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800 border border-blue-200 hover:border-blue-400 rounded px-2 py-1 transition-colors"
@@ -734,18 +740,30 @@ function Groups() {
 
   return (
     <div className="flex-1 bg-gray-50">
-      <Header pageName="Group Management" />
+      <Header pageName={assignment?.name || 'Groups'} />
 
       <main className="w-[85%] mx-auto py-6">
         <div className="px-4 py-6 sm:px-0">
           {/* Toolbar */}
           <div className="mb-6 flex justify-between items-center">
             <div>
-              <h2 className="text-2xl font-bold text-gray-900">Manage Groups</h2>
-              <p className="text-gray-600 mt-1">Create and manage team groups</p>
+              <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm text-gray-500">
+                <Link to="/subjects" className="hover:text-primary-600 hover:underline">
+                  Subjects
+                </Link>
+                <span aria-hidden="true">›</span>
+                <Link to={`/subjects/${subjectId}`} className="hover:text-primary-600 hover:underline">
+                  {assignment?.subject_name}
+                </Link>
+                <span aria-hidden="true">›</span>
+                <span className="font-medium text-gray-900">{assignment?.name}</span>
+              </nav>
+              <p className="text-gray-600 mt-1">
+                {canManage ? 'Create and manage groups for this assignment' : 'Groups for this assignment'}
+              </p>
             </div>
             <div className="flex items-center gap-2">
-              {selectedIds.size > 0 && (
+              {canManage && selectedIds.size > 0 && (
                 <button
                   onClick={() => setDeleteModal(selectedGroups)}
                   className="flex items-center gap-1.5 px-3 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors text-sm"
@@ -761,24 +779,28 @@ function Groups() {
               >
                 {exporting ? 'Exporting...' : 'Export Mappings'}
               </button>
-              <Link
-                to="/groups/import"
-                className="flex items-center gap-1.5 px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors text-sm"
-              >
-                Import Mappings
-              </Link>
-              <button
-                onClick={() => setBulkCreateModal({ prefix: '', count: '1', maxMembers: '' })}
-                className="flex items-center gap-1.5 px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors text-sm"
-              >
-                Bulk Create
-              </button>
-              <button
-                onClick={() => setShowCreateModal(true)}
-                className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
-              >
-                + Create Group
-              </button>
+              {canManage && (
+                <>
+                  <Link
+                    to={`/groups/import?subjectId=${subjectId}&assignmentId=${assignmentId}`}
+                    className="flex items-center gap-1.5 px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors text-sm"
+                  >
+                    Import Mappings
+                  </Link>
+                  <button
+                    onClick={() => setBulkCreateModal({ prefix: '', count: '1', maxMembers: '' })}
+                    className="flex items-center gap-1.5 px-3 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors text-sm"
+                  >
+                    Bulk Create
+                  </button>
+                  <button
+                    onClick={() => setShowCreateModal(true)}
+                    className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
+                  >
+                    + Create Group
+                  </button>
+                </>
+              )}
             </div>
           </div>
 
@@ -808,12 +830,14 @@ function Groups() {
           {groups.length === 0 ? (
             <div className="text-center py-12 bg-white rounded-lg shadow">
               <p className="text-gray-500">No groups created yet</p>
-              <button
-                onClick={() => setShowCreateModal(true)}
-                className="mt-4 text-primary-600 hover:text-primary-700 font-medium"
-              >
-                Create your first group
-              </button>
+              {canManage && (
+                <button
+                  onClick={() => setShowCreateModal(true)}
+                  className="mt-4 text-primary-600 hover:text-primary-700 font-medium"
+                >
+                  Create your first group
+                </button>
+              )}
             </div>
           ) : matchingGroups.length === 0 ? (
             <div className="text-center py-12 bg-white rounded-lg shadow">

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -297,7 +297,9 @@ function Groups() {
       return;
     }
 
-    const pad = n < 10 ? 1 : 2;
+    // Pad to the width of the batch size (min 2) so names sort correctly
+    // everywhere they are ordered lexicographically (DB, exports, UI).
+    const pad = n < 10 ? 1 : String(n).length;
     const allGroups = Array.from({ length: n }, (_, i) => {
       const item = { name: `${prefix.trim()}${String(i + 1).padStart(pad, '0')}` };
       if (maxMembersVal !== null) {
@@ -343,7 +345,7 @@ function Groups() {
     if (!prefix.trim() || isNaN(n) || n < 1) {
       return [];
     }
-    const pad = n < 10 ? 1 : 2;
+    const pad = n < 10 ? 1 : String(n).length;
     return Array.from({ length: n }, (_, i) => `${prefix.trim()}${String(i + 1).padStart(pad, '0')}`);
   };
 

--- a/frontend/src/pages/ImportGroupMappings.jsx
+++ b/frontend/src/pages/ImportGroupMappings.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '@/utils/api';
 import { ArrowLeft, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import Header from '../components/Header.jsx';
 import CsvDropzone from '../components/CsvDropzone.jsx';
+import CascadingAssignmentSelect from '../components/CascadingAssignmentSelect.jsx';
 import { parseCsv, downloadCsv } from '../utils/csv.js';
 import { API_BASE } from '../config.js';
 
@@ -27,7 +28,17 @@ function autoDetectColumns(headers) {
 
 function ImportGroupMappings() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [step, setStep] = useState(1);
+
+  // Target assignment (Subject → Assignment cascade), preselected from query params
+  const [subjects, setSubjects] = useState([]);
+  const [subjectsError, setSubjectsError] = useState('');
+  const [selection, setSelection] = useState(() => ({
+    subjectId: searchParams.get('subjectId') || '',
+    assignmentId: searchParams.get('assignmentId') || '',
+    groupId: '',
+  }));
 
   // Step 1 state
   const [csvHeaders, setCsvHeaders] = useState([]);
@@ -51,11 +62,32 @@ function ImportGroupMappings() {
   const countdownRef = useRef(null);
 
   useEffect(() => {
-    if (step === 2 && csvRows.length > 0) {
+    let cancelled = false;
+    api
+      .get(`${API_BASE}/subjects`)
+      .then((res) => {
+        if (!cancelled) {
+          setSubjects(res.data.subjects || []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSubjectsError('Failed to load subjects. Please reload the page.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Rebuild the preview when entering step 2 or when the target assignment
+  // changes (group names must be re-validated against the new assignment).
+  useEffect(() => {
+    if (step === 2 && csvRows.length > 0 && selection.assignmentId) {
       buildPreview();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step]);
+  }, [step, selection.assignmentId]);
 
   const processFile = (file) => {
     setFileError('');
@@ -98,7 +130,10 @@ function ImportGroupMappings() {
   const buildPreview = async () => {
     setLoadingPreview(true);
     try {
-      const [usersRes, groupsRes] = await Promise.all([api.get(`${API_BASE}/users`), api.get(`${API_BASE}/groups`)]);
+      const [usersRes, groupsRes] = await Promise.all([
+        api.get(`${API_BASE}/users`),
+        api.get(`${API_BASE}/assignments/${selection.assignmentId}/groups`),
+      ]);
       const userEmailSet = new Map((usersRes.data.users || []).map((u) => [u.email.toLowerCase(), u]));
       const groupNameSet = new Map((groupsRes.data.groups || []).map((g) => [g.name.toLowerCase(), g]));
 
@@ -109,7 +144,7 @@ function ImportGroupMappings() {
         const userExists = user !== undefined;
         const groupExists = groupNameSet.has(groupName.toLowerCase());
         const isPrivilegedUser = user && (user.role_name === 'admin' || user.role_name === 'assignment_manager');
-        const alreadyInGroup = user && user.group_id !== null && user.group_id !== undefined;
+        const alreadyInGroup = user && (user.memberships || []).some((m) => m.assignment_id === selection.assignmentId);
 
         let status = 'import';
         let statusLabel = 'Import';
@@ -193,9 +228,8 @@ function ImportGroupMappings() {
         email: r.email,
         groupName: r.groupName,
         action: r.action,
-        skipReason: r.skipReason,
       }));
-      const res = await api.post(`${API_BASE}/groups/import-mappings`, { rows });
+      const res = await api.post(`${API_BASE}/assignments/${selection.assignmentId}/import-mappings`, { rows });
       setImportResult(res.data);
 
       // Auto-download skipped rows CSV
@@ -263,8 +297,34 @@ function ImportGroupMappings() {
             ))}
           </div>
 
+          {/* Target assignment (Subject → Assignment cascade) */}
+          {step < 3 && (
+            <div className="bg-white rounded-lg shadow p-6 mb-6">
+              <h3 className="text-lg font-medium text-gray-900 mb-2">Target Assignment</h3>
+              <p className="text-gray-600 text-sm mb-4">
+                Choose the subject and assignment these group mappings belong to.
+              </p>
+              <div className="max-w-md">
+                <CascadingAssignmentSelect
+                  subjects={subjects}
+                  value={selection}
+                  onChange={setSelection}
+                  showGroup={false}
+                  disabled={importing}
+                />
+              </div>
+              {subjectsError && <p className="text-sm text-red-600">{subjectsError}</p>}
+            </div>
+          )}
+
+          {step < 3 && !selection.assignmentId && (
+            <div className="bg-white rounded-lg shadow p-6 text-sm text-gray-500">
+              Select a subject and assignment to continue.
+            </div>
+          )}
+
           {/* Step 1: Upload */}
-          {step === 1 && (
+          {step === 1 && selection.assignmentId && (
             <div className="bg-white rounded-lg shadow p-6">
               <h3 className="text-lg font-medium text-gray-900 mb-4">Upload CSV File</h3>
               <p className="text-gray-600 text-sm mb-4">
@@ -343,7 +403,7 @@ function ImportGroupMappings() {
           )}
 
           {/* Step 2: Preview */}
-          {step === 2 && (
+          {step === 2 && selection.assignmentId && (
             <div className="bg-white rounded-lg shadow p-6">
               <h3 className="text-lg font-medium text-gray-900 mb-2">Preview</h3>
 

--- a/frontend/src/pages/ImportGroupMappings.jsx
+++ b/frontend/src/pages/ImportGroupMappings.jsx
@@ -570,7 +570,7 @@ function ImportGroupMappings() {
 
       {/* Import confirmation modal */}
       {showConfirmModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div
             role="dialog"
             aria-modal="true"

--- a/frontend/src/pages/ImportUsers.jsx
+++ b/frontend/src/pages/ImportUsers.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '@/utils/api';
 import { ArrowLeft, ArrowRight, Check, AlertTriangle, ChevronDown } from 'lucide-react';
@@ -274,6 +274,9 @@ export default function ImportUsers() {
   const [existingByEmail, setExistingByEmail] = useState(new Map());
   const [existingByStudentId, setExistingByStudentId] = useState(new Map());
   const [conflictAction, setConflictAction] = useState('skip');
+  const [subjects, setSubjects] = useState([]);
+  const [subjectId, setSubjectId] = useState('');
+  const [subjectsError, setSubjectsError] = useState('');
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -281,6 +284,27 @@ export default function ImportUsers() {
 
   // Step 4
   const [result, setResult] = useState(null);
+
+  // ── Subjects (target subject for enrolment) ──────────────────────────────
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get(`${API_BASE}/subjects`)
+      .then((res) => {
+        if (!cancelled) {
+          setSubjects(res.data.subjects || []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSubjectsError('Failed to load subjects. Please reload the page.');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // ── File handling ────────────────────────────────────────────────────────
 
@@ -430,6 +454,10 @@ export default function ImportUsers() {
   // ── Import ───────────────────────────────────────────────────────────────
 
   const handleImport = async () => {
+    if (!subjectId) {
+      setSubmitError('Subject is required');
+      return;
+    }
     setSubmitting(true);
     setSubmitError('');
     try {
@@ -453,6 +481,7 @@ export default function ImportUsers() {
         users: validUsers,
         conflictAction,
         sendSetupEmail,
+        subjectId,
       });
       setResult({
         ...res.data,
@@ -460,7 +489,11 @@ export default function ImportUsers() {
       });
       setStep(4);
     } catch (e) {
-      setSubmitError(e.response?.data?.error || 'Import failed. Please try again.');
+      if (e.response?.status === 403) {
+        setSubmitError(e.response?.data?.error || 'You do not have permission to import users into this subject.');
+      } else {
+        setSubmitError(e.response?.data?.error || 'Import failed. Please try again.');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -480,6 +513,7 @@ export default function ImportUsers() {
     setExistingByEmail(new Map());
     setExistingByStudentId(new Map());
     setConflictAction('skip');
+    setSubjectId('');
     setPreviewError('');
     setSubmitError('');
     setResult(null);
@@ -740,6 +774,32 @@ export default function ImportUsers() {
 
               {/* Options */}
               <div className="flex flex-wrap gap-6 mb-5 p-4 bg-gray-50 rounded-lg border border-gray-200 text-sm">
+                <div>
+                  <label htmlFor="target-subject" className="block font-medium text-gray-700 mb-2">
+                    Target subject <span className="text-red-600">*</span>
+                  </label>
+                  <div className="relative">
+                    <select
+                      id="target-subject"
+                      value={subjectId}
+                      onChange={(e) => {
+                        setSubjectId(e.target.value);
+                        setSubmitError('');
+                      }}
+                      className="appearance-none border border-gray-300 rounded-md pl-3 pr-8 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white"
+                    >
+                      <option value="">Select subject</option>
+                      {subjects.map((s) => (
+                        <option key={s.id} value={s.id}>
+                          {s.name}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400 pointer-events-none" />
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">Imported users will be enrolled in this subject.</p>
+                  {subjectsError && <p className="text-xs text-red-600 mt-1">{subjectsError}</p>}
+                </div>
                 <fieldset>
                   <legend className="font-medium text-gray-700 mb-2">For existing users:</legend>
                   <div className="flex gap-4">

--- a/frontend/src/pages/SubjectDetail.jsx
+++ b/frontend/src/pages/SubjectDetail.jsx
@@ -5,13 +5,14 @@ import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
 import IconBtn from '../components/IconBtn.jsx';
 import TypedDeleteConfirmModal from '../components/TypedDeleteConfirmModal.jsx';
+import SubjectMembersSection from '../components/SubjectMembersSection.jsx';
 import { Trash2 } from 'lucide-react';
 import { parseBody, createAssignmentSchema } from '../utils/schemas.js';
 import { API_BASE } from '../config.js';
 
 function SubjectDetail() {
   const { subjectId } = useParams();
-  const { isAdmin } = useAuth();
+  const { isAdmin, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -119,6 +120,10 @@ function SubjectDetail() {
       setDeleting(false);
     }
   };
+
+  // Admins manage every subject; assignment managers only manage subjects where
+  // they manage at least one assignment (managedAssignments rows carry subject_id).
+  const canManage = isAdmin || (user?.managedAssignments || []).some((a) => a.subject_id === subject?.id);
 
   if (loading) {
     return (
@@ -255,6 +260,9 @@ function SubjectDetail() {
               </table>
             </div>
           )}
+
+          {/* Members section — visible only to admins and managers of this subject */}
+          {subject && canManage && <SubjectMembersSection subject={subject} isAdmin={isAdmin} canManage={canManage} />}
         </div>
       </main>
 

--- a/frontend/src/pages/SubjectDetail.jsx
+++ b/frontend/src/pages/SubjectDetail.jsx
@@ -1,0 +1,319 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import api from '@/utils/api';
+import { useAuth } from '../context/AuthContext.jsx';
+import Header from '../components/Header.jsx';
+import IconBtn from '../components/IconBtn.jsx';
+import TypedDeleteConfirmModal from '../components/TypedDeleteConfirmModal.jsx';
+import { Trash2 } from 'lucide-react';
+import { parseBody, createAssignmentSchema } from '../utils/schemas.js';
+import { API_BASE } from '../config.js';
+
+function SubjectDetail() {
+  const { subjectId } = useParams();
+  const { isAdmin } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [subject, setSubject] = useState(null);
+  const [assignments, setAssignments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Create assignment modal
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newAssignmentName, setNewAssignmentName] = useState('');
+  const [createFormError, setCreateFormError] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  // Delete confirmation modal — holds the assignment to delete
+  const [deleteModal, setDeleteModal] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const successTimeoutRef = useRef(null);
+  const errorTimeoutRef = useRef(null);
+
+  const fetchSubject = useCallback(async () => {
+    try {
+      const response = await api.get(`${API_BASE}/subjects/${subjectId}`);
+      setSubject(response.data.subject || null);
+      setAssignments(response.data.assignments || []);
+      setLoadError(false);
+    } catch (_err) {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [subjectId]);
+
+  // Re-fetch whenever this page is navigated to (location.key changes on each navigation).
+  useEffect(() => {
+    fetchSubject();
+  }, [location.key, fetchSubject]);
+
+  // Re-fetch when the browser tab becomes visible again (multi-tab scenario).
+  useEffect(() => {
+    const handler = () => {
+      if (!document.hidden) {
+        fetchSubject();
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [fetchSubject]);
+
+  const showError = (msg) => {
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+    }
+    setError(msg);
+    errorTimeoutRef.current = setTimeout(() => setError(''), 3000);
+  };
+
+  const showSuccess = (msg) => {
+    if (successTimeoutRef.current) {
+      clearTimeout(successTimeoutRef.current);
+    }
+    setSuccess(msg);
+    successTimeoutRef.current = setTimeout(() => setSuccess(''), 2000);
+  };
+
+  const handleCreateAssignment = async (e) => {
+    e.preventDefault();
+    setCreateFormError('');
+    const { data: body, error: validationError } = parseBody(createAssignmentSchema, {
+      subjectId,
+      name: newAssignmentName,
+    });
+    if (validationError) {
+      setCreateFormError(validationError);
+      return;
+    }
+    setCreating(true);
+    try {
+      await api.post(`${API_BASE}/assignments`, { subjectId: body.subjectId, name: body.name });
+      showSuccess('Assignment created successfully');
+      setNewAssignmentName('');
+      setShowCreateModal(false);
+      fetchSubject();
+    } catch (err) {
+      setCreateFormError(err.response?.data?.error || 'Failed to create assignment');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDeleteConfirmed = async () => {
+    setDeleting(true);
+    try {
+      await api.delete(`${API_BASE}/assignments/${deleteModal.id}`);
+      showSuccess('Assignment deleted successfully');
+      setDeleteModal(null);
+      fetchSubject();
+    } catch (err) {
+      showError(err.response?.data?.error || 'Failed to delete assignment');
+      setDeleteModal(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex-1 bg-gray-50">
+        <Header pageName="Subject" />
+        <main className="w-[85%] mx-auto py-6">
+          <div className="px-4 py-6 sm:px-0">
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+              Failed to load subject
+            </div>
+            <Link to="/subjects" className="text-primary-600 hover:text-primary-700 font-medium">
+              Back to Subjects
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 bg-gray-50">
+      <Header pageName="Subject" />
+
+      <main className="w-[85%] mx-auto py-6">
+        <div className="px-4 py-6 sm:px-0">
+          {/* Breadcrumb */}
+          <nav aria-label="Breadcrumb" className="mb-4 text-sm text-gray-500">
+            <Link to="/subjects" className="text-primary-600 hover:text-primary-700">
+              Subjects
+            </Link>
+            <span className="mx-2">/</span>
+            <span className="text-gray-900 font-medium">{subject?.name}</span>
+          </nav>
+
+          {/* Toolbar */}
+          <div className="mb-6 flex justify-between items-center">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">{subject?.name}</h2>
+              <p className="text-gray-600 mt-1">Assignments in this subject</p>
+            </div>
+            {isAdmin && (
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
+              >
+                + Create Assignment
+              </button>
+            )}
+          </div>
+
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-md text-sm">
+              {success}
+            </div>
+          )}
+
+          {assignments.length === 0 ? (
+            <div className="text-center py-12 bg-white rounded-lg shadow">
+              <p className="text-gray-500">No assignments yet</p>
+            </div>
+          ) : (
+            <div className="bg-white shadow overflow-x-auto rounded-lg">
+              <table className="w-full min-w-[680px] divide-y divide-gray-200 table-fixed">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="w-[40%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Name
+                    </th>
+                    <th className="w-[16%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Groups
+                    </th>
+                    <th className="w-[18%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Created
+                    </th>
+                    <th className="w-[14%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {assignments.map((assignment) => (
+                    <tr
+                      key={assignment.id}
+                      onClick={() => navigate(`/subjects/${subjectId}/assignments/${assignment.id}`)}
+                      className="cursor-pointer hover:bg-gray-50 transition-colors"
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                          e.preventDefault();
+                          navigate(`/subjects/${subjectId}/assignments/${assignment.id}`);
+                        }
+                      }}
+                    >
+                      <td className="px-4 py-4">
+                        <span className="text-sm font-medium text-gray-900">{assignment.name}</span>
+                      </td>
+                      <td className="px-4 py-4 text-sm text-gray-700">{assignment.group_count}</td>
+                      <td className="px-4 py-4 text-sm text-gray-500">
+                        {new Date(assignment.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-4">
+                        {isAdmin && (
+                          <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+                            <IconBtn
+                              label="Delete Assignment"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeleteModal(assignment);
+                              }}
+                              className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </IconBtn>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Create Assignment Modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New Assignment</h3>
+            <form onSubmit={handleCreateAssignment}>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Assignment Name</label>
+                <input
+                  type="text"
+                  value={newAssignmentName}
+                  onChange={(e) => setNewAssignmentName(e.target.value)}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter assignment name"
+                  autoFocus
+                />
+              </div>
+              {createFormError && <p className="mb-3 text-sm text-red-600">{createFormError}</p>}
+              <div className="flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCreateModal(false);
+                    setNewAssignmentName('');
+                    setCreateFormError('');
+                  }}
+                  className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={creating}
+                  className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {creating ? 'Creating...' : 'Create'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Assignment Modal (two-step typed confirmation) */}
+      {deleteModal && (
+        <TypedDeleteConfirmModal
+          entityLabel="assignment"
+          entityName={deleteModal.name}
+          warning={`${deleteModal.group_count} groups and their memberships will be permanently deleted`}
+          deleting={deleting}
+          onConfirm={handleDeleteConfirmed}
+          onCancel={() => setDeleteModal(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default SubjectDetail;

--- a/frontend/src/pages/SubjectDetail.jsx
+++ b/frontend/src/pages/SubjectDetail.jsx
@@ -260,7 +260,7 @@ function SubjectDetail() {
 
       {/* Create Assignment Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New Assignment</h3>
             <form onSubmit={handleCreateAssignment}>

--- a/frontend/src/pages/Subjects.jsx
+++ b/frontend/src/pages/Subjects.jsx
@@ -246,7 +246,7 @@ function Subjects() {
 
       {/* Create Subject Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New Subject</h3>
             <form onSubmit={handleCreateSubject}>

--- a/frontend/src/pages/Subjects.jsx
+++ b/frontend/src/pages/Subjects.jsx
@@ -1,0 +1,305 @@
+import { useState, useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import api from '@/utils/api';
+import { useAuth } from '../context/AuthContext.jsx';
+import Header from '../components/Header.jsx';
+import IconBtn from '../components/IconBtn.jsx';
+import TypedDeleteConfirmModal from '../components/TypedDeleteConfirmModal.jsx';
+import { Trash2 } from 'lucide-react';
+import { parseBody, createSubjectSchema } from '../utils/schemas.js';
+import { API_BASE } from '../config.js';
+
+function Subjects() {
+  const { isAdmin } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [subjects, setSubjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // Create subject modal
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newSubjectName, setNewSubjectName] = useState('');
+  const [createFormError, setCreateFormError] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  // Delete confirmation modal — holds the subject to delete
+  const [deleteModal, setDeleteModal] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const successTimeoutRef = useRef(null);
+  const errorTimeoutRef = useRef(null);
+
+  // Re-fetch whenever this page is navigated to (location.key changes on each navigation).
+  useEffect(() => {
+    fetchSubjects();
+  }, [location.key]);
+
+  // Re-fetch when the browser tab becomes visible again (multi-tab scenario).
+  useEffect(() => {
+    const handler = () => {
+      if (!document.hidden) {
+        fetchSubjects();
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, []);
+
+  const fetchSubjects = async () => {
+    try {
+      const response = await api.get(`${API_BASE}/subjects`);
+      setSubjects(response.data.subjects || []);
+    } catch (_err) {
+      setError('Failed to load subjects');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const showError = (msg) => {
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+    }
+    setError(msg);
+    errorTimeoutRef.current = setTimeout(() => setError(''), 3000);
+  };
+
+  const showSuccess = (msg) => {
+    if (successTimeoutRef.current) {
+      clearTimeout(successTimeoutRef.current);
+    }
+    setSuccess(msg);
+    successTimeoutRef.current = setTimeout(() => setSuccess(''), 2000);
+  };
+
+  const handleCreateSubject = async (e) => {
+    e.preventDefault();
+    setCreateFormError('');
+    const { data: body, error: validationError } = parseBody(createSubjectSchema, { name: newSubjectName });
+    if (validationError) {
+      setCreateFormError(validationError);
+      return;
+    }
+    setCreating(true);
+    try {
+      await api.post(`${API_BASE}/subjects`, { name: body.name });
+      showSuccess('Subject created successfully');
+      setNewSubjectName('');
+      setShowCreateModal(false);
+      fetchSubjects();
+    } catch (err) {
+      setCreateFormError(err.response?.data?.error || 'Failed to create subject');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDeleteConfirmed = async () => {
+    setDeleting(true);
+    try {
+      await api.delete(`${API_BASE}/subjects/${deleteModal.id}`);
+      showSuccess('Subject deleted successfully');
+      setDeleteModal(null);
+      fetchSubjects();
+    } catch (err) {
+      showError(err.response?.data?.error || 'Failed to delete subject');
+      setDeleteModal(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const matchingSubjects = searchTerm
+    ? subjects.filter((s) => s.name.toLowerCase().includes(searchTerm.toLowerCase()))
+    : subjects;
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 bg-gray-50">
+      <Header pageName="Subjects" />
+
+      <main className="w-[85%] mx-auto py-6">
+        <div className="px-4 py-6 sm:px-0">
+          {/* Toolbar */}
+          <div className="mb-6 flex justify-between items-center">
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Manage Subjects</h2>
+              <p className="text-gray-600 mt-1">Browse subjects and drill into their assignments</p>
+            </div>
+            {isAdmin && (
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 transition-colors"
+              >
+                + Create Subject
+              </button>
+            )}
+          </div>
+
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded-md text-sm">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-600 px-4 py-3 rounded-md text-sm">
+              {success}
+            </div>
+          )}
+
+          {/* Search */}
+          <div className="mb-4">
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search subjects..."
+              aria-label="Search subjects"
+              className="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 w-72"
+            />
+          </div>
+
+          {matchingSubjects.length === 0 ? (
+            <div className="text-center py-12 bg-white rounded-lg shadow">
+              <p className="text-gray-500">No subjects found</p>
+            </div>
+          ) : (
+            <div className="bg-white shadow overflow-x-auto rounded-lg">
+              <table className="w-full min-w-[680px] divide-y divide-gray-200 table-fixed">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="w-[36%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Name
+                    </th>
+                    <th className="w-[16%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Assignments
+                    </th>
+                    <th className="w-[16%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Members
+                    </th>
+                    <th className="w-[18%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Created
+                    </th>
+                    <th className="w-[14%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {matchingSubjects.map((subject) => (
+                    <tr
+                      key={subject.id}
+                      onClick={() => navigate(`/subjects/${subject.id}`)}
+                      className="cursor-pointer hover:bg-gray-50 transition-colors"
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                          e.preventDefault();
+                          navigate(`/subjects/${subject.id}`);
+                        }
+                      }}
+                    >
+                      <td className="px-4 py-4">
+                        <span className="text-sm font-medium text-gray-900">{subject.name}</span>
+                      </td>
+                      <td className="px-4 py-4 text-sm text-gray-700">{subject.assignment_count}</td>
+                      <td className="px-4 py-4 text-sm text-gray-700">{subject.member_count}</td>
+                      <td className="px-4 py-4 text-sm text-gray-500">
+                        {new Date(subject.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-4">
+                        {isAdmin && (
+                          <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+                            <IconBtn
+                              label="Delete Subject"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeleteModal(subject);
+                              }}
+                              className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </IconBtn>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Create Subject Modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New Subject</h3>
+            <form onSubmit={handleCreateSubject}>
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Subject Name</label>
+                <input
+                  type="text"
+                  value={newSubjectName}
+                  onChange={(e) => setNewSubjectName(e.target.value)}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  placeholder="Enter subject name"
+                  autoFocus
+                />
+              </div>
+              {createFormError && <p className="mb-3 text-sm text-red-600">{createFormError}</p>}
+              <div className="flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCreateModal(false);
+                    setNewSubjectName('');
+                    setCreateFormError('');
+                  }}
+                  className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={creating}
+                  className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {creating ? 'Creating...' : 'Create'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Subject Modal (two-step typed confirmation) */}
+      {deleteModal && (
+        <TypedDeleteConfirmModal
+          entityLabel="subject"
+          entityName={deleteModal.name}
+          warning={`${deleteModal.assignment_count} assignments and ${deleteModal.member_count} members will be permanently deleted`}
+          deleting={deleting}
+          onConfirm={handleDeleteConfirmed}
+          onCancel={() => setDeleteModal(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Subjects;

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -28,6 +28,31 @@ const emptySelection = { subjectId: '', assignmentId: '', groupId: '' };
 const membershipLines = (u) =>
   (u.memberships || []).map((m) => `${m.subject_name} › ${m.assignment_name} › ${m.group_name}`);
 
+/**
+ * Render a user's subject names for the Subjects column. Subjects whose
+ * membership is suspended (membership_enabled === false; undefined counts as
+ * enabled) get a " (suspended)" suffix and line-through styling.
+ */
+const renderSubjectNames = (u) => {
+  const subjectList = u.subjects || [];
+  if (subjectList.length === 0) {
+    return '—';
+  }
+  if (subjectList.every((s) => s.membership_enabled !== false)) {
+    return subjectList.map((s) => s.name).join(', ');
+  }
+  return subjectList.map((s, index) => (
+    <span key={s.id}>
+      {index > 0 && ', '}
+      {s.membership_enabled === false ? (
+        <span className="line-through text-gray-400">{s.name} (suspended)</span>
+      ) : (
+        s.name
+      )}
+    </span>
+  ));
+};
+
 function Users() {
   const { user, isAdmin, isAssignmentManager } = useAuth();
   const navigate = useNavigate();
@@ -517,7 +542,7 @@ function Users() {
                   <div className="text-sm">&nbsp;</div>
                 ) : (
                   <div className="text-sm text-gray-900 truncate" title={membershipLines(u).join('\n')}>
-                    {(u.subjects || []).map((s) => s.name).join(', ') || '—'}
+                    {renderSubjectNames(u)}
                   </div>
                 )}
               </td>

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import api from '@/utils/api';
-import { Pencil, UserPlus, Check, X, Download, Trash2, Upload, Mail } from 'lucide-react';
+import { Pencil, UserPlus, BookOpen, Download, Trash2, Upload, Mail } from 'lucide-react';
 import { useAuth } from '../context/AuthContext.jsx';
 import Header from '../components/Header.jsx';
 import { formatRoleName } from '../utils/formatting.js';
 import IndeterminateCheckbox from '../components/IndeterminateCheckbox.jsx';
+import AssignGroupModal from '../components/AssignGroupModal.jsx';
+import SubjectMembershipModal from '../components/SubjectMembershipModal.jsx';
+import CascadingAssignmentSelect from '../components/CascadingAssignmentSelect.jsx';
 import { parseBody, createUserSchema, updateUserSchema } from '../utils/schemas.js';
 import { API_BASE } from '../config.js';
 
@@ -15,23 +18,30 @@ const emptyNewUser = {
   lastName: '',
   email: '',
   studentId: '',
-  groupId: '',
   role: 'user',
   sendSetupEmail: false,
 };
+
+const emptySelection = { subjectId: '', assignmentId: '', groupId: '' };
+
+/** Format a user's group memberships as "Subject › Assignment › Group" lines. */
+const membershipLines = (u) =>
+  (u.memberships || []).map((m) => `${m.subject_name} › ${m.assignment_name} › ${m.group_name}`);
 
 function Users() {
   const { user, isAdmin, isAssignmentManager } = useAuth();
   const navigate = useNavigate();
   const [users, setUsers] = useState([]);
-  const [groups, setGroups] = useState([]);
+  const [subjects, setSubjects] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-  const [selectedUser, setSelectedUser] = useState(null);
-  const [selectedGroup, setSelectedGroup] = useState('');
+  const [warning, setWarning] = useState('');
+  const [assignModalUser, setAssignModalUser] = useState(null);
+  const [membershipModalUser, setMembershipModalUser] = useState(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newUser, setNewUser] = useState({ ...emptyNewUser });
+  const [createSelection, setCreateSelection] = useState({ ...emptySelection });
   const [editingUser, setEditingUser] = useState(null);
   const [formError, setFormError] = useState('');
   const [sendingEmails, setSendingEmails] = useState(false);
@@ -47,11 +57,12 @@ function Users() {
   // Filters
   const [filterRole, setFilterRole] = useState('');
   const [filterStatus, setFilterStatus] = useState('');
-  const [filterGroup, setFilterGroup] = useState('');
+  const [filterSubject, setFilterSubject] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
 
   const successTimeoutRef = useRef(null);
   const errorTimeoutRef = useRef(null);
+  const warningTimeoutRef = useRef(null);
 
   const location = useLocation();
 
@@ -75,12 +86,12 @@ function Users() {
 
   const fetchData = async () => {
     try {
-      const [usersRes, groupsRes] = await Promise.all([
+      const [usersRes, subjectsRes] = await Promise.all([
         api.get(`${API_BASE}/users`),
-        api.get(`${API_BASE}/groups/enabled`),
+        api.get(`${API_BASE}/subjects`),
       ]);
       setUsers(usersRes.data.users || []);
-      setGroups(groupsRes.data.groups || []);
+      setSubjects(subjectsRes.data.subjects || []);
     } catch (_err) {
       setError('Failed to load data');
     } finally {
@@ -88,32 +99,33 @@ function Users() {
     }
   };
 
-  const handleGroupChange = async (userId, groupId) => {
-    try {
-      await api.put(`${API_BASE}/users/${userId}/group`, { groupId });
-      showSuccess('User group updated successfully');
-      fetchData();
-    } catch (err) {
-      showError(err.response?.data?.error || 'Failed to update group');
-    }
-  };
-
-  const handleAssignGroup = async () => {
-    if (!selectedUser) {
-      return;
-    }
-
-    const groupId = selectedGroup === '' ? null : selectedGroup;
-    await handleGroupChange(selectedUser, groupId);
-    setSelectedUser(null);
-    setSelectedGroup('');
-  };
-
   const handleCreateUser = async (e) => {
     e.preventDefault();
     setFormError('');
 
-    const { data: body, error: validationError } = parseBody(createUserSchema, newUser);
+    if (newUser.role === 'user' && !createSelection.subjectId) {
+      setFormError('Subject is required');
+      return;
+    }
+
+    const candidate = {
+      username: newUser.username,
+      email: newUser.email,
+      firstName: newUser.firstName,
+      lastName: newUser.lastName,
+      studentId: newUser.studentId,
+      role: newUser.role,
+      sendSetupEmail: newUser.sendSetupEmail,
+      ...(newUser.role === 'user' && {
+        subjectIds: [createSelection.subjectId],
+        assignmentId: createSelection.assignmentId,
+        groupId: createSelection.groupId,
+      }),
+      ...(newUser.role === 'assignment_manager' &&
+        createSelection.assignmentId && { assignmentIds: [createSelection.assignmentId] }),
+    };
+
+    const { data: body, error: validationError } = parseBody(createUserSchema, candidate);
     if (validationError) {
       setFormError(validationError);
       return;
@@ -121,18 +133,25 @@ function Users() {
 
     setCreating(true);
     try {
-      await api.post(`${API_BASE}/users`, {
+      const res = await api.post(`${API_BASE}/users`, {
         username: body.username,
         email: body.email,
         firstName: body.firstName || undefined,
         lastName: body.lastName || undefined,
         studentId: body.studentId || undefined,
-        groupId: body.groupId || undefined,
         role: body.role,
         sendSetupEmail: body.sendSetupEmail,
+        ...(body.subjectIds && { subjectIds: body.subjectIds }),
+        ...(body.assignmentId && { assignmentId: body.assignmentId }),
+        ...(body.groupId && { groupId: body.groupId }),
+        ...(body.assignmentIds && { assignmentIds: body.assignmentIds }),
       });
       showSuccess('User created successfully');
+      if (res.data?.warning) {
+        showWarning(res.data.warning);
+      }
       setNewUser({ ...emptyNewUser });
+      setCreateSelection({ ...emptySelection });
       setShowCreateModal(false);
       fetchData();
     } catch (err) {
@@ -218,6 +237,7 @@ function Users() {
       roleName: u.role_name || 'user',
       originalRoleName: u.role_name || 'user',
       enabled: u.enabled !== false,
+      memberships: u.memberships || [],
     });
   };
 
@@ -235,6 +255,14 @@ function Users() {
     }
     setError(msg);
     errorTimeoutRef.current = setTimeout(() => setError(''), 3000);
+  };
+
+  const showWarning = (msg) => {
+    if (warningTimeoutRef.current) {
+      clearTimeout(warningTimeoutRef.current);
+    }
+    setWarning(msg);
+    warningTimeoutRef.current = setTimeout(() => setWarning(''), 6000);
   };
 
   // ── Selection helpers ──────────────────────────────────────────────────
@@ -349,14 +377,15 @@ function Users() {
       const str = val === null || val === undefined ? '' : String(val);
       return str.includes(',') || str.includes('"') || str.includes('\n') ? `"${str.replace(/"/g, '""')}"` : str;
     };
-    const headers = ['Username', 'First Name', 'Last Name', 'Email', 'Role', 'Group', 'Student ID'];
+    const headers = ['Username', 'First Name', 'Last Name', 'Email', 'Role', 'Subjects', 'Groups', 'Student ID'];
     const rows = exportUsers.map((u) => [
       csvEscape(u.username),
       csvEscape(u.first_name),
       csvEscape(u.last_name),
       csvEscape(u.email),
       csvEscape(formatRoleName(u.role_name)),
-      csvEscape(u.group_name),
+      csvEscape((u.subjects || []).map((s) => s.name).join(', ')),
+      csvEscape((u.memberships || []).map((m) => `${m.assignment_name}:${m.group_name}`).join(', ')),
       csvEscape(u.student_id),
     ]);
     const csv = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
@@ -381,10 +410,7 @@ function Users() {
     if (filterStatus && u.status !== filterStatus) {
       return false;
     }
-    if (filterGroup === 'none' && u.group_id) {
-      return false;
-    }
-    if (filterGroup && filterGroup !== 'none' && u.group_id !== filterGroup) {
+    if (filterSubject && !(u.subjects || []).some((s) => s.id === filterSubject)) {
       return false;
     }
     if (searchTerm) {
@@ -401,11 +427,11 @@ function Users() {
   });
 
   const adminUsers = filteredUsers.filter((u) => u.role_name === 'admin' || u.role_name === 'assignment_manager');
-  const ungroupedUsers = filteredUsers.filter((u) => u.role_name === 'user' && !u.group_id);
-  const groupedUsers = filteredUsers.filter((u) => u.role_name === 'user' && !!u.group_id);
+  const noSubjectUsers = filteredUsers.filter((u) => u.role_name === 'user' && (u.subjects || []).length === 0);
+  const subjectUsers = filteredUsers.filter((u) => u.role_name === 'user' && (u.subjects || []).length > 0);
 
   const selectedUsers = users.filter((u) => selectedIds.has(u.id));
-  const deleteModalWithGroup = (deleteModal ?? []).filter((u) => !!u.group_id);
+  const deleteModalWithMemberships = (deleteModal ?? []).filter((u) => (u.memberships || []).length > 0);
 
   const renderTable = (sectionUsers, emptyMessage) => (
     <div className="bg-white shadow overflow-x-auto rounded-lg">
@@ -426,7 +452,7 @@ function Users() {
               Role
             </th>
             <th className="w-[18%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Current Group
+              Subjects
             </th>
             <th className="w-[10%] px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Status
@@ -490,8 +516,8 @@ function Users() {
                 {u.role_name === 'admin' || u.role_name === 'assignment_manager' ? (
                   <div className="text-sm">&nbsp;</div>
                 ) : (
-                  <div className="text-sm text-gray-900 truncate" title={u.group_name || 'Not assigned'}>
-                    {u.group_name || 'Not assigned'}
+                  <div className="text-sm text-gray-900 truncate" title={membershipLines(u).join('\n')}>
+                    {(u.subjects || []).map((s) => s.name).join(', ') || '—'}
                   </div>
                 )}
               </td>
@@ -509,89 +535,67 @@ function Users() {
                 </span>
               </td>
               <td className="px-4 py-4">
-                {selectedUser === u.id ? (
-                  <div className="flex items-center gap-2">
-                    <select
-                      value={selectedGroup}
-                      onChange={(e) => setSelectedGroup(e.target.value)}
-                      className="min-w-0 flex-1 border border-gray-300 rounded-md px-2 py-1 text-sm"
-                      aria-label="Assign to group"
-                    >
-                      <option value="">No Group</option>
-                      {groups
-                        .filter((g) => g.max_members === null || g.member_count < g.max_members)
-                        .map((g) => (
-                          <option key={g.id} value={g.id}>
-                            {g.name}
-                          </option>
-                        ))}
-                    </select>
-                    <button
-                      onClick={handleAssignGroup}
-                      aria-label="Save"
-                      className="text-primary-600 hover:text-primary-800"
-                    >
-                      <Check className="h-4 w-4" />
-                    </button>
-                    <button
-                      onClick={() => {
-                        setSelectedUser(null);
-                        setSelectedGroup('');
-                      }}
-                      aria-label="Cancel"
-                      className="text-gray-500 hover:text-gray-700"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-1">
-                    {/* Edit User Profile button for admins, assignment managers (non-admins), and users editing their own profile */}
-                    {(isAdmin || (isAssignmentManager && u.role_name !== 'admin') || u.id === user?.id) && (
-                      <div className="relative group">
-                        <button
-                          onClick={() => openEditModal(u)}
-                          aria-label="Edit User Profile"
-                          className="p-1.5 rounded text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </button>
-                        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                          Edit User Profile
-                        </span>
-                      </div>
-                    )}
-                    {/* Assign Group button only visible for users with role 'user' */}
-                    {u.role_name === 'user' && (
-                      <div className="relative group">
-                        <button
-                          onClick={() => setSelectedUser(u.id)}
-                          aria-label="Assign Group"
-                          className="p-1.5 rounded text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors"
-                        >
-                          <UserPlus className="h-4 w-4" />
-                        </button>
-                        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                          Assign Group
-                        </span>
-                      </div>
-                    )}
-                    {isAdmin && u.id !== user?.id && (
-                      <div className="relative group">
-                        <button
-                          onClick={() => handleDeleteUser(u.id)}
-                          aria-label="Delete User"
-                          className="p-1.5 rounded text-red-400 hover:text-red-600 hover:bg-red-50 transition-colors"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                        <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                          Delete User
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                )}
+                <div className="flex items-center gap-1">
+                  {/* Edit User Profile button for admins, assignment managers (non-admins), and users editing their own profile */}
+                  {(isAdmin || (isAssignmentManager && u.role_name !== 'admin') || u.id === user?.id) && (
+                    <div className="relative group">
+                      <button
+                        onClick={() => openEditModal(u)}
+                        aria-label="Edit User Profile"
+                        className="p-1.5 rounded text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                        Edit User Profile
+                      </span>
+                    </div>
+                  )}
+                  {/* Assign Group opens the modal; admins and assignment managers only (backend enforces AM scope) */}
+                  {(isAdmin || isAssignmentManager) && u.role_name === 'user' && (
+                    <div className="relative group">
+                      <button
+                        onClick={() => setAssignModalUser(u)}
+                        aria-label="Assign Group"
+                        className="p-1.5 rounded text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                      >
+                        <UserPlus className="h-4 w-4" />
+                      </button>
+                      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                        Assign Group
+                      </span>
+                    </div>
+                  )}
+                  {/* Manage Subjects is admin only */}
+                  {isAdmin && u.role_name === 'user' && (
+                    <div className="relative group">
+                      <button
+                        onClick={() => setMembershipModalUser(u)}
+                        aria-label="Manage Subjects"
+                        className="p-1.5 rounded text-gray-500 hover:text-primary-600 hover:bg-primary-50 transition-colors"
+                      >
+                        <BookOpen className="h-4 w-4" />
+                      </button>
+                      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                        Manage Subjects
+                      </span>
+                    </div>
+                  )}
+                  {isAdmin && u.id !== user?.id && (
+                    <div className="relative group">
+                      <button
+                        onClick={() => handleDeleteUser(u.id)}
+                        aria-label="Delete User"
+                        className="p-1.5 rounded text-red-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                      <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 px-2 py-1 text-xs bg-gray-800 text-white rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity z-10">
+                        Delete User
+                      </span>
+                    </div>
+                  )}
+                </div>
               </td>
             </tr>
           ))}
@@ -738,6 +742,12 @@ function Users() {
             </div>
           )}
 
+          {warning && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-md text-sm">
+              {warning}
+            </div>
+          )}
+
           {/* Filters */}
           <div className="mb-6 flex flex-wrap items-center gap-3">
             <input
@@ -772,25 +782,24 @@ function Users() {
               <option value="pending">Pending</option>
             </select>
             <select
-              value={filterGroup}
-              onChange={(e) => setFilterGroup(e.target.value)}
-              aria-label="Filter by group"
+              value={filterSubject}
+              onChange={(e) => setFilterSubject(e.target.value)}
+              aria-label="Filter by subject"
               className="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             >
-              <option value="">All Groups</option>
-              <option value="none">Unassigned</option>
-              {groups.map((g) => (
-                <option key={g.id} value={g.id}>
-                  {g.name}
+              <option value="">All subjects</option>
+              {subjects.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
                 </option>
               ))}
             </select>
-            {(filterRole || filterStatus || filterGroup || searchTerm) && (
+            {(filterRole || filterStatus || filterSubject || searchTerm) && (
               <button
                 onClick={() => {
                   setFilterRole('');
                   setFilterStatus('');
-                  setFilterGroup('');
+                  setFilterSubject('');
                   setSearchTerm('');
                 }}
                 className="text-sm text-gray-500 hover:text-primary-600 underline"
@@ -809,22 +818,22 @@ function Users() {
             'Export Administrators'
           )}
 
-          {/* Section 2: Unassigned users */}
+          {/* Section 2: Users not enrolled in any subject */}
           {renderSection(
-            'Users without a group',
-            ungroupedUsers,
-            'All users are assigned to a group',
-            () => exportToCsv(ungroupedUsers, 'users-without-group.csv'),
-            'Export Users without a group'
+            'Users without a subject',
+            noSubjectUsers,
+            'All users belong to a subject',
+            () => exportToCsv(noSubjectUsers, 'users-without-subject.csv'),
+            'Export Users without a subject'
           )}
 
-          {/* Section 3: Assigned users */}
+          {/* Section 3: Users enrolled in at least one subject */}
           {renderSection(
-            'Users in a group',
-            groupedUsers,
-            'No users have been assigned to a group yet',
-            () => exportToCsv(groupedUsers, 'users-in-group.csv'),
-            'Export Users in a group'
+            'Users in subjects',
+            subjectUsers,
+            'No users belong to a subject yet',
+            () => exportToCsv(subjectUsers, 'users-in-subjects.csv'),
+            'Export Users in subjects'
           )}
         </div>
       </main>
@@ -898,7 +907,10 @@ function Users() {
                 </label>
                 <select
                   value={newUser.role}
-                  onChange={(e) => setNewUser({ ...newUser, role: e.target.value })}
+                  onChange={(e) => {
+                    setNewUser({ ...newUser, role: e.target.value });
+                    setCreateSelection({ ...emptySelection });
+                  }}
                   className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
                   <option value="user">User</option>
@@ -918,21 +930,30 @@ function Users() {
                       placeholder="Enter student ID"
                     />
                   </div>
-                  <div className="mb-3">
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Group (Optional)</label>
-                    <select
-                      value={newUser.groupId}
-                      onChange={(e) => setNewUser({ ...newUser, groupId: e.target.value })}
-                      className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    >
-                      <option value="">No Group</option>
-                      {groups.map((g) => (
-                        <option key={g.id} value={g.id}>
-                          {g.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  <p className="mb-2 text-xs text-gray-500">
+                    Subject is required. Assignment and group allow immediate placement (optional).
+                  </p>
+                  <CascadingAssignmentSelect
+                    subjects={subjects}
+                    value={createSelection}
+                    onChange={setCreateSelection}
+                    showGroup
+                    disabled={creating}
+                  />
+                </>
+              )}
+              {newUser.role === 'assignment_manager' && (
+                <>
+                  <p className="mb-2 text-xs text-gray-500">
+                    Optionally scope the manager to an assignment (pick a subject to narrow the list).
+                  </p>
+                  <CascadingAssignmentSelect
+                    subjects={subjects}
+                    value={createSelection}
+                    onChange={setCreateSelection}
+                    showGroup={false}
+                    disabled={creating}
+                  />
                 </>
               )}
               <div className="mb-3 text-sm text-gray-500 bg-blue-50 border border-blue-200 rounded-md px-3 py-2">
@@ -956,6 +977,7 @@ function Users() {
                   onClick={() => {
                     setShowCreateModal(false);
                     setNewUser({ ...emptyNewUser });
+                    setCreateSelection({ ...emptySelection });
                   }}
                   className="px-4 py-2 text-gray-700 hover:text-gray-900"
                 >
@@ -1047,6 +1069,20 @@ function Users() {
                     className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary-500"
                     placeholder="Enter student ID"
                   />
+                </div>
+              )}
+              {editingUser.roleName === 'user' && (
+                <div className="mb-3">
+                  <span className="block text-sm font-medium text-gray-700 mb-1">Memberships</span>
+                  {editingUser.memberships.length > 0 ? (
+                    <ul className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-md px-3 py-2 space-y-0.5">
+                      {membershipLines({ memberships: editingUser.memberships }).map((line) => (
+                        <li key={line}>{line}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-gray-500">None</p>
+                  )}
                 </div>
               )}
               {isAdmin && editingUser.username !== 'admin' && (
@@ -1142,16 +1178,16 @@ function Users() {
               </h3>
             </div>
             <div className="flex-1 overflow-y-auto px-6 py-3">
-              {deleteModalWithGroup.length > 0 && (
+              {deleteModalWithMemberships.length > 0 && (
                 <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-md px-3 py-2 text-sm text-yellow-800">
                   <p className="font-medium mb-1">
-                    {deleteModalWithGroup.length} user{deleteModalWithGroup.length > 1 ? 's are' : ' is'} in a group and
-                    will be unassigned:
+                    {deleteModalWithMemberships.length} user{deleteModalWithMemberships.length > 1 ? 's have' : ' has'}{' '}
+                    group memberships that will be removed:
                   </p>
                   <ul className="list-disc list-inside space-y-0.5">
-                    {deleteModalWithGroup.map((u) => (
+                    {deleteModalWithMemberships.map((u) => (
                       <li key={u.id}>
-                        {u.username} <span className="text-yellow-600">({u.group_name})</span>
+                        {u.username} <span className="text-yellow-600">({membershipLines(u).join('; ')})</span>
                       </li>
                     ))}
                   </ul>
@@ -1178,6 +1214,30 @@ function Users() {
             </div>
           </div>
         </div>
+      )}
+      {/* Assign Group Modal */}
+      {assignModalUser && (
+        <AssignGroupModal
+          user={assignModalUser}
+          subjects={subjects}
+          onClose={() => setAssignModalUser(null)}
+          onAssigned={() => {
+            showSuccess('User group updated successfully');
+            fetchData();
+          }}
+        />
+      )}
+      {/* Manage Subjects Modal */}
+      {membershipModalUser && (
+        <SubjectMembershipModal
+          user={membershipModalUser}
+          subjects={subjects}
+          onClose={() => setMembershipModalUser(null)}
+          onChanged={() => {
+            showSuccess('Subjects updated successfully');
+            fetchData();
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/Users.jsx
+++ b/frontend/src/pages/Users.jsx
@@ -840,7 +840,7 @@ function Users() {
 
       {/* Create User Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Create New User</h3>
             <form onSubmit={handleCreateUser}>
@@ -997,7 +997,7 @@ function Users() {
       )}
       {/* Edit User Modal */}
       {editingUser && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">Edit User</h3>
             <form onSubmit={handleEditUser}>
@@ -1137,7 +1137,7 @@ function Users() {
       )}
       {/* Send Setup Emails Confirmation Modal */}
       {sendEmailsModal !== null && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
             <h3 className="text-lg font-semibold text-gray-900 mb-3">
               Send setup email{sendEmailsModal !== 1 ? 's' : ''}?
@@ -1170,7 +1170,7 @@ function Users() {
       )}
       {/* Delete Confirmation Modal (single or bulk) */}
       {deleteModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-lg w-full max-w-md max-h-[90vh] flex flex-col">
             <div className="p-6 pb-0 flex-shrink-0">
               <h3 className="text-lg font-semibold text-gray-900 mb-3">

--- a/frontend/src/utils/schemas.js
+++ b/frontend/src/utils/schemas.js
@@ -79,6 +79,11 @@ export const groupNameSchema = sanitizedString.pipe(
   z.string().min(1, 'Group name is required').max(100, 'Group name must be at most 100 characters')
 );
 
+const subjectNameSchema = nameSchema('Subject name');
+const assignmentNameSchema = nameSchema('Assignment name');
+
+const uuidArraySchema = z.array(z.string().uuid('Invalid ID format'));
+
 // ── Endpoint schemas ─────────────────────────────────────────────────────────
 
 export const loginSchema = z.object({
@@ -94,16 +99,32 @@ export const registerSchema = z.object({
   studentId: studentIdSchema,
 });
 
-export const createUserSchema = z.object({
-  username: usernameSchema,
-  email: emailSchema,
-  firstName: nameSchema('First name'),
-  lastName: nameSchema('Last name'),
-  studentId: studentIdSchema,
-  role: z.enum(['admin', 'assignment_manager', 'user']).optional(),
-  groupId: z.preprocess((v) => (v === '' ? null : v), z.string().uuid().optional().nullable()),
-  sendSetupEmail: z.boolean().optional(),
-});
+export const createUserSchema = z
+  .object({
+    username: usernameSchema,
+    email: emailSchema,
+    firstName: nameSchema('First name'),
+    lastName: nameSchema('Last name'),
+    studentId: studentIdSchema,
+    role: z.enum(['admin', 'assignment_manager', 'user']).optional(),
+    // role 'user': subjects to enrol in, plus optional immediate group
+    // placement (assignment ∈ subjectIds — enforced by the backend).
+    subjectIds: uuidArraySchema.optional(),
+    assignmentId: z.preprocess((v) => (v === '' ? null : v), z.string().uuid().optional().nullable()),
+    groupId: z.preprocess((v) => (v === '' ? null : v), z.string().uuid().optional().nullable()),
+    // role 'assignment_manager': assignments the new AM will manage.
+    assignmentIds: uuidArraySchema.optional(),
+    sendSetupEmail: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.groupId && !data.assignmentId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['groupId'],
+        message: 'Select an assignment first',
+      });
+    }
+  });
 
 export const updateUserSchema = z.object({
   email: emailSchema.optional(),
@@ -119,7 +140,17 @@ export const changePasswordSchema = z.object({
 });
 
 export const createGroupSchema = z.object({
+  assignmentId: z.string().uuid('Invalid assignment ID'),
   name: groupNameSchema,
+});
+
+export const createSubjectSchema = z.object({
+  name: subjectNameSchema,
+});
+
+export const createAssignmentSchema = z.object({
+  subjectId: z.string().uuid('Invalid subject ID'),
+  name: assignmentNameSchema,
 });
 
 export const updateGroupSchema = z.object({

--- a/frontend/tests/unit/App.test.jsx
+++ b/frontend/tests/unit/App.test.jsx
@@ -145,6 +145,56 @@ describe('App', () => {
     expect(screen.queryByText('Register Page')).not.toBeInTheDocument();
   });
 
+  describe('/users admin-only routes', () => {
+    it('renders users page for admins', () => {
+      useAuth.mockReturnValue(asAdmin());
+
+      window.history.pushState({}, '', '/users');
+      render(<App />);
+
+      expect(screen.getByText('Users Page')).toBeInTheDocument();
+    });
+
+    it('redirects assignment managers from /users to dashboard', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/users');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Users Page')).not.toBeInTheDocument();
+    });
+
+    it('redirects plain users from /users to dashboard', () => {
+      useAuth.mockReturnValue(asPlainUser());
+
+      window.history.pushState({}, '', '/users');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Users Page')).not.toBeInTheDocument();
+    });
+
+    it('renders import users page for admins', () => {
+      useAuth.mockReturnValue(asAdmin());
+
+      window.history.pushState({}, '', '/users/import');
+      render(<App />);
+
+      expect(screen.getByText('Import Users Page')).toBeInTheDocument();
+    });
+
+    it('redirects assignment managers from /users/import to dashboard', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/users/import');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Import Users Page')).not.toBeInTheDocument();
+    });
+  });
+
   describe('/subjects routes', () => {
     it('renders subjects page for assignment managers', () => {
       useAuth.mockReturnValue(asAssignmentManager());

--- a/frontend/tests/unit/App.test.jsx
+++ b/frontend/tests/unit/App.test.jsx
@@ -17,6 +17,16 @@ jest.mock('../../src/pages/Register.jsx', () => {
   MockRegister.displayName = 'MockRegister';
   return MockRegister;
 });
+jest.mock('../../src/pages/ForgotPassword.jsx', () => {
+  const MockForgotPassword = () => <div>Forgot Password Page</div>;
+  MockForgotPassword.displayName = 'MockForgotPassword';
+  return MockForgotPassword;
+});
+jest.mock('../../src/pages/SetPassword.jsx', () => {
+  const MockSetPassword = () => <div>Set Password Page</div>;
+  MockSetPassword.displayName = 'MockSetPassword';
+  return MockSetPassword;
+});
 jest.mock('../../src/pages/Dashboard.jsx', () => {
   const MockDashboard = () => <div>Dashboard Page</div>;
   MockDashboard.displayName = 'MockDashboard';
@@ -27,16 +37,65 @@ jest.mock('../../src/pages/Users.jsx', () => {
   MockUsers.displayName = 'MockUsers';
   return MockUsers;
 });
+jest.mock('../../src/pages/ImportUsers.jsx', () => {
+  const MockImportUsers = () => <div>Import Users Page</div>;
+  MockImportUsers.displayName = 'MockImportUsers';
+  return MockImportUsers;
+});
 jest.mock('../../src/pages/Groups.jsx', () => {
   const MockGroups = () => <div>Groups Page</div>;
   MockGroups.displayName = 'MockGroups';
   return MockGroups;
+});
+jest.mock('../../src/pages/ImportGroupMappings.jsx', () => {
+  const MockImportGroupMappings = () => <div>Import Group Mappings Page</div>;
+  MockImportGroupMappings.displayName = 'MockImportGroupMappings';
+  return MockImportGroupMappings;
+});
+jest.mock('../../src/pages/Settings.jsx', () => {
+  const MockSettings = () => <div>Settings Page</div>;
+  MockSettings.displayName = 'MockSettings';
+  return MockSettings;
+});
+jest.mock('../../src/pages/Subjects.jsx', () => {
+  const MockSubjects = () => <div>Subjects Page</div>;
+  MockSubjects.displayName = 'MockSubjects';
+  return MockSubjects;
+});
+jest.mock('../../src/pages/SubjectDetail.jsx', () => {
+  const MockSubjectDetail = () => <div>Subject Detail Page</div>;
+  MockSubjectDetail.displayName = 'MockSubjectDetail';
+  return MockSubjectDetail;
 });
 
 jest.mock('../../src/context/AuthContext.jsx', () => ({
   AuthProvider: ({ children }) => children,
   useAuth: jest.fn(),
 }));
+
+const asPlainUser = () => ({
+  isAuthenticated: true,
+  loading: false,
+  isAdmin: false,
+  isAssignmentManager: false,
+  user: { username: 'member', role: 'user' },
+});
+
+const asAssignmentManager = () => ({
+  isAuthenticated: true,
+  loading: false,
+  isAdmin: false,
+  isAssignmentManager: true,
+  user: { username: 'tm', role: 'assignment_manager' },
+});
+
+const asAdmin = () => ({
+  isAuthenticated: true,
+  loading: false,
+  isAdmin: true,
+  isAssignmentManager: true,
+  user: { username: 'admin', role: 'admin' },
+});
 
 describe('App', () => {
   beforeEach(() => {
@@ -58,13 +117,7 @@ describe('App', () => {
   });
 
   it('renders dashboard for authenticated users', () => {
-    useAuth.mockReturnValue({
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: false,
-      isAssignmentManager: false,
-      user: { username: 'member', role: 'user' },
-    });
+    useAuth.mockReturnValue(asPlainUser());
 
     window.history.pushState({}, '', '/dashboard');
     render(<App />);
@@ -72,44 +125,8 @@ describe('App', () => {
     expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
   });
 
-  it('blocks non-admin access to groups route', () => {
-    useAuth.mockReturnValue({
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: false,
-      isAssignmentManager: true,
-      user: { username: 'tm', role: 'assignment_manager' },
-    });
-
-    window.history.pushState({}, '', '/groups');
-    render(<App />);
-
-    expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
-  });
-
-  it('allows admin access to groups route', () => {
-    useAuth.mockReturnValue({
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: true,
-      isAssignmentManager: true,
-      user: { username: 'admin', role: 'admin' },
-    });
-
-    window.history.pushState({}, '', '/groups');
-    render(<App />);
-
-    expect(screen.getByText('Groups Page')).toBeInTheDocument();
-  });
-
   it('redirects authenticated user from /login to /dashboard', () => {
-    useAuth.mockReturnValue({
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: false,
-      isAssignmentManager: false,
-      user: { username: 'member', role: 'user' },
-    });
+    useAuth.mockReturnValue(asPlainUser());
 
     window.history.pushState({}, '', '/login');
     render(<App />);
@@ -119,19 +136,111 @@ describe('App', () => {
   });
 
   it('redirects authenticated user from /register to /dashboard when registration enabled', () => {
-    useAuth.mockReturnValue({
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: false,
-      isAssignmentManager: false,
-      user: { username: 'member', role: 'user' },
-      registrationEnabled: true,
-    });
+    useAuth.mockReturnValue({ ...asPlainUser(), registrationEnabled: true });
 
     window.history.pushState({}, '', '/register');
     render(<App />);
 
     expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
     expect(screen.queryByText('Register Page')).not.toBeInTheDocument();
+  });
+
+  describe('/subjects routes', () => {
+    it('renders subjects page for assignment managers', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/subjects');
+      render(<App />);
+
+      expect(screen.getByText('Subjects Page')).toBeInTheDocument();
+    });
+
+    it('renders subjects page for admins', () => {
+      useAuth.mockReturnValue(asAdmin());
+
+      window.history.pushState({}, '', '/subjects');
+      render(<App />);
+
+      expect(screen.getByText('Subjects Page')).toBeInTheDocument();
+    });
+
+    it('blocks plain users from /subjects', () => {
+      useAuth.mockReturnValue(asPlainUser());
+
+      window.history.pushState({}, '', '/subjects');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Subjects Page')).not.toBeInTheDocument();
+    });
+
+    it('renders subject detail page at /subjects/:subjectId for assignment managers', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/subjects/11111111-1111-4111-8111-111111111111');
+      render(<App />);
+
+      expect(screen.getByText('Subject Detail Page')).toBeInTheDocument();
+    });
+
+    it('blocks plain users from /subjects/:subjectId', () => {
+      useAuth.mockReturnValue(asPlainUser());
+
+      window.history.pushState({}, '', '/subjects/11111111-1111-4111-8111-111111111111');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Subject Detail Page')).not.toBeInTheDocument();
+    });
+
+    it('renders groups page at /subjects/:subjectId/assignments/:assignmentId for assignment managers', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/subjects/s1/assignments/a1');
+      render(<App />);
+
+      expect(screen.getByText('Groups Page')).toBeInTheDocument();
+    });
+
+    it('blocks plain users from the assignment groups route', () => {
+      useAuth.mockReturnValue(asPlainUser());
+
+      window.history.pushState({}, '', '/subjects/s1/assignments/a1');
+      render(<App />);
+
+      expect(screen.getByText('Dashboard Page')).toBeInTheDocument();
+      expect(screen.queryByText('Groups Page')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('/groups legacy routes', () => {
+    it('redirects /groups to /subjects for assignment managers', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/groups');
+      render(<App />);
+
+      expect(screen.getByText('Subjects Page')).toBeInTheDocument();
+      expect(screen.queryByText('Groups Page')).not.toBeInTheDocument();
+    });
+
+    it('redirects /groups to /subjects for admins', () => {
+      useAuth.mockReturnValue(asAdmin());
+
+      window.history.pushState({}, '', '/groups');
+      render(<App />);
+
+      expect(screen.getByText('Subjects Page')).toBeInTheDocument();
+      expect(screen.queryByText('Groups Page')).not.toBeInTheDocument();
+    });
+
+    it('keeps /groups/import for assignment managers', () => {
+      useAuth.mockReturnValue(asAssignmentManager());
+
+      window.history.pushState({}, '', '/groups/import');
+      render(<App />);
+
+      expect(screen.getByText('Import Group Mappings Page')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/unit/components/AssignGroupModal.test.jsx
+++ b/frontend/tests/unit/components/AssignGroupModal.test.jsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import api from '@/utils/api';
+import AssignGroupModal from '../../../src/components/AssignGroupModal.jsx';
+
+jest.mock('@/utils/api');
+
+const subjectA = { id: 's0000000-0000-0000-0000-000000000001', name: 'Subject A' };
+const subjectB = { id: 's0000000-0000-0000-0000-000000000002', name: 'Subject B' };
+
+const assignmentWithMembership = { id: 'a0000000-0000-0000-0000-000000000001', name: 'Assignment 1', group_count: 2 };
+const assignmentWithoutMembership = {
+  id: 'a0000000-0000-0000-0000-000000000002',
+  name: 'Assignment 2',
+  group_count: 1,
+};
+
+const groups = [
+  { id: 'g0000000-0000-0000-0000-000000000001', name: 'Group 1', enabled: true, max_members: 5, member_count: 2 },
+];
+
+const baseUser = {
+  id: 'u0000000-0000-0000-0000-000000000001',
+  username: 'alice',
+  memberships: [{ assignment_id: assignmentWithMembership.id, group_id: groups[0].id }],
+  subjects: [subjectA],
+};
+
+const defaultProps = {
+  user: baseUser,
+  subjects: [subjectA, subjectB],
+  onClose: jest.fn(),
+  onAssigned: jest.fn(),
+};
+
+function renderModal(overrides = {}) {
+  return render(<AssignGroupModal {...defaultProps} {...overrides} />);
+}
+
+async function selectCascade(user, assignmentName = 'Assignment 1') {
+  await user.selectOptions(screen.getByLabelText('Subject'), subjectA.id);
+  await waitFor(() => {
+    expect(screen.getByRole('option', { name: assignmentName })).toBeInTheDocument();
+  });
+  const assignment = assignmentName === 'Assignment 1' ? assignmentWithMembership : assignmentWithoutMembership;
+  await user.selectOptions(screen.getByLabelText('Assignment'), assignment.id);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.get.mockImplementation((url) => {
+    if (url.includes('/subjects/')) {
+      return Promise.resolve({
+        data: { subject: subjectA, assignments: [assignmentWithMembership, assignmentWithoutMembership] },
+      });
+    }
+    if (url.includes('/groups')) {
+      return Promise.resolve({ data: { groups } });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  });
+  api.put.mockResolvedValue({ data: {} });
+});
+
+describe('AssignGroupModal', () => {
+  it('renders the title with the username', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Assign Group — alice' })).toBeInTheDocument();
+  });
+
+  it("offers only the target user's subjects", () => {
+    renderModal();
+    expect(screen.getByRole('option', { name: 'Subject A' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Subject B' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the subjects prop filtered by membership subject ids when user.subjects is missing', () => {
+    renderModal({
+      user: {
+        ...baseUser,
+        subjects: undefined,
+        memberships: [{ assignment_id: assignmentWithMembership.id, group_id: groups[0].id, subject_id: subjectA.id }],
+      },
+    });
+    expect(screen.getByRole('option', { name: 'Subject A' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Subject B' })).not.toBeInTheDocument();
+  });
+
+  it('disables Assign until subject, assignment, and group are all chosen', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    const assignButton = screen.getByRole('button', { name: 'Assign' });
+    expect(assignButton).toBeDisabled();
+
+    await user.selectOptions(screen.getByLabelText('Subject'), subjectA.id);
+    expect(assignButton).toBeDisabled();
+
+    await selectCascade(user);
+    expect(assignButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    expect(assignButton).toBeEnabled();
+  });
+
+  it('PUTs the correct body on assign and calls onAssigned and onClose', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await selectCascade(user);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
+        {
+          assignmentId: assignmentWithMembership.id,
+          groupId: groups[0].id,
+        }
+      );
+    });
+    expect(defaultProps.onAssigned).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Remove from group only when a membership exists for the selected assignment', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    expect(screen.queryByRole('button', { name: 'Remove from group' })).not.toBeInTheDocument();
+
+    await selectCascade(user, 'Assignment 1');
+    expect(screen.getByRole('button', { name: 'Remove from group' })).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Assignment'), assignmentWithoutMembership.id);
+    expect(screen.queryByRole('button', { name: 'Remove from group' })).not.toBeInTheDocument();
+  });
+
+  it('PUTs groupId null on remove and calls onAssigned and onClose', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await selectCascade(user, 'Assignment 1');
+    await user.click(screen.getByRole('button', { name: 'Remove from group' }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
+        {
+          assignmentId: assignmentWithMembership.id,
+          groupId: null,
+        }
+      );
+    });
+    expect(defaultProps.onAssigned).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the API error on 403 and keeps the modal open', async () => {
+    const user = userEvent.setup();
+    api.put.mockRejectedValue({ response: { status: 403, data: { error: 'Forbidden' } } });
+    renderModal();
+    await selectCascade(user);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Forbidden')).toBeInTheDocument();
+    });
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(defaultProps.onAssigned).not.toHaveBeenCalled();
+  });
+
+  it('shows "Group is full" on 409', async () => {
+    const user = userEvent.setup();
+    api.put.mockRejectedValue({ response: { status: 409, data: { error: 'Group is full' } } });
+    renderModal();
+    await selectCascade(user);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Group is full')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a fallback message when the error response has no error field', async () => {
+    const user = userEvent.setup();
+    api.put.mockRejectedValue(new Error('network'));
+    renderModal();
+    await selectCascade(user);
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update group')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/unit/components/CascadingAssignmentSelect.test.jsx
+++ b/frontend/tests/unit/components/CascadingAssignmentSelect.test.jsx
@@ -1,0 +1,205 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import api from '@/utils/api';
+import CascadingAssignmentSelect from '../../../src/components/CascadingAssignmentSelect.jsx';
+
+jest.mock('@/utils/api');
+
+const subjects = [
+  { id: 's0000000-0000-0000-0000-000000000001', name: 'Subject A' },
+  { id: 's0000000-0000-0000-0000-000000000002', name: 'Subject B' },
+];
+
+const assignments = [
+  { id: 'a0000000-0000-0000-0000-000000000001', name: 'Assignment 1', group_count: 2 },
+  { id: 'a0000000-0000-0000-0000-000000000002', name: 'Assignment 2', group_count: 0 },
+];
+
+const groups = [
+  { id: 'g0000000-0000-0000-0000-000000000001', name: 'Group 1', enabled: true, max_members: 5, member_count: 2 },
+  { id: 'g0000000-0000-0000-0000-000000000002', name: 'Group 2', enabled: true, max_members: null, member_count: 0 },
+];
+
+const emptyValue = { subjectId: '', assignmentId: '', groupId: '' };
+
+function renderSelect(props = {}) {
+  return render(<CascadingAssignmentSelect subjects={subjects} value={emptyValue} onChange={() => {}} {...props} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.get.mockImplementation((url) => {
+    if (url.includes('/subjects/')) {
+      return Promise.resolve({ data: { subject: subjects[0], assignments } });
+    }
+    if (url.includes('/groups')) {
+      return Promise.resolve({ data: { groups } });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  });
+});
+
+describe('CascadingAssignmentSelect', () => {
+  it('renders subject options from the subjects prop with a placeholder', () => {
+    renderSelect();
+    const select = screen.getByLabelText('Subject');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Select subject' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Subject A' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Subject B' })).toBeInTheDocument();
+  });
+
+  it('disables the assignment select before a subject is chosen', () => {
+    renderSelect();
+    expect(screen.getByLabelText('Assignment')).toBeDisabled();
+  });
+
+  it('disables the group select before an assignment is chosen', () => {
+    renderSelect();
+    expect(screen.getByLabelText('Group')).toBeDisabled();
+  });
+
+  it('disables all selects when disabled is true', () => {
+    renderSelect({ disabled: true });
+    expect(screen.getByLabelText('Subject')).toBeDisabled();
+    expect(screen.getByLabelText('Assignment')).toBeDisabled();
+    expect(screen.getByLabelText('Group')).toBeDisabled();
+  });
+
+  it('hides the group select when showGroup is false', () => {
+    renderSelect({ showGroup: false });
+    expect(screen.queryByLabelText('Group')).not.toBeInTheDocument();
+  });
+
+  it('emits the full next value with children reset when the subject changes', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderSelect({
+      value: {
+        subjectId: subjects[1].id,
+        assignmentId: assignments[0].id,
+        groupId: groups[0].id,
+      },
+      onChange,
+    });
+    await user.selectOptions(screen.getByLabelText('Subject'), subjects[0].id);
+    expect(onChange).toHaveBeenCalledWith({ subjectId: subjects[0].id, assignmentId: '', groupId: '' });
+  });
+
+  it('fetches and populates assignments when a subject is selected', async () => {
+    renderSelect({ value: { ...emptyValue, subjectId: subjects[0].id } });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument();
+    });
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/subjects\/s0000000-0000-0000-0000-000000000001$/));
+    expect(screen.getByRole('option', { name: 'Assignment 2' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Select assignment' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Assignment')).toBeEnabled();
+  });
+
+  it('emits assignment change with groupId reset', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderSelect({
+      value: { subjectId: subjects[0].id, assignmentId: '', groupId: '' },
+      onChange,
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Assignment'), assignments[0].id);
+    expect(onChange).toHaveBeenCalledWith({
+      subjectId: subjects[0].id,
+      assignmentId: assignments[0].id,
+      groupId: '',
+    });
+  });
+
+  it('fetches and populates groups when an assignment is selected', async () => {
+    renderSelect({
+      value: { subjectId: subjects[0].id, assignmentId: assignments[0].id, groupId: '' },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    expect(api.get).toHaveBeenCalledWith(
+      expect.stringMatching(/\/assignments\/a0000000-0000-0000-0000-000000000001\/groups$/)
+    );
+    // No max_members -> plain name without count suffix
+    expect(screen.getByRole('option', { name: 'Group 2' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Select group' })).toBeInTheDocument();
+  });
+
+  it('emits group change preserving subject and assignment', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderSelect({
+      value: { subjectId: subjects[0].id, assignmentId: assignments[0].id, groupId: '' },
+      onChange,
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument();
+    });
+    await user.selectOptions(screen.getByLabelText('Group'), groups[0].id);
+    expect(onChange).toHaveBeenCalledWith({
+      subjectId: subjects[0].id,
+      assignmentId: assignments[0].id,
+      groupId: groups[0].id,
+    });
+  });
+
+  it('does not fetch groups when showGroup is false', async () => {
+    renderSelect({
+      value: { subjectId: subjects[0].id, assignmentId: assignments[0].id, groupId: '' },
+      showGroup: false,
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument();
+    });
+    expect(api.get).not.toHaveBeenCalledWith(expect.stringMatching(/\/assignments\/.+\/groups$/));
+  });
+
+  it('shows an error and leaves the assignment select empty when the fetch fails', async () => {
+    api.get.mockRejectedValue(new Error('network'));
+    renderSelect({ value: { ...emptyValue, subjectId: subjects[0].id } });
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load options')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('option', { name: 'Assignment 1' })).not.toBeInTheDocument();
+  });
+
+  it('does not refetch a cached subject (one api call per subject id)', async () => {
+    const { rerender } = renderSelect({ value: { ...emptyValue, subjectId: subjects[0].id } });
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument();
+    });
+    expect(api.get).toHaveBeenCalledTimes(1);
+
+    // Switch away then back to the same subject
+    rerender(
+      <CascadingAssignmentSelect
+        subjects={subjects}
+        value={{ ...emptyValue, subjectId: subjects[1].id }}
+        onChange={() => {}}
+      />
+    );
+    await waitFor(() => expect(api.get).toHaveBeenCalledTimes(2));
+
+    rerender(
+      <CascadingAssignmentSelect
+        subjects={subjects}
+        value={{ ...emptyValue, subjectId: subjects[0].id }}
+        onChange={() => {}}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument();
+    });
+    expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses custom labels when provided', () => {
+    renderSelect({ labels: { subject: 'Course' } });
+    expect(screen.getByLabelText('Course')).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/components/IconBtn.test.jsx
+++ b/frontend/tests/unit/components/IconBtn.test.jsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IconBtn from '../../../src/components/IconBtn.jsx';
+
+describe('IconBtn', () => {
+  it('renders a button with the label as aria-label', () => {
+    render(
+      <IconBtn onClick={() => {}} label="Delete group" className="text-red-600">
+        <span>icon</span>
+      </IconBtn>
+    );
+    expect(screen.getByRole('button', { name: 'Delete group' })).toBeInTheDocument();
+  });
+
+  it('renders its children inside the button', () => {
+    render(
+      <IconBtn onClick={() => {}} label="Edit" className="">
+        <span data-testid="icon-child">icon</span>
+      </IconBtn>
+    );
+    const button = screen.getByRole('button', { name: 'Edit' });
+    expect(button).toContainElement(screen.getByTestId('icon-child'));
+  });
+
+  it('renders the label text in a tooltip span', () => {
+    render(
+      <IconBtn onClick={() => {}} label="Set limit" className="">
+        <span>icon</span>
+      </IconBtn>
+    );
+    // Label appears twice: once as aria-label, once as visible tooltip text
+    expect(screen.getByText('Set limit')).toBeInTheDocument();
+  });
+
+  it('appends the className prop to the button classes', () => {
+    render(
+      <IconBtn onClick={() => {}} label="Disable" className="text-gray-400 hover:bg-gray-100">
+        <span>icon</span>
+      </IconBtn>
+    );
+    const button = screen.getByRole('button', { name: 'Disable' });
+    expect(button).toHaveClass('text-gray-400');
+    expect(button).toHaveClass('hover:bg-gray-100');
+    expect(button).toHaveClass('p-1.5');
+  });
+
+  it('has type="button" so it never submits forms', () => {
+    render(
+      <IconBtn onClick={() => {}} label="Remove" className="">
+        <span>icon</span>
+      </IconBtn>
+    );
+    expect(screen.getByRole('button', { name: 'Remove' })).toHaveAttribute('type', 'button');
+  });
+
+  it('fires onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+    render(
+      <IconBtn onClick={handleClick} label="Delete" className="">
+        <span>icon</span>
+      </IconBtn>
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onClick without a click', () => {
+    const handleClick = jest.fn();
+    render(
+      <IconBtn onClick={handleClick} label="Delete" className="">
+        <span>icon</span>
+      </IconBtn>
+    );
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/components/SubjectMembersSection.test.jsx
+++ b/frontend/tests/unit/components/SubjectMembersSection.test.jsx
@@ -1,0 +1,521 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import api from '@/utils/api';
+import SubjectMembersSection from '../../../src/components/SubjectMembersSection.jsx';
+
+jest.mock('@/utils/api');
+
+const SUBJECT = { id: '11111111-1111-4111-8111-111111111111', name: 'Mathematics' };
+const OTHER_SUBJECT = { id: '22222222-2222-4222-8222-222222222222', name: 'Physics' };
+
+const SUSPEND_WARNING =
+  'Suspending removes their group memberships in this subject. Re-enabling will NOT restore groups.';
+
+const makeMember = (overrides = {}) => ({
+  id: 'aaaaaaaa-0000-4000-8000-000000000001',
+  username: 'u1',
+  email: 'u1@test.com',
+  first_name: 'First',
+  last_name: 'Last',
+  student_id: 's1',
+  enabled: true,
+  status: 'active',
+  role_name: 'user',
+  membership_enabled: true,
+  ...overrides,
+});
+
+/** URL router mock: subject members endpoint plus the admin GET /users list. */
+const mockApiGet = ({ members = [makeMember()], allUsers = [], assignments = [] } = {}) => {
+  api.get.mockImplementation((url) => {
+    if (/\/subjects\/[^/]+\/users$/.test(url)) {
+      return Promise.resolve({ data: { users: members } });
+    }
+    if (/\/subjects\/[^/]+$/.test(url)) {
+      return Promise.resolve({ data: { subject: SUBJECT, assignments } });
+    }
+    if (/\/users$/.test(url)) {
+      return Promise.resolve({ data: { users: allUsers } });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  });
+};
+
+const renderSection = async ({
+  members,
+  allUsers,
+  assignments,
+  subject = SUBJECT,
+  isAdmin = true,
+  canManage = true,
+} = {}) => {
+  mockApiGet({ members, allUsers, assignments });
+  const view = render(<SubjectMembersSection subject={subject} isAdmin={isAdmin} canManage={canManage} />);
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument());
+  await waitFor(() => expect(view.container.querySelector('.animate-spin')).not.toBeInTheDocument());
+  return view;
+};
+
+describe('SubjectMembersSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Fetch / loading / error / empty ─────────────────────────────────────
+  describe('fetching members', () => {
+    it('shows a loading spinner before data resolves', () => {
+      api.get.mockImplementation(() => new Promise(() => {}));
+      const { container } = render(<SubjectMembersSection subject={SUBJECT} isAdmin canManage />);
+
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+      expect(screen.queryByText('u1')).not.toBeInTheDocument();
+    });
+
+    it('fetches members for the subject and renders name, username, email and status', async () => {
+      await renderSection();
+
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT.id}/users`));
+      expect(screen.getByText('First Last')).toBeInTheDocument();
+      expect(screen.getByText('u1')).toBeInTheDocument();
+      expect(screen.getByText('u1@test.com')).toBeInTheDocument();
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('refetches when the subject changes', async () => {
+      const { rerender } = await renderSection();
+
+      rerender(<SubjectMembersSection subject={OTHER_SUBJECT} isAdmin canManage />);
+
+      await waitFor(() =>
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${OTHER_SUBJECT.id}/users`))
+      );
+    });
+
+    it('shows the server error when the fetch fails with a message', async () => {
+      api.get.mockRejectedValue({ response: { data: { error: 'Not authorized for this subject' } } });
+      render(<SubjectMembersSection subject={SUBJECT} isAdmin canManage />);
+
+      await waitFor(() => expect(screen.getByText('Not authorized for this subject')).toBeInTheDocument());
+    });
+
+    it('shows a generic error banner when the fetch fails without a message', async () => {
+      api.get.mockRejectedValue(new Error('network'));
+      render(<SubjectMembersSection subject={SUBJECT} isAdmin canManage />);
+
+      await waitFor(() => expect(screen.getByText('Failed to load members')).toBeInTheDocument());
+    });
+
+    it('shows an empty state when the subject has no members', async () => {
+      await renderSection({ members: [] });
+
+      expect(screen.getByText('No members yet')).toBeInTheDocument();
+    });
+  });
+
+  // ── Status badges ────────────────────────────────────────────────────────
+  describe('status badges', () => {
+    it('renders a yellow Pending badge for pending members', async () => {
+      await renderSection({ members: [makeMember({ status: 'pending' })] });
+
+      const badge = screen.getByText('Pending');
+      expect(badge.className).toContain('bg-yellow-100');
+    });
+
+    it('renders a green Active badge for active members', async () => {
+      await renderSection();
+
+      const badge = screen.getByText('Active');
+      expect(badge.className).toContain('bg-green-100');
+    });
+
+    it('renders a gray Suspended badge when membership_enabled is false', async () => {
+      await renderSection({ members: [makeMember({ membership_enabled: false })] });
+
+      const badge = screen.getByText('Suspended');
+      expect(badge.className).toContain('bg-gray-100');
+    });
+
+    it('does not render a Suspended badge when membership is enabled', async () => {
+      await renderSection();
+
+      expect(screen.queryByText('Suspended')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Suspend / enable ────────────────────────────────────────────────────
+  describe('suspend flow', () => {
+    it('opens a confirm modal with the irreversibility warning', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: 'Suspend Member' }));
+
+      expect(screen.getByText(SUSPEND_WARNING)).toBeInTheDocument();
+      expect(api.put).not.toHaveBeenCalled();
+    });
+
+    it('confirms suspension, PUTs enabled=false, refetches and shows success', async () => {
+      const user = userEvent.setup();
+      api.put.mockResolvedValue({ data: { message: 'ok', membershipEnabled: false } });
+      const member = makeMember();
+      await renderSection({ members: [member] });
+      const getCallsBefore = api.get.mock.calls.length;
+
+      await user.click(screen.getByRole('button', { name: 'Suspend Member' }));
+      await user.click(screen.getByRole('button', { name: 'Suspend' }));
+
+      await waitFor(() => {
+        expect(api.put).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT.id}/users/${member.id}`), {
+          enabled: false,
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Member suspended')).toBeInTheDocument();
+        expect(api.get.mock.calls.length).toBeGreaterThan(getCallsBefore);
+      });
+      expect(screen.queryByText(SUSPEND_WARNING)).not.toBeInTheDocument();
+    });
+
+    it('cancels the suspend modal without calling the API', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: 'Suspend Member' }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.queryByText(SUSPEND_WARNING)).not.toBeInTheDocument();
+      expect(api.put).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the API error when suspension fails', async () => {
+      const user = userEvent.setup();
+      api.put.mockRejectedValue({ response: { data: { error: 'Suspension denied' } } });
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: 'Suspend Member' }));
+      await user.click(screen.getByRole('button', { name: 'Suspend' }));
+
+      await waitFor(() => expect(screen.getByText('Suspension denied')).toBeInTheDocument());
+    });
+
+    it('enables a suspended member directly without a modal', async () => {
+      const user = userEvent.setup();
+      api.put.mockResolvedValue({ data: { message: 'ok', membershipEnabled: true } });
+      const member = makeMember({ membership_enabled: false });
+      await renderSection({ members: [member] });
+      const getCallsBefore = api.get.mock.calls.length;
+
+      await user.click(screen.getByRole('button', { name: 'Enable Member' }));
+
+      await waitFor(() => {
+        expect(api.put).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT.id}/users/${member.id}`), {
+          enabled: true,
+        });
+      });
+      expect(screen.queryByText(SUSPEND_WARNING)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Member enabled')).toBeInTheDocument();
+        expect(api.get.mock.calls.length).toBeGreaterThan(getCallsBefore);
+      });
+    });
+
+    it('surfaces the API error when enabling fails', async () => {
+      const user = userEvent.setup();
+      api.put.mockRejectedValue({ response: { data: { error: 'Enable denied' } } });
+      await renderSection({ members: [makeMember({ membership_enabled: false })] });
+
+      await user.click(screen.getByRole('button', { name: 'Enable Member' }));
+
+      await waitFor(() => expect(screen.getByText('Enable denied')).toBeInTheDocument());
+    });
+  });
+
+  // ── Assign group ─────────────────────────────────────────────────────────
+  describe('assign group', () => {
+    it('opens AssignGroupModal scoped to this subject', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: 'Assign Group' }));
+
+      const heading = screen.getByRole('heading', { name: 'Assign Group — u1' });
+      const modal = heading.closest('.fixed');
+      expect(within(modal).getByRole('option', { name: 'Mathematics' })).toBeInTheDocument();
+    });
+
+    it('closes AssignGroupModal on cancel without a PUT', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: 'Assign Group' }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.queryByRole('heading', { name: 'Assign Group — u1' })).not.toBeInTheDocument();
+      expect(api.put).not.toHaveBeenCalled();
+    });
+
+    it("passes the member's memberships through so Remove from group is offered for their assignment", async () => {
+      const ASSIGNMENT = { id: 'bbbbbbbb-0000-4000-8000-000000000001', name: 'Assignment 1' };
+      const member = makeMember({
+        memberships: [
+          {
+            subject_id: SUBJECT.id,
+            assignment_id: ASSIGNMENT.id,
+            assignment_name: ASSIGNMENT.name,
+            group_id: 'cccccccc-0000-4000-8000-000000000001',
+            group_name: 'Team Alpha',
+          },
+        ],
+      });
+      const user = userEvent.setup();
+      await renderSection({ members: [member], assignments: [ASSIGNMENT] });
+
+      await user.click(screen.getByRole('button', { name: 'Assign Group' }));
+
+      // Walk the cascade — the modal offers "Remove from group" only when the
+      // user has a membership for the selected assignment.
+      await user.selectOptions(await screen.findByLabelText('Subject'), SUBJECT.id);
+      await user.selectOptions(await screen.findByLabelText('Assignment'), ASSIGNMENT.id);
+
+      expect(await screen.findByRole('button', { name: /remove from group/i })).toBeInTheDocument();
+    });
+  });
+
+  // ── Send setup email ─────────────────────────────────────────────────────
+  describe('send setup email', () => {
+    it('posts the pending member id and shows success', async () => {
+      const user = userEvent.setup();
+      api.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
+      const member = makeMember({ status: 'pending' });
+      await renderSection({ members: [member] });
+
+      await user.click(screen.getByRole('button', { name: 'Send Setup Email' }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/users\/send-setup-emails$/), {
+          userIds: [member.id],
+        });
+      });
+      await waitFor(() => expect(screen.getByText('Setup email sent')).toBeInTheDocument());
+    });
+
+    it('hides the setup email action for non-pending members', async () => {
+      await renderSection();
+
+      expect(screen.queryByRole('button', { name: 'Send Setup Email' })).not.toBeInTheDocument();
+    });
+
+    it('surfaces the API error when sending fails', async () => {
+      const user = userEvent.setup();
+      api.post.mockRejectedValue({ response: { data: { error: 'Email service down' } } });
+      await renderSection({ members: [makeMember({ status: 'pending' })] });
+
+      await user.click(screen.getByRole('button', { name: 'Send Setup Email' }));
+
+      await waitFor(() => expect(screen.getByText('Email service down')).toBeInTheDocument());
+    });
+  });
+
+  // ── Gating ───────────────────────────────────────────────────────────────
+  describe('gating', () => {
+    it('hides all row actions and toolbar buttons when canManage is false', async () => {
+      await renderSection({
+        members: [makeMember({ status: 'pending', membership_enabled: false })],
+        isAdmin: false,
+        canManage: false,
+      });
+
+      expect(screen.getByText('u1')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Suspend Member' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Enable Member' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Assign Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Send Setup Email' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /create user/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /add existing user/i })).not.toBeInTheDocument();
+    });
+
+    it('hides row actions for non-user roles even when canManage', async () => {
+      await renderSection({
+        members: [makeMember({ role_name: 'assignment_manager', status: 'pending' })],
+      });
+
+      expect(screen.queryByRole('button', { name: 'Suspend Member' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Assign Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Send Setup Email' })).not.toBeInTheDocument();
+    });
+
+    it('shows Add Existing User for admins only', async () => {
+      await renderSection();
+      expect(screen.getByRole('button', { name: /add existing user/i })).toBeInTheDocument();
+    });
+
+    it('hides Add Existing User for non-admin managers', async () => {
+      await renderSection({ isAdmin: false, canManage: true });
+
+      expect(screen.getByRole('button', { name: /create user/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /add existing user/i })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Add existing user (admin) ────────────────────────────────────────────
+  describe('add existing user', () => {
+    const nonMember = makeMember({
+      id: 'aaaaaaaa-0000-4000-8000-000000000002',
+      username: 'newbie',
+      email: 'newbie@test.com',
+    });
+    const managerUser = makeMember({
+      id: 'aaaaaaaa-0000-4000-8000-000000000003',
+      username: 'mgr',
+      email: 'mgr@test.com',
+      role_name: 'assignment_manager',
+    });
+
+    it('fetches /users and offers only user-role non-members', async () => {
+      const user = userEvent.setup();
+      await renderSection({ allUsers: [makeMember(), nonMember, managerUser] });
+
+      await user.click(screen.getByRole('button', { name: /add existing user/i }));
+
+      await waitFor(() => expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/users$/)));
+      const select = await screen.findByRole('combobox', { name: 'Select user' });
+      const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+      expect(options).toContain('newbie (newbie@test.com)');
+      expect(options.some((o) => o.startsWith('u1 '))).toBe(false);
+      expect(options.some((o) => o.startsWith('mgr '))).toBe(false);
+    });
+
+    it('adds the chosen user to the subject, refetches and shows success', async () => {
+      const user = userEvent.setup();
+      api.post.mockResolvedValue({ data: { message: 'ok' } });
+      await renderSection({ allUsers: [makeMember(), nonMember] });
+      const memberCallsBefore = api.get.mock.calls.filter((c) => /\/subjects\/[^/]+\/users$/.test(c[0])).length;
+
+      await user.click(screen.getByRole('button', { name: /add existing user/i }));
+      await user.selectOptions(await screen.findByRole('combobox', { name: 'Select user' }), nonMember.id);
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT.id}/users`), {
+          userIds: [nonMember.id],
+        });
+      });
+      await waitFor(() => {
+        expect(screen.getByText('User added to subject')).toBeInTheDocument();
+        expect(api.get.mock.calls.filter((c) => /\/subjects\/[^/]+\/users$/.test(c[0])).length).toBeGreaterThan(
+          memberCallsBefore
+        );
+      });
+      expect(screen.queryByRole('combobox', { name: 'Select user' })).not.toBeInTheDocument();
+    });
+
+    it('shows the API error inside the modal and keeps it open when adding fails', async () => {
+      const user = userEvent.setup();
+      api.post.mockRejectedValue({ response: { data: { error: 'Already enrolled' } } });
+      await renderSection({ allUsers: [nonMember] });
+
+      await user.click(screen.getByRole('button', { name: /add existing user/i }));
+      await user.selectOptions(await screen.findByRole('combobox', { name: 'Select user' }), nonMember.id);
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+
+      await waitFor(() => expect(screen.getByText('Already enrolled')).toBeInTheDocument());
+      expect(screen.getByRole('combobox', { name: 'Select user' })).toBeInTheDocument();
+    });
+
+    it('cancels the add modal without posting', async () => {
+      const user = userEvent.setup();
+      await renderSection({ allUsers: [nonMember] });
+
+      await user.click(screen.getByRole('button', { name: /add existing user/i }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.queryByRole('combobox', { name: 'Select user' })).not.toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Create user ──────────────────────────────────────────────────────────
+  describe('create user', () => {
+    const fillForm = async (user) => {
+      await user.type(screen.getByPlaceholderText('Enter username'), 'newuser');
+      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
+      await user.type(screen.getByPlaceholderText('Enter first name'), 'New');
+      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+    };
+
+    it('creates a user enrolled in this subject, refetches and shows success', async () => {
+      const user = userEvent.setup();
+      api.post.mockResolvedValue({ data: { message: 'ok', user: {} } });
+      await renderSection();
+      const memberCallsBefore = api.get.mock.calls.filter((c) => /\/subjects\/[^/]+\/users$/.test(c[0])).length;
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillForm(user);
+      await user.type(screen.getByPlaceholderText('Enter student ID'), 'ST42');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(
+          expect.stringMatching(/\/users$/),
+          expect.objectContaining({
+            username: 'newuser',
+            email: 'new@test.com',
+            firstName: 'New',
+            lastName: 'User',
+            studentId: 'ST42',
+            role: 'user',
+            subjectIds: [SUBJECT.id],
+          })
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText('User created successfully')).toBeInTheDocument();
+        expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
+        expect(api.get.mock.calls.filter((c) => /\/subjects\/[^/]+\/users$/.test(c[0])).length).toBeGreaterThan(
+          memberCallsBefore
+        );
+      });
+    });
+
+    it('shows a validation error and does not POST for an invalid username', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await user.type(screen.getByPlaceholderText('Enter username'), 'bad user!');
+      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
+      await user.type(screen.getByPlaceholderText('Enter first name'), 'New');
+      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(
+        await screen.findByText('Username may only contain letters, numbers, underscores, hyphens, and dots')
+      ).toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('shows the API error inside the modal and keeps it open when creation fails', async () => {
+      const user = userEvent.setup();
+      api.post.mockRejectedValue({ response: { data: { error: 'Username already exists' } } });
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillForm(user);
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => expect(screen.getByText('Username already exists')).toBeInTheDocument());
+      expect(screen.getByText('Create New User')).toBeInTheDocument();
+    });
+
+    it('cancels the create modal without posting', async () => {
+      const user = userEvent.setup();
+      await renderSection();
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/unit/components/SubjectMembershipModal.test.jsx
+++ b/frontend/tests/unit/components/SubjectMembershipModal.test.jsx
@@ -1,0 +1,187 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import api from '@/utils/api';
+import SubjectMembershipModal from '../../../src/components/SubjectMembershipModal.jsx';
+
+jest.mock('@/utils/api');
+
+const SUBJECT_A = { id: 'aaaaaaaa-0000-4000-8000-000000000001', name: 'Subject A' };
+const SUBJECT_B = { id: 'aaaaaaaa-0000-4000-8000-000000000002', name: 'Subject B' };
+const SUBJECT_C = { id: 'aaaaaaaa-0000-4000-8000-000000000003', name: 'Subject C' };
+
+const MEMBERSHIP_A = {
+  assignment_id: 'bbbbbbbb-0000-4000-8000-000000000001',
+  assignment_name: 'Assignment 1',
+  subject_id: SUBJECT_A.id,
+  subject_name: 'Subject A',
+  group_id: 'cccccccc-0000-4000-8000-000000000001',
+  group_name: 'Group 1',
+};
+
+const baseUser = {
+  id: 'u0000000-0000-0000-0000-000000000001',
+  username: 'alice',
+  subjects: [SUBJECT_A],
+  memberships: [MEMBERSHIP_A],
+};
+
+const defaultProps = {
+  user: baseUser,
+  subjects: [SUBJECT_A, SUBJECT_B, SUBJECT_C],
+  onClose: jest.fn(),
+  onChanged: jest.fn(),
+};
+
+function renderModal(overrides = {}) {
+  return render(<SubjectMembershipModal {...defaultProps} {...overrides} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  api.post.mockResolvedValue({ data: {} });
+  api.delete.mockResolvedValue({ data: {} });
+});
+
+describe('SubjectMembershipModal', () => {
+  it('renders the title with the username', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Manage Subjects — alice' })).toBeInTheDocument();
+  });
+
+  it('renders a checkbox for every subject, pre-checked for current memberships', () => {
+    renderModal();
+    expect(screen.getByRole('checkbox', { name: 'Subject A' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Subject B' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Subject C' })).not.toBeChecked();
+  });
+
+  it('toggles checkboxes on click', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    expect(screen.getByRole('checkbox', { name: 'Subject B' })).toBeChecked();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    expect(screen.getByRole('checkbox', { name: 'Subject A' })).not.toBeChecked();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    expect(screen.getByRole('checkbox', { name: 'Subject A' })).toBeChecked();
+  });
+
+  it('saves the diff: POST for additions and DELETE for removals', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Subject C' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT_B.id}/users`), {
+        userIds: [baseUser.id],
+      });
+    });
+    expect(api.post).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT_C.id}/users`), {
+      userIds: [baseUser.id],
+    });
+    expect(api.post).toHaveBeenCalledTimes(2);
+    expect(api.delete).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT_A.id}/users/${baseUser.id}`));
+    expect(api.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onChanged then onClose on successful save', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(defaultProps.onChanged).toHaveBeenCalledTimes(1);
+    });
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a warning before saving when a removed subject contains group memberships', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    expect(screen.queryByText(/removing a subject also removes/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    expect(
+      screen.getByText(/removing a subject also removes the user's group memberships in it\./i)
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    expect(screen.queryByText(/removing a subject also removes/i)).not.toBeInTheDocument();
+  });
+
+  it('does not warn when removing a subject with no memberships in it', async () => {
+    const user = userEvent.setup();
+    renderModal({
+      user: { ...baseUser, subjects: [SUBJECT_B], memberships: [] },
+    });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    expect(screen.queryByText(/removing a subject also removes/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the API error and stays open when a save call fails', async () => {
+    const user = userEvent.setup();
+    api.post.mockRejectedValue({ response: { data: { error: 'Enrolment failed' } } });
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enrolment failed')).toBeInTheDocument();
+    });
+    expect(defaultProps.onChanged).not.toHaveBeenCalled();
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Manage Subjects — alice' })).toBeInTheDocument();
+  });
+
+  it('shows a fallback error message when the failure has no error field', async () => {
+    const user = userEvent.setup();
+    api.delete.mockRejectedValue(new Error('network'));
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update subjects')).toBeInTheDocument();
+    });
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+  });
+
+  it('saving with no changes makes no API calls and just closes', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(api.post).not.toHaveBeenCalled();
+    expect(api.delete).not.toHaveBeenCalled();
+    expect(defaultProps.onChanged).not.toHaveBeenCalled();
+  });
+
+  it('cancel calls onClose without any API calls', async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(api.post).not.toHaveBeenCalled();
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/components/TypedDeleteConfirmModal.test.jsx
+++ b/frontend/tests/unit/components/TypedDeleteConfirmModal.test.jsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TypedDeleteConfirmModal from '../../../src/components/TypedDeleteConfirmModal.jsx';
+
+const defaultProps = {
+  entityLabel: 'Subject',
+  entityName: 'Subject A',
+  onConfirm: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+function renderModal(overrides = {}) {
+  return render(<TypedDeleteConfirmModal {...defaultProps} {...overrides} />);
+}
+
+async function advanceToStepTwo(user) {
+  await user.type(screen.getByLabelText('Confirmation name'), 'Subject A');
+  await user.click(screen.getByRole('button', { name: 'Continue' }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('TypedDeleteConfirmModal', () => {
+  describe('step 1 — typed entity name gate', () => {
+    it('renders the heading with the entity label', () => {
+      renderModal();
+      expect(screen.getByRole('heading', { name: 'Delete Subject' })).toBeInTheDocument();
+    });
+
+    it('disables Continue initially', () => {
+      renderModal();
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+
+    it('keeps Continue disabled on partial input', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.type(screen.getByLabelText('Confirmation name'), 'Subj');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+
+    it('keeps Continue disabled on case-mismatched input', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.type(screen.getByLabelText('Confirmation name'), 'subject a');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+
+    it('keeps Continue disabled on padded input (no trimming)', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.type(screen.getByLabelText('Confirmation name'), ' Subject A');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+
+    it('enables Continue on an exact match', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.type(screen.getByLabelText('Confirmation name'), 'Subject A');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
+    });
+
+    it('does not call onConfirm from step 1', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('renders the warning node in a yellow box when provided', () => {
+      renderModal({ warning: <p>3 assignments will be deleted</p> });
+      expect(screen.getByText('3 assignments will be deleted')).toBeInTheDocument();
+    });
+
+    it('does not render a warning box when warning is null', () => {
+      renderModal();
+      expect(screen.queryByText('3 assignments will be deleted')).not.toBeInTheDocument();
+    });
+
+    it('calls onCancel when Cancel is clicked at step 1', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('step 2 — typed delete gate', () => {
+    it('clears the input when advancing to step 2', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      expect(screen.getByLabelText('Confirmation word')).toHaveValue('');
+    });
+
+    it('disables Delete when the input is empty', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+
+    it('keeps Delete disabled on "Delete" (wrong case)', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      await user.type(screen.getByLabelText('Confirmation word'), 'Delete');
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+
+    it('keeps Delete disabled on partial input "del"', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      await user.type(screen.getByLabelText('Confirmation word'), 'del');
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+
+    it('enables Delete on exactly "delete"', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+    });
+
+    it('calls onConfirm exactly once after completing both steps', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel when Cancel is clicked at step 2', async () => {
+      const user = userEvent.setup();
+      renderModal();
+      await advanceToStepTwo(user);
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('disables the Delete button and shows "Deleting..." while deleting', async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderModal();
+      await advanceToStepTwo(user);
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      rerender(<TypedDeleteConfirmModal {...defaultProps} deleting={true} />);
+      const deleteButton = screen.getByRole('button', { name: 'Deleting...' });
+      expect(deleteButton).toBeDisabled();
+    });
+  });
+
+  describe('remount behaviour', () => {
+    it('resets to step 1 with an empty input on remount', async () => {
+      const user = userEvent.setup();
+      const { unmount } = renderModal();
+      await advanceToStepTwo(user);
+      unmount();
+      renderModal();
+      const input = screen.getByLabelText('Confirmation name');
+      expect(input).toHaveValue('');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/tests/unit/context/AuthContext.test.jsx
+++ b/frontend/tests/unit/context/AuthContext.test.jsx
@@ -5,6 +5,33 @@ import { AuthProvider, useAuth } from '../../../src/context/AuthContext.jsx';
 
 jest.mock('@/utils/api');
 
+// tests/setup.js mocks localStorage but not sessionStorage — mock it the same way here
+const sessionStorageMock = (() => {
+  let store = {};
+
+  return {
+    getItem: jest.fn((key) => store[key] ?? null),
+    setItem: jest.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: jest.fn((key) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessionStorageMock,
+  configurable: true,
+});
+
+beforeEach(() => {
+  sessionStorageMock.clear();
+});
+
 function TestHarness() {
   const {
     user,
@@ -20,6 +47,8 @@ function TestHarness() {
     registrationEnabled,
     memberships,
     managedAssignmentIds,
+    currentSubjectId,
+    setCurrentSubject,
   } = useAuth();
 
   const handleLogin = async () => {
@@ -44,10 +73,13 @@ function TestHarness() {
       <div data-testid="memberships-count">{memberships.length}</div>
       <div data-testid="membership-groups">{memberships.map((m) => m.group_name).join(',') || 'none'}</div>
       <div data-testid="managed-assignment-ids">{managedAssignmentIds.join(',') || 'none'}</div>
+      <div data-testid="current-subject">{currentSubjectId ?? 'none'}</div>
       <button onClick={handleLogin}>Login</button>
       <button onClick={handleRegister}>Register</button>
       <button onClick={logout}>Logout</button>
       <button onClick={refreshUser}>Refresh</button>
+      <button onClick={() => setCurrentSubject('s2')}>Select S2</button>
+      <button onClick={() => setCurrentSubject(null)}>Clear Subject</button>
     </div>
   );
 }
@@ -398,9 +430,13 @@ describe('AuthContext', () => {
 
   it('logout clears local state and storage', async () => {
     localStorage.setItem('token', 'existing-token');
+    const S1 = '11111111-1111-4111-8111-111111111111';
+    sessionStorage.setItem('gap.currentSubject', S1);
     api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
-      .mockResolvedValueOnce({ data: { user: { username: 'root', role: 'admin' } } }); // /auth/me on mount
+      .mockResolvedValueOnce({
+        data: { user: { username: 'root', role: 'admin', subjects: [{ id: S1, name: 'S1' }] } },
+      }); // /auth/me on mount
     api.post.mockRejectedValue(new Error('network error'));
 
     render(
@@ -423,6 +459,8 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('auth')).toHaveTextContent('no');
     expect(screen.getByTestId('user')).toHaveTextContent('none');
     expect(screen.getByTestId('token')).toHaveTextContent('none');
+    // The remembered subject selection must not leak to the next user in this tab
+    expect(sessionStorage.getItem('gap.currentSubject')).toBeNull();
   });
 });
 
@@ -460,6 +498,175 @@ describe('registrationEnabled config', () => {
     });
 
     expect(screen.getByTestId('registration-enabled')).toHaveTextContent('no');
+  });
+});
+
+describe('currentSubjectId management', () => {
+  const SUBJECT_1 = { id: 's1', name: 'Software Modelling' };
+  const SUBJECT_2 = { id: 's2', name: 'Distributed Systems' };
+  const SUBJECT_3 = { id: 's3', name: 'Algorithms' };
+
+  function mockUserFetch(subjects) {
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({
+        data: {
+          user: { username: 'carol', role: 'user', subjects, memberships: [], managedAssignments: [] },
+        },
+      }); // /auth/me on mount
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    api.get.mockResolvedValue({ data: { registrationEnabled: false } });
+  });
+
+  it('defaults currentSubjectId to null when nothing is stored', async () => {
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('loaded');
+    });
+
+    expect(screen.getByTestId('current-subject')).toHaveTextContent('none');
+  });
+
+  it('auto-selects the only subject and persists it to sessionStorage', async () => {
+    localStorage.setItem('token', 'existing-token');
+    mockUserFetch([SUBJECT_1]);
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-subject')).toHaveTextContent('s1');
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('gap.currentSubject', 's1');
+  });
+
+  it('restores a stored subject id that is in the user subject list', async () => {
+    sessionStorage.setItem('gap.currentSubject', 's2');
+    localStorage.setItem('token', 'existing-token');
+    mockUserFetch([SUBJECT_1, SUBJECT_2]);
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+
+    expect(screen.getByTestId('current-subject')).toHaveTextContent('s2');
+    expect(sessionStorage.removeItem).not.toHaveBeenCalledWith('gap.currentSubject');
+  });
+
+  it('ignores a stale stored subject id and clears the storage key', async () => {
+    sessionStorage.setItem('gap.currentSubject', 'stale-subject');
+    localStorage.setItem('token', 'existing-token');
+    mockUserFetch([SUBJECT_1, SUBJECT_2]);
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-subject')).toHaveTextContent('none');
+    });
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('gap.currentSubject');
+  });
+
+  it('setCurrentSubject persists the id and clears storage when called with null', async () => {
+    localStorage.setItem('token', 'existing-token');
+    mockUserFetch([SUBJECT_1, SUBJECT_2]);
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+    expect(screen.getByTestId('current-subject')).toHaveTextContent('none');
+
+    await userEvent.click(screen.getByText('Select S2'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-subject')).toHaveTextContent('s2');
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('gap.currentSubject', 's2');
+
+    await userEvent.click(screen.getByText('Clear Subject'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-subject')).toHaveTextContent('none');
+    });
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('gap.currentSubject');
+  });
+
+  it('clears the selection when the subject disappears after refreshUser', async () => {
+    sessionStorage.setItem('gap.currentSubject', 's2');
+    localStorage.setItem('token', 'existing-token');
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({
+        data: {
+          user: {
+            username: 'carol',
+            role: 'user',
+            subjects: [SUBJECT_1, SUBJECT_2],
+            memberships: [],
+            managedAssignments: [],
+          },
+        },
+      }) // /auth/me on mount
+      .mockResolvedValueOnce({
+        data: {
+          user: {
+            username: 'carol',
+            role: 'user',
+            subjects: [SUBJECT_1, SUBJECT_3],
+            memberships: [],
+            managedAssignments: [],
+          },
+        },
+      }); // refreshUser
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+    expect(screen.getByTestId('current-subject')).toHaveTextContent('s2');
+
+    await userEvent.click(screen.getByText('Refresh'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-subject')).toHaveTextContent('none');
+    });
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith('gap.currentSubject');
   });
 });
 

--- a/frontend/tests/unit/context/AuthContext.test.jsx
+++ b/frontend/tests/unit/context/AuthContext.test.jsx
@@ -18,6 +18,8 @@ function TestHarness() {
     logout,
     refreshUser,
     registrationEnabled,
+    memberships,
+    managedAssignmentIds,
   } = useAuth();
 
   const handleLogin = async () => {
@@ -39,6 +41,9 @@ function TestHarness() {
       <div data-testid="is-admin">{isAdmin ? 'yes' : 'no'}</div>
       <div data-testid="is-assignment-manager">{isAssignmentManager ? 'yes' : 'no'}</div>
       <div data-testid="registration-enabled">{registrationEnabled ? 'yes' : 'no'}</div>
+      <div data-testid="memberships-count">{memberships.length}</div>
+      <div data-testid="membership-groups">{memberships.map((m) => m.group_name).join(',') || 'none'}</div>
+      <div data-testid="managed-assignment-ids">{managedAssignmentIds.join(',') || 'none'}</div>
       <button onClick={handleLogin}>Login</button>
       <button onClick={handleRegister}>Register</button>
       <button onClick={logout}>Logout</button>
@@ -69,6 +74,10 @@ describe('AuthContext', () => {
 
     expect(screen.getByTestId('auth')).toHaveTextContent('no');
     expect(screen.getByTestId('user')).toHaveTextContent('none');
+    // Derived fields default to empty when there is no user
+    expect(screen.getByTestId('memberships-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('membership-groups')).toHaveTextContent('none');
+    expect(screen.getByTestId('managed-assignment-ids')).toHaveTextContent('none');
     // /auth/config is always fetched on mount; /auth/me is only called when a token exists
     expect(api.get).not.toHaveBeenCalledWith(expect.stringContaining('/auth/me'));
   });
@@ -77,7 +86,20 @@ describe('AuthContext', () => {
     localStorage.setItem('token', 'existing-token');
     api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
-      .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'assignment_manager' } } }); // /auth/me on mount
+      .mockResolvedValueOnce({
+        data: {
+          user: {
+            username: 'alice',
+            role: 'assignment_manager',
+            subjects: [{ id: 's1', name: 'Software Modelling' }],
+            memberships: [],
+            managedAssignments: [
+              { id: 'as1', name: 'Assignment 1', subject_id: 's1', subject_name: 'Software Modelling' },
+              { id: 'as2', name: 'Assignment 2', subject_id: 's1', subject_name: 'Software Modelling' },
+            ],
+          },
+        },
+      }); // /auth/me on mount
 
     render(
       <AuthProvider>
@@ -92,6 +114,77 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('user')).toHaveTextContent('alice');
     expect(screen.getByTestId('is-admin')).toHaveTextContent('no');
     expect(screen.getByTestId('is-assignment-manager')).toHaveTextContent('yes');
+    expect(screen.getByTestId('managed-assignment-ids')).toHaveTextContent('as1,as2');
+    expect(screen.getByTestId('memberships-count')).toHaveTextContent('0');
+  });
+
+  it('derives memberships and managedAssignmentIds from the user object', async () => {
+    localStorage.setItem('token', 'existing-token');
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({
+        data: {
+          user: {
+            username: 'bob',
+            role: 'user',
+            subjects: [{ id: 's1', name: 'Software Modelling' }],
+            memberships: [
+              {
+                assignment_id: 'as1',
+                assignment_name: 'Assignment 1',
+                subject_id: 's1',
+                subject_name: 'Software Modelling',
+                group_id: 'g1',
+                group_name: 'Team Alpha',
+              },
+              {
+                assignment_id: 'as2',
+                assignment_name: 'Assignment 2',
+                subject_id: 's1',
+                subject_name: 'Software Modelling',
+                group_id: 'g2',
+                group_name: 'Team Beta',
+              },
+            ],
+            managedAssignments: [{ id: 'as9', name: 'Managed', subject_id: 's1', subject_name: 'Software Modelling' }],
+          },
+        },
+      }); // /auth/me on mount
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+
+    expect(screen.getByTestId('memberships-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('membership-groups')).toHaveTextContent('Team Alpha,Team Beta');
+    expect(screen.getByTestId('managed-assignment-ids')).toHaveTextContent('as9');
+  });
+
+  it('defaults derived fields to empty arrays when user lacks membership fields', async () => {
+    localStorage.setItem('token', 'existing-token');
+    api.get
+      .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
+      .mockResolvedValueOnce({ data: { user: { username: 'legacy', role: 'user' } } }); // /auth/me on mount
+
+    render(
+      <AuthProvider>
+        <TestHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth')).toHaveTextContent('yes');
+    });
+
+    expect(screen.getByTestId('memberships-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('membership-groups')).toHaveTextContent('none');
+    expect(screen.getByTestId('managed-assignment-ids')).toHaveTextContent('none');
   });
 
   it('clears invalid token when /auth/me fails', async () => {
@@ -113,13 +206,20 @@ describe('AuthContext', () => {
   });
 
   it('login stores token and authenticates user on success', async () => {
+    const demoUser = {
+      username: 'demo',
+      role: 'normal_user',
+      subjects: [],
+      memberships: [],
+      managedAssignments: [],
+    };
     // /auth/config on mount (no token yet), then /auth/me after token is set by login
     api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
-      .mockResolvedValueOnce({ data: { user: { username: 'demo', role: 'normal_user' } } }); // /auth/me after login sets token
+      .mockResolvedValueOnce({ data: { user: demoUser } }); // /auth/me after login sets token
 
     api.post.mockResolvedValue({
-      data: { token: 'jwt-token', user: { username: 'demo', role: 'normal_user' } },
+      data: { token: 'jwt-token', user: demoUser },
     });
 
     render(
@@ -232,14 +332,22 @@ describe('AuthContext', () => {
     localStorage.setItem('token', 'existing-token');
     api.get
       .mockResolvedValueOnce({ data: { registrationEnabled: false } }) // /auth/config on mount
-      .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'user', groupId: null } } })
+      .mockResolvedValueOnce({ data: { user: { username: 'alice', role: 'user', memberships: [] } } })
       .mockResolvedValueOnce({
         data: {
           user: {
             username: 'alice',
             role: 'user',
-            groupId: 'g0000000-0000-0000-0000-000000000001',
-            groupName: 'Team A',
+            memberships: [
+              {
+                assignment_id: 'as1',
+                assignment_name: 'Assignment 1',
+                subject_id: 's1',
+                subject_name: 'Software Modelling',
+                group_id: 'g0000000-0000-0000-0000-000000000001',
+                group_name: 'Team A',
+              },
+            ],
           },
         },
       });
@@ -253,12 +361,14 @@ describe('AuthContext', () => {
     await waitFor(() => {
       expect(screen.getByTestId('auth')).toHaveTextContent('yes');
     });
+    expect(screen.getByTestId('membership-groups')).toHaveTextContent('none');
 
     await userEvent.click(screen.getByText('Refresh'));
 
     await waitFor(() => {
       expect(api.get).toHaveBeenCalledTimes(3); // config + /auth/me on mount + refreshUser
     });
+    expect(screen.getByTestId('membership-groups')).toHaveTextContent('Team A');
   });
 
   it('refreshUser clears auth on failure', async () => {

--- a/frontend/tests/unit/pages/Dashboard.test.jsx
+++ b/frontend/tests/unit/pages/Dashboard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import api from '@/utils/api';
@@ -10,407 +10,425 @@ jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
 
-describe('Dashboard page', () => {
-  const mockLogout = jest.fn();
-  const mockRefreshUser = jest.fn();
+const mockLogout = jest.fn();
+const mockRefreshUser = jest.fn();
 
+const SUBJECT_1 = { id: 'sub-1', name: 'Software Modelling' };
+const SUBJECT_2 = { id: 'sub-2', name: 'Distributed Systems' };
+
+const MEMBERSHIP_A1 = {
+  assignment_id: 'a-1',
+  assignment_name: 'Assignment 1',
+  subject_id: 'sub-1',
+  subject_name: 'Software Modelling',
+  group_id: 'g-1',
+  group_name: 'Team Alpha',
+};
+
+function makeUser(overrides = {}) {
+  return {
+    id: 'u-10',
+    username: 'testuser',
+    email: 'test@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    role: 'user',
+    studentId: 's1234567',
+    subjects: [SUBJECT_1],
+    memberships: [],
+    managedAssignments: [],
+    ...overrides,
+  };
+}
+
+function mockAuth({ user, isAdmin = false, isAssignmentManager = false }) {
+  useAuth.mockReturnValue({
+    user,
+    logout: mockLogout,
+    refreshUser: mockRefreshUser,
+    isAdmin,
+    isAssignmentManager,
+    memberships: user?.memberships ?? [],
+    managedAssignmentIds: (user?.managedAssignments ?? []).map((a) => a.id),
+  });
+}
+
+function mockApi({
+  locked = false,
+  subjects = {},
+  groupsByAssignment = {},
+  membersByGroup = {},
+  failSubjects = [],
+} = {}) {
+  api.get.mockImplementation((url) => {
+    if (url.includes('/config/group-join-locked')) {
+      return Promise.resolve({ data: { locked } });
+    }
+    const subjectMatch = url.match(/\/subjects\/([^/?]+)$/);
+    if (subjectMatch) {
+      const id = subjectMatch[1];
+      if (failSubjects.includes(id)) {
+        return Promise.reject(new Error('subject fetch failed'));
+      }
+      return Promise.resolve({ data: { subject: { id }, assignments: subjects[id] ?? [] } });
+    }
+    const assignmentMatch = url.match(/\/assignments\/([^/?]+)\/groups/);
+    if (assignmentMatch) {
+      return Promise.resolve({ data: { groups: groupsByAssignment[assignmentMatch[1]] ?? [] } });
+    }
+    const groupMatch = url.match(/\/groups\/([^/?]+)$/);
+    if (groupMatch) {
+      return Promise.resolve({ data: { group: {}, members: membersByGroup[groupMatch[1]] ?? [] } });
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+}
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+}
+
+describe('Dashboard page', () => {
   beforeEach(() => {
-    useAuth.mockReturnValue({
-      user: { username: 'testuser', email: 'test@example.com', role: 'normal_user' },
-      logout: mockLogout,
-      refreshUser: mockRefreshUser,
-      isAdmin: false,
-      isAssignmentManager: false,
-    });
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('renders user profile data', () => {
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
+  describe('profile card', () => {
+    it('shows subject names joined by comma and no Group row', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }) });
+      mockApi({ subjects: { 'sub-1': [], 'sub-2': [] } });
 
-    expect(screen.getByText(/welcome back, testuser!/i)).toBeInTheDocument();
-    expect(screen.getByText('test@example.com')).toBeInTheDocument();
-    expect(screen.getByText('Normal User')).toBeInTheDocument();
-  });
+      renderDashboard();
 
-  it('shows admin links for admin users', () => {
-    useAuth.mockReturnValue({
-      user: { username: 'admin', email: 'admin@example.com', role: 'admin' },
-      logout: mockLogout,
-      refreshUser: mockRefreshUser,
-      isAdmin: true,
-      isAssignmentManager: true,
+      expect(screen.getByText(/welcome back, testuser!/i)).toBeInTheDocument();
+      expect(screen.getByText('Software Modelling, Distributed Systems')).toBeInTheDocument();
+      expect(screen.queryByText(/^Group$/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Not assigned')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining('/subjects/sub-1'));
+      });
     });
 
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /manage groups/i })).toBeInTheDocument();
-  });
-
-  it('shows Manage Users but not Manage Groups for assignment_manager role', () => {
-    useAuth.mockReturnValue({
-      user: { username: 'manager', email: 'manager@example.com', role: 'assignment_manager' },
-      logout: mockLogout,
-      refreshUser: mockRefreshUser,
-      isAdmin: false,
-      isAssignmentManager: true,
-    });
-
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: /manage groups/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
-  });
-
-  it('hides administration block for normal users', () => {
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
-
-    expect(screen.queryByText('Administration')).not.toBeInTheDocument();
-  });
-
-  it('does not show My Group section for admin users', () => {
-    useAuth.mockReturnValue({
-      user: { username: 'admin', email: 'admin@example.com', role: 'admin' },
-      logout: mockLogout,
-      refreshUser: mockRefreshUser,
-      isAdmin: true,
-      isAssignmentManager: true,
-    });
-
-    render(
-      <MemoryRouter>
-        <Dashboard />
-      </MemoryRouter>
-    );
-
-    expect(screen.queryByText('My Group')).not.toBeInTheDocument();
-  });
-
-  describe('My Group (normal user)', () => {
-    it('shows current group with leave button when user is in a group', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
+    it('shows a dash when the user has no subjects', () => {
+      mockAuth({
+        user: makeUser({ username: 'admin', role: 'admin', subjects: [] }),
+        isAdmin: true,
+        isAssignmentManager: true,
       });
 
-      api.get.mockResolvedValue({ data: { members: [] } });
+      renderDashboard();
 
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      expect(screen.getByText('My Group')).toBeInTheDocument();
-      expect(screen.getAllByText('Team Alpha').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByRole('button', { name: /leave group/i })).toBeInTheDocument();
+      expect(screen.getByText('Subjects')).toBeInTheDocument();
+      expect(screen.getByText('—')).toBeInTheDocument();
     });
+  });
 
-    it('fetches and shows group members when user is in a group', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
+  describe('administration links', () => {
+    it('shows Subjects & Assignments link for admins pointing at /subjects', () => {
+      mockAuth({
+        user: makeUser({ username: 'admin', role: 'admin', subjects: [] }),
+        isAdmin: true,
+        isAssignmentManager: true,
       });
 
-      api.get.mockResolvedValue({
-        data: {
-          members: [
-            {
-              id: 'u0000000-0000-0000-0000-000000000010',
-              username: 'testuser',
-              email: 'test@example.com',
-              first_name: 'Test',
-              last_name: 'User',
-            },
-            {
-              id: 'u0000000-0000-0000-0000-000000000020',
-              username: 'alice',
-              email: 'alice@example.com',
-              first_name: 'Alice',
-              last_name: 'Smith',
-            },
+      renderDashboard();
+
+      const subjectsLink = screen.getByRole('link', { name: /subjects & assignments/i });
+      expect(subjectsLink).toBeInTheDocument();
+      expect(subjectsLink).toHaveAttribute('href', '/subjects');
+      expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /manage groups/i })).not.toBeInTheDocument();
+    });
+
+    it('shows Subjects & Assignments link for assignment managers', () => {
+      mockAuth({
+        user: makeUser({ username: 'manager', role: 'assignment_manager', subjects: [] }),
+        isAdmin: false,
+        isAssignmentManager: true,
+      });
+
+      renderDashboard();
+
+      expect(screen.getByRole('link', { name: /subjects & assignments/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
+    });
+
+    it('hides the administration block for normal users', () => {
+      mockAuth({ user: makeUser({ subjects: [] }) });
+
+      renderDashboard();
+
+      expect(screen.queryByText('Administration')).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /subjects & assignments/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('per-subject cards', () => {
+    it('renders a card per subject listing its assignments', async () => {
+      mockAuth({
+        user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2], memberships: [MEMBERSHIP_A1] }),
+      });
+      mockApi({
+        subjects: {
+          'sub-1': [
+            { id: 'a-1', name: 'Assignment 1', group_count: 2 },
+            { id: 'a-2', name: 'Assignment 2', group_count: 1 },
+          ],
+          'sub-2': [{ id: 'a-3', name: 'Assignment 3', group_count: 0 }],
+        },
+        groupsByAssignment: { 'a-2': [], 'a-3': [] },
+      });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('Assignment 1')).toBeInTheDocument();
+        expect(screen.getByText('Assignment 2')).toBeInTheDocument();
+        expect(screen.getByText('Assignment 3')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Software Modelling')).toBeInTheDocument();
+      expect(screen.getByText('Distributed Systems')).toBeInTheDocument();
+    });
+
+    it('does not render subject cards or fetch subjects for admins', () => {
+      mockAuth({
+        user: makeUser({ username: 'admin', role: 'admin', subjects: [SUBJECT_1] }),
+        isAdmin: true,
+        isAssignmentManager: true,
+      });
+      mockApi();
+
+      renderDashboard();
+
+      expect(api.get).not.toHaveBeenCalledWith(expect.stringContaining('/subjects/'));
+      expect(screen.queryByText(/you are not enrolled in any subject/i)).not.toBeInTheDocument();
+    });
+
+    it('shows an empty state when the user has no subjects', () => {
+      mockAuth({ user: makeUser({ subjects: [] }) });
+      mockApi();
+
+      renderDashboard();
+
+      expect(
+        screen.getByText('You are not enrolled in any subject yet. Contact your administrator.')
+      ).toBeInTheDocument();
+    });
+
+    it('shows an inline error in the failing subject card while other subjects render', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }) });
+      mockApi({
+        subjects: { 'sub-2': [{ id: 'a-3', name: 'Assignment 3', group_count: 0 }] },
+        groupsByAssignment: { 'a-3': [] },
+        failSubjects: ['sub-1'],
+      });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to load subject details')).toBeInTheDocument();
+        expect(screen.getByText('Assignment 3')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('assignment with membership', () => {
+    const memberUser = makeUser({ memberships: [MEMBERSHIP_A1] });
+    const subjectFixture = { 'sub-1': [{ id: 'a-1', name: 'Assignment 1', group_count: 2 }] };
+
+    it('shows the current group with a leave button', async () => {
+      mockAuth({ user: memberUser });
+      mockApi({ subjects: subjectFixture });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText(/your group:/i)).toBeInTheDocument();
+        expect(screen.getByText('Team Alpha')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /leave group/i })).toBeInTheDocument();
+      });
+      // No join UI for an assignment the user already belongs to
+      expect(screen.queryByRole('button', { name: /^join$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /feeling lucky/i })).not.toBeInTheDocument();
+    });
+
+    it('fetches and shows group members only when expanded', async () => {
+      mockAuth({ user: memberUser });
+      mockApi({
+        subjects: subjectFixture,
+        membersByGroup: {
+          'g-1': [
+            { id: 'u-10', username: 'testuser', first_name: 'Test', last_name: 'User', role_name: 'user' },
+            { id: 'u-20', username: 'alice', first_name: 'Alice', last_name: 'Smith', role_name: 'user' },
+            { id: 'u-30', username: 'legacyuser', first_name: null, last_name: null, role_name: 'user' },
           ],
         },
       });
 
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText('Group Members')).toBeInTheDocument();
-        // shows formatted name "A. Smith" not username "alice"
+        expect(screen.getByRole('button', { name: /show members/i })).toBeInTheDocument();
+      });
+      expect(api.get).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-1$/));
+
+      await userEvent.click(screen.getByRole('button', { name: /show members/i }));
+
+      await waitFor(() => {
+        expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-1$/));
+        // "Initial. LastName" format, current user marked, username fallback
+        expect(screen.getByText('T. User')).toBeInTheDocument();
         expect(screen.getByText('A. Smith')).toBeInTheDocument();
-        expect(screen.getByText('alice@example.com')).toBeInTheDocument();
-        // current user is marked with (you)
+        expect(screen.getByText('legacyuser')).toBeInTheDocument();
         expect(screen.getByText('(you)')).toBeInTheDocument();
       });
+
+      await userEvent.click(screen.getByRole('button', { name: /hide members/i }));
+      expect(screen.queryByText('A. Smith')).not.toBeInTheDocument();
     });
 
-    it('displays member name as "Initial. LastName" format', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
+    it('hides the leave button and shows lock banner when the global lock is on', async () => {
+      mockAuth({ user: memberUser });
+      mockApi({ locked: true, subjects: subjectFixture });
 
-      api.get.mockResolvedValue({
-        data: {
-          members: [
-            { id: 'u1', username: 'jdoe', email: 'jdoe@example.com', first_name: 'John', last_name: 'Doe' },
-            { id: 'u2', username: 'msmith', email: 'm@example.com', first_name: 'Mary', last_name: 'Smith' },
-          ],
-        },
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText('J. Doe')).toBeInTheDocument();
-        expect(screen.getByText('M. Smith')).toBeInTheDocument();
-        // usernames should NOT be shown
-        expect(screen.queryByText('jdoe')).not.toBeInTheDocument();
-        expect(screen.queryByText('msmith')).not.toBeInTheDocument();
+        expect(screen.getByText('Team Alpha')).toBeInTheDocument();
       });
-    });
-
-    it('falls back to username when first_name is missing', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({
-        data: {
-          members: [
-            { id: 'u1', username: 'legacyuser', email: 'legacy@example.com', first_name: null, last_name: null },
-          ],
-        },
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
       await waitFor(() => {
-        expect(screen.getByText('legacyuser')).toBeInTheDocument();
+        expect(screen.getByText(/group joining is locked/i)).toBeInTheDocument();
       });
+      expect(screen.queryByRole('button', { name: /leave group/i })).not.toBeInTheDocument();
     });
 
-    it('shows no members message when group has no members', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({ data: { members: [] } });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('No members yet')).toBeInTheDocument();
-      });
-    });
-
-    it('fetches and shows available groups when user has no group', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({
-        data: {
-          groups: [
-            { id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 },
-            { id: 'g0000000-0000-0000-0000-000000000002', name: 'Team B', max_members: null, member_count: 10 },
-            { id: 'g0000000-0000-0000-0000-000000000003', name: 'Full Team', max_members: 3, member_count: 3 },
-          ],
-        },
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Team A')).toBeInTheDocument();
-        expect(screen.getByText('Team B')).toBeInTheDocument();
-      });
-
-      // Full team should be filtered out
-      expect(screen.queryByText('Full Team')).not.toBeInTheDocument();
-    });
-
-    it('shows member count with max members', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({
-        data: {
-          groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
-        },
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/2/)).toBeInTheDocument();
-        expect(screen.getByText(/\/ 5/)).toBeInTheDocument();
-      });
-    });
-
-    it('joins a group successfully', async () => {
+    it('leaves a group, refreshes the user, and refetches joinable groups', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
+      mockAuth({ user: memberUser });
+      mockApi({ subjects: subjectFixture, groupsByAssignment: { 'a-1': [] } });
+      api.post.mockResolvedValue({ data: {} });
 
-      api.get.mockResolvedValue({
-        data: {
-          groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
-        },
-      });
-      api.post.mockResolvedValue({});
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText('Team A')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /leave group/i })).toBeInTheDocument();
       });
 
-      await user.click(screen.getByRole('button', { name: /join/i }));
+      await user.click(screen.getByRole('button', { name: /leave group/i }));
 
       await waitFor(() => {
-        expect(api.post).toHaveBeenCalledWith(
-          expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001\/join$/)
-        );
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-1\/leave$/));
+        expect(screen.getByText('Successfully left group')).toBeInTheDocument();
+        expect(mockRefreshUser).toHaveBeenCalled();
+        expect(api.get).toHaveBeenCalledWith(expect.stringContaining('/assignments/a-1/groups'));
+      });
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => {
+        expect(screen.queryByText('Successfully left group')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows the server error when leaving fails', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      mockAuth({ user: memberUser });
+      mockApi({ subjects: subjectFixture });
+      api.post.mockRejectedValue({ response: { data: { error: 'Group changes are locked' } } });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /leave group/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /leave group/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Group changes are locked')).toBeInTheDocument();
+      });
+      expect(mockRefreshUser).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => {
+        expect(screen.queryByText('Group changes are locked')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('assignment without membership', () => {
+    const subjectFixture = { 'sub-1': [{ id: 'a-2', name: 'Assignment 2', group_count: 3 }] };
+
+    it('lists joinable groups and filters out full ones', async () => {
+      mockAuth({ user: makeUser() });
+      mockApi({
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [
+            { id: 'g-2', name: 'Team B', enabled: true, max_members: 5, member_count: 2 },
+            { id: 'g-3', name: 'Team C', enabled: true, max_members: null, member_count: 10 },
+            { id: 'g-4', name: 'Full Team', enabled: true, max_members: 3, member_count: 3 },
+          ],
+        },
+      });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('Team B')).toBeInTheDocument();
+        expect(screen.getByText('Team C')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Full Team')).not.toBeInTheDocument();
+      expect(screen.getAllByRole('button', { name: /^join$/i })).toHaveLength(2);
+    });
+
+    it('shows a message when no joinable groups exist', async () => {
+      mockAuth({ user: makeUser() });
+      mockApi({ subjects: subjectFixture, groupsByAssignment: { 'a-2': [] } });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('No available groups to join')).toBeInTheDocument();
+      });
+    });
+
+    it('joins a group and refreshes the user', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      mockAuth({ user: makeUser() });
+      mockApi({
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [{ id: 'g-2', name: 'Team B', enabled: true, max_members: 5, member_count: 2 }],
+        },
+      });
+      api.post.mockResolvedValue({ data: { message: 'ok', groupId: 'g-2', groupName: 'Team B' } });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('Team B')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /^join$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-2\/join$/));
         expect(screen.getByText('Successfully joined group')).toBeInTheDocument();
         expect(mockRefreshUser).toHaveBeenCalled();
       });
@@ -421,494 +439,168 @@ describe('Dashboard page', () => {
       });
     });
 
-    it('shows error when joining group fails', async () => {
+    it('shows the server error when joining fails with 409', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({
-        data: {
-          groups: [{ id: 'g0000000-0000-0000-0000-000000000001', name: 'Team A', max_members: 5, member_count: 2 }],
+      mockAuth({ user: makeUser() });
+      mockApi({
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [{ id: 'g-2', name: 'Team B', enabled: true, max_members: 5, member_count: 2 }],
         },
       });
-      api.post.mockRejectedValue({ response: { data: { error: 'Group is full' } } });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Team A')).toBeInTheDocument();
+      api.post.mockRejectedValue({
+        response: { status: 409, data: { error: 'You already belong to a group for this assignment' } },
       });
 
-      await user.click(screen.getByRole('button', { name: /join/i }));
+      renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText('Group is full')).toBeInTheDocument();
+        expect(screen.getByText('Team B')).toBeInTheDocument();
       });
+
+      await user.click(screen.getByRole('button', { name: /^join$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('You already belong to a group for this assignment')).toBeInTheDocument();
+      });
+      expect(mockRefreshUser).not.toHaveBeenCalled();
 
       jest.advanceTimersByTime(3000);
       await waitFor(() => {
-        expect(screen.queryByText('Group is full')).not.toBeInTheDocument();
+        expect(screen.queryByText('You already belong to a group for this assignment')).not.toBeInTheDocument();
       });
     });
 
-    it('leaves a group successfully', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    it("joins a random non-empty group via I'm Feeling Lucky", async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.99);
 
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
+      mockAuth({ user: makeUser() });
+      mockApi({
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [
+            { id: 'g-empty', name: 'Empty Group', enabled: true, max_members: 5, member_count: 0 },
+            { id: 'g-a', name: 'Active A', enabled: true, max_members: 5, member_count: 1 },
+            { id: 'g-b', name: 'Active B', enabled: true, max_members: 5, member_count: 2 },
+          ],
         },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
       });
+      api.post.mockResolvedValue({ data: {} });
 
-      api.get.mockResolvedValue({ data: { members: [] } });
-      api.post.mockResolvedValue({});
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await user.click(screen.getByRole('button', { name: /leave group/i }));
-
-      await waitFor(() => {
-        expect(api.post).toHaveBeenCalledWith(
-          expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001\/leave$/)
-        );
-        expect(screen.getByText('Successfully left group')).toBeInTheDocument();
-        expect(mockRefreshUser).toHaveBeenCalled();
-      });
-
-      jest.advanceTimersByTime(3000);
-      await waitFor(() => {
-        expect(screen.queryByText('Successfully left group')).not.toBeInTheDocument();
-      });
-    });
-
-    it('shows error when leaving group fails', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: 'g0000000-0000-0000-0000-000000000001',
-          groupName: 'Team Alpha',
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({ data: { members: [] } });
-      api.post.mockRejectedValue({ response: { data: { error: 'Not a member' } } });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await user.click(screen.getByRole('button', { name: /leave group/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Not a member')).toBeInTheDocument();
-      });
-
-      jest.advanceTimersByTime(3000);
-      await waitFor(() => {
-        expect(screen.queryByText('Not a member')).not.toBeInTheDocument();
-      });
-    });
-
-    it('shows no available groups message when none exist', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({ data: { groups: [] } });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('No available groups to join')).toBeInTheDocument();
-      });
-    });
-
-    it('shows error when fetching available groups fails', async () => {
-      jest.useFakeTimers();
-
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockRejectedValue(new Error('network'));
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Failed to load available groups')).toBeInTheDocument();
-      });
-
-      jest.advanceTimersByTime(3000);
-      await waitFor(() => {
-        expect(screen.queryByText('Failed to load available groups')).not.toBeInTheDocument();
-      });
-    });
-
-    it('does not call leave when user has no groupId', async () => {
-      useAuth.mockReturnValue({
-        user: {
-          id: 'u0000000-0000-0000-0000-000000000010',
-          username: 'testuser',
-          email: 'test@example.com',
-          role: 'user',
-          groupId: null,
-          groupName: null,
-        },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockResolvedValue({ data: { groups: [] } });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      // The leave button shouldn't even show, but the handleLeaveGroup has a guard
-      expect(screen.queryByRole('button', { name: /leave group/i })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Settings link (admin/AM)', () => {
-    it('shows settings link for admin users', () => {
-      useAuth.mockReturnValue({
-        user: { username: 'admin', email: 'admin@example.com', role: 'admin' },
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: true,
-        isAssignmentManager: true,
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
-    });
-
-    it('does not show settings link for normal users', () => {
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      expect(screen.queryByRole('link', { name: /settings/i })).not.toBeInTheDocument();
-    });
-  });
-
-  describe("I'm Feeling Lucky", () => {
-    const normalUserNoGroup = {
-      id: 'u0000000-0000-0000-0000-000000000010',
-      username: 'testuser',
-      email: 'test@example.com',
-      role: 'user',
-      groupId: null,
-      groupName: null,
-    };
-
-    beforeEach(() => {
-      useAuth.mockReturnValue({
-        user: normalUserNoGroup,
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-    });
-
-    it('shows "I\'m Feeling Lucky" button when user has no group and lock is off', async () => {
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: false } });
-        }
-        return Promise.resolve({
-          data: {
-            groups: [{ id: 'g1', name: 'Team A', max_members: 5, member_count: 2 }],
-          },
-        });
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /feeling lucky/i })).toBeInTheDocument();
       });
-    });
-
-    it('assigns to a non-empty group when one exists', async () => {
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: false } });
-        }
-        return Promise.resolve({
-          data: {
-            groups: [
-              { id: 'g1', name: 'Empty Group', max_members: 5, member_count: 0 },
-              { id: 'g2', name: 'Active Group', max_members: 5, member_count: 3 },
-            ],
-          },
-        });
-      });
-      api.post.mockResolvedValue({});
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => screen.getByRole('button', { name: /feeling lucky/i }));
 
       await userEvent.click(screen.getByRole('button', { name: /feeling lucky/i }));
 
       await waitFor(() => {
-        // Should join g2 (non-empty), not g1 (empty)
-        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g2\/join$/));
+        // pool is the non-empty groups [g-a, g-b]; floor(0.99 * 2) = 1 -> g-b
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-b\/join$/));
       });
+
+      randomSpy.mockRestore();
     });
 
-    it('falls back to any group when no non-empty groups exist', async () => {
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: false } });
-        }
-        return Promise.resolve({
-          data: {
-            groups: [{ id: 'g1', name: 'Empty Group', max_members: 5, member_count: 0 }],
-          },
-        });
+    it('falls back to empty groups for lucky when all groups are empty', async () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+
+      mockAuth({ user: makeUser() });
+      mockApi({
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [{ id: 'g-empty', name: 'Empty Group', enabled: true, max_members: 5, member_count: 0 }],
+        },
       });
-      api.post.mockResolvedValue({});
+      api.post.mockResolvedValue({ data: {} });
 
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
-      await waitFor(() => screen.getByRole('button', { name: /feeling lucky/i }));
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /feeling lucky/i })).toBeInTheDocument();
+      });
 
       await userEvent.click(screen.getByRole('button', { name: /feeling lucky/i }));
 
       await waitFor(() => {
-        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g1\/join$/));
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g-empty\/join$/));
       });
+
+      randomSpy.mockRestore();
     });
 
-    it('shows error when no groups are available', async () => {
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: false } });
-        }
-        return Promise.resolve({ data: { groups: [] } });
+    it('shows an error when lucky finds no joinable group', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+      mockAuth({ user: makeUser() });
+      mockApi({ subjects: subjectFixture, groupsByAssignment: { 'a-2': [] } });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /feeling lucky/i })).toBeInTheDocument();
       });
 
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => screen.getByRole('button', { name: /feeling lucky/i }));
-
-      await userEvent.click(screen.getByRole('button', { name: /feeling lucky/i }));
+      await user.click(screen.getByRole('button', { name: /feeling lucky/i }));
 
       await waitFor(() => {
         expect(screen.getByText('No available group to join')).toBeInTheDocument();
       });
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('shows the locked banner instead of join UI when the global lock is on', async () => {
+      mockAuth({ user: makeUser() });
+      mockApi({
+        locked: true,
+        subjects: subjectFixture,
+        groupsByAssignment: {
+          'a-2': [{ id: 'g-2', name: 'Team B', enabled: true, max_members: 5, member_count: 2 }],
+        },
+      });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText(/group joining is locked/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: /^join$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /feeling lucky/i })).not.toBeInTheDocument();
     });
   });
 
-  describe('Group join lock', () => {
-    const normalUserNoGroup = {
-      id: 'u0000000-0000-0000-0000-000000000010',
-      username: 'testuser',
-      email: 'test@example.com',
-      role: 'user',
-      groupId: null,
-      groupName: null,
-    };
-
-    const normalUserInGroup = {
-      id: 'u0000000-0000-0000-0000-000000000010',
-      username: 'testuser',
-      email: 'test@example.com',
-      role: 'user',
-      groupId: 'g0000000-0000-0000-0000-000000000001',
-      groupName: 'Team Alpha',
-    };
-
-    it('shows lock message instead of join UI when lock is enabled and user has no group', async () => {
-      useAuth.mockReturnValue({
-        user: normalUserNoGroup,
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
+  describe('mixed subject content', () => {
+    it('renders membership and join UI side by side within the same subject card', async () => {
+      mockAuth({ user: makeUser({ memberships: [MEMBERSHIP_A1] }) });
+      mockApi({
+        subjects: {
+          'sub-1': [
+            { id: 'a-1', name: 'Assignment 1', group_count: 2 },
+            { id: 'a-2', name: 'Assignment 2', group_count: 1 },
+          ],
+        },
+        groupsByAssignment: {
+          'a-2': [{ id: 'g-2', name: 'Team B', enabled: true, max_members: 5, member_count: 2 }],
+        },
       });
 
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: true } });
-        }
-        return Promise.resolve({ data: { groups: [] } });
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
+      renderDashboard();
 
       await waitFor(() => {
-        expect(screen.getByText(/group joining is locked/i)).toBeInTheDocument();
+        expect(screen.getByText('Team Alpha')).toBeInTheDocument();
+        expect(screen.getByText('Team B')).toBeInTheDocument();
       });
 
-      expect(screen.queryByRole('button', { name: /feeling lucky/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /^join$/i })).not.toBeInTheDocument();
-    });
-
-    it('hides leave button and shows lock message when user is in a group and lock is enabled', async () => {
-      useAuth.mockReturnValue({
-        user: normalUserInGroup,
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: true } });
-        }
-        return Promise.resolve({ data: { members: [] } });
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/group joining is locked/i)).toBeInTheDocument();
-      });
-
-      expect(screen.queryByRole('button', { name: /leave group/i })).not.toBeInTheDocument();
-    });
-
-    it('shows leave button and join UI when lock is disabled', async () => {
-      useAuth.mockReturnValue({
-        user: normalUserInGroup,
-        logout: mockLogout,
-        refreshUser: mockRefreshUser,
-        isAdmin: false,
-        isAssignmentManager: false,
-      });
-
-      api.get.mockImplementation((url) => {
-        if (url.includes('group-join-locked')) {
-          return Promise.resolve({ data: { locked: false } });
-        }
-        return Promise.resolve({ data: { members: [] } });
-      });
-
-      render(
-        <MemoryRouter>
-          <Dashboard />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /leave group/i })).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText(/group joining is locked/i)).not.toBeInTheDocument();
+      const card = screen.getByRole('heading', { name: 'Software Modelling' }).closest('div');
+      expect(within(card).getByRole('button', { name: /leave group/i })).toBeInTheDocument();
+      expect(within(card).getByRole('button', { name: /^join$/i })).toBeInTheDocument();
+      // groups are only fetched for the assignment without a membership
+      expect(api.get).toHaveBeenCalledWith(expect.stringContaining('/assignments/a-2/groups'));
+      expect(api.get).not.toHaveBeenCalledWith(expect.stringContaining('/assignments/a-1/groups'));
     });
   });
 });

--- a/frontend/tests/unit/pages/Dashboard.test.jsx
+++ b/frontend/tests/unit/pages/Dashboard.test.jsx
@@ -12,6 +12,7 @@ jest.mock('../../../src/context/AuthContext.jsx', () => ({
 
 const mockLogout = jest.fn();
 const mockRefreshUser = jest.fn();
+const mockSetCurrentSubject = jest.fn();
 
 const SUBJECT_1 = { id: 'sub-1', name: 'Software Modelling' };
 const SUBJECT_2 = { id: 'sub-2', name: 'Distributed Systems' };
@@ -41,7 +42,7 @@ function makeUser(overrides = {}) {
   };
 }
 
-function mockAuth({ user, isAdmin = false, isAssignmentManager = false }) {
+function mockAuth({ user, isAdmin = false, isAssignmentManager = false, currentSubjectId = null }) {
   useAuth.mockReturnValue({
     user,
     logout: mockLogout,
@@ -50,6 +51,8 @@ function mockAuth({ user, isAdmin = false, isAssignmentManager = false }) {
     isAssignmentManager,
     memberships: user?.memberships ?? [],
     managedAssignmentIds: (user?.managedAssignments ?? []).map((a) => a.id),
+    currentSubjectId,
+    setCurrentSubject: mockSetCurrentSubject,
   });
 }
 
@@ -149,7 +152,7 @@ describe('Dashboard page', () => {
       expect(screen.queryByRole('link', { name: /manage groups/i })).not.toBeInTheDocument();
     });
 
-    it('shows Subjects & Assignments link for assignment managers', () => {
+    it('hides the Manage Users link for assignment managers and mentions user management in the Subjects card', () => {
       mockAuth({
         user: makeUser({ username: 'manager', role: 'assignment_manager', subjects: [] }),
         isAdmin: false,
@@ -158,8 +161,29 @@ describe('Dashboard page', () => {
 
       renderDashboard();
 
-      expect(screen.getByRole('link', { name: /subjects & assignments/i })).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /manage users/i })).toBeInTheDocument();
+      // Manage Users is admin-only now
+      expect(screen.queryByRole('link', { name: /^👥 Manage Users$/ })).not.toBeInTheDocument();
+      expect(screen.queryAllByRole('link').some((l) => l.getAttribute('href') === '/users')).toBe(false);
+      // AM copy tweak: Subjects card mentions managing users within their subjects
+      const subjectsLink = screen.getByRole('link', { name: /subjects & assignments/i });
+      expect(subjectsLink).toHaveAttribute('href', '/subjects');
+      expect(subjectsLink).toHaveTextContent(/manage users within your subjects/i);
+    });
+
+    it('keeps the Manage Users link admin-only', () => {
+      mockAuth({
+        user: makeUser({ username: 'admin', role: 'admin', subjects: [] }),
+        isAdmin: true,
+        isAssignmentManager: true,
+      });
+
+      renderDashboard();
+
+      const usersLink = screen.getByRole('link', { name: /^👥 Manage Users$/ });
+      expect(usersLink).toHaveAttribute('href', '/users');
+      // Admin keeps the plain Subjects card copy
+      const subjectsLink = screen.getByRole('link', { name: /subjects & assignments/i });
+      expect(subjectsLink).not.toHaveTextContent(/manage users within your subjects/i);
     });
 
     it('hides the administration block for normal users', () => {
@@ -173,33 +197,99 @@ describe('Dashboard page', () => {
     });
   });
 
-  describe('per-subject cards', () => {
-    it('renders a card per subject listing its assignments', async () => {
+  describe('subject selection', () => {
+    const multiSubjectFixture = {
+      'sub-1': [
+        { id: 'a-1', name: 'Assignment 1', group_count: 2 },
+        { id: 'a-2', name: 'Assignment 2', group_count: 1 },
+      ],
+      'sub-2': [{ id: 'a-3', name: 'Assignment 3', group_count: 0 }],
+    };
+    const multiSubjectGroups = { 'a-1': [], 'a-2': [], 'a-3': [] };
+
+    it('shows the subject picker instead of subject cards when nothing is selected', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }) });
+      mockApi({ subjects: multiSubjectFixture, groupsByAssignment: multiSubjectGroups });
+
+      renderDashboard();
+
+      expect(screen.getByText('Select your subject')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /software modelling/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /distributed systems/i })).toBeInTheDocument();
+
+      // Assignment counts appear once the (already existing) subject fetches resolve
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /software modelling/i })).toHaveTextContent('2 assignments');
+        expect(screen.getByRole('button', { name: /distributed systems/i })).toHaveTextContent('1 assignment');
+      });
+
+      // No subject card content is rendered while the picker is showing
+      expect(screen.queryByText('Assignment 1')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assignment 3')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /switch subject/i })).not.toBeInTheDocument();
+    });
+
+    it('selects a subject when its picker card is clicked', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }) });
+      mockApi({ subjects: multiSubjectFixture, groupsByAssignment: multiSubjectGroups });
+
+      renderDashboard();
+
+      await userEvent.click(screen.getByRole('button', { name: /distributed systems/i }));
+
+      expect(mockSetCurrentSubject).toHaveBeenCalledWith('sub-2');
+    });
+
+    it('renders only the selected subject card plus a switcher when a subject is selected', async () => {
       mockAuth({
         user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2], memberships: [MEMBERSHIP_A1] }),
+        currentSubjectId: 'sub-1',
       });
-      mockApi({
-        subjects: {
-          'sub-1': [
-            { id: 'a-1', name: 'Assignment 1', group_count: 2 },
-            { id: 'a-2', name: 'Assignment 2', group_count: 1 },
-          ],
-          'sub-2': [{ id: 'a-3', name: 'Assignment 3', group_count: 0 }],
-        },
-        groupsByAssignment: { 'a-2': [], 'a-3': [] },
-      });
+      mockApi({ subjects: multiSubjectFixture, groupsByAssignment: multiSubjectGroups });
 
       renderDashboard();
 
       await waitFor(() => {
         expect(screen.getByText('Assignment 1')).toBeInTheDocument();
         expect(screen.getByText('Assignment 2')).toBeInTheDocument();
-        expect(screen.getByText('Assignment 3')).toBeInTheDocument();
       });
-      expect(screen.getByText('Software Modelling')).toBeInTheDocument();
-      expect(screen.getByText('Distributed Systems')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Software Modelling' })).toBeInTheDocument();
+      // The other subject's card is not rendered
+      expect(screen.queryByText('Assignment 3')).not.toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Distributed Systems' })).not.toBeInTheDocument();
+      // No picker, but a switcher is available
+      expect(screen.queryByText('Select your subject')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /switch subject/i })).toBeInTheDocument();
     });
 
+    it('returns to the picker when Switch subject is clicked', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }), currentSubjectId: 'sub-1' });
+      mockApi({ subjects: multiSubjectFixture, groupsByAssignment: multiSubjectGroups });
+
+      renderDashboard();
+
+      await userEvent.click(screen.getByRole('button', { name: /switch subject/i }));
+
+      expect(mockSetCurrentSubject).toHaveBeenCalledWith(null);
+    });
+
+    it('lands single-subject users straight on their subject card with no picker or switcher', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1], memberships: [MEMBERSHIP_A1] }) });
+      mockApi({ subjects: { 'sub-1': [{ id: 'a-1', name: 'Assignment 1', group_count: 2 }] } });
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByText('Assignment 1')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('heading', { name: 'Software Modelling' })).toBeInTheDocument();
+      expect(screen.queryByText('Select your subject')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /switch subject/i })).not.toBeInTheDocument();
+      expect(mockSetCurrentSubject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('per-subject cards', () => {
     it('does not render subject cards or fetch subjects for admins', () => {
       mockAuth({
         user: makeUser({ username: 'admin', role: 'admin', subjects: [SUBJECT_1] }),
@@ -225,8 +315,8 @@ describe('Dashboard page', () => {
       ).toBeInTheDocument();
     });
 
-    it('shows an inline error in the failing subject card while other subjects render', async () => {
-      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }) });
+    it('shows an inline error when the selected subject fails to load', async () => {
+      mockAuth({ user: makeUser({ subjects: [SUBJECT_1, SUBJECT_2] }), currentSubjectId: 'sub-1' });
       mockApi({
         subjects: { 'sub-2': [{ id: 'a-3', name: 'Assignment 3', group_count: 0 }] },
         groupsByAssignment: { 'a-3': [] },
@@ -237,8 +327,9 @@ describe('Dashboard page', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Failed to load subject details')).toBeInTheDocument();
-        expect(screen.getByText('Assignment 3')).toBeInTheDocument();
       });
+      // The other (healthy) subject stays hidden behind the switcher
+      expect(screen.queryByText('Assignment 3')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/unit/pages/Groups.test.jsx
+++ b/frontend/tests/unit/pages/Groups.test.jsx
@@ -1082,6 +1082,79 @@ describe('Groups page (groups of one assignment)', () => {
       expect(screen.getByText(/\(6 groups\)/i)).toBeInTheDocument();
     });
 
+    it('pads generated names to the width of the batch size (3 digits for 300 groups)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '300');
+
+      // Preview reflects the padded last name
+      expect(screen.getByText(/team300/i)).toBeInTheDocument();
+      expect(screen.getByText(/team001/i)).toBeInTheDocument();
+
+      api.post.mockResolvedValueOnce({ data: { groups: [] } });
+      await user.click(screen.getByRole('button', { name: /create 300 groups/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledTimes(1);
+        const body = api.post.mock.calls[0][1];
+        expect(body.groups[0].name).toBe('Team001');
+        expect(body.groups[9].name).toBe('Team010');
+        expect(body.groups[99].name).toBe('Team100');
+        expect(body.groups[299].name).toBe('Team300');
+      });
+    });
+
+    it('pads generated names to 4 digits for 3000 groups', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '3000');
+
+      api.post.mockResolvedValue({ data: { groups: [] } });
+      await user.click(screen.getByRole('button', { name: /create 3000 groups/i }));
+
+      await waitFor(() => {
+        // Large batches are split into sequential calls; check first and last chunk
+        const calls = api.post.mock.calls;
+        const firstBatch = calls[0][1].groups;
+        const lastBatch = calls[calls.length - 1][1].groups;
+        expect(firstBatch[0].name).toBe('Team0001');
+        expect(lastBatch[lastBatch.length - 1].name).toBe('Team3000');
+      });
+    });
+
+    it('keeps 2-digit padding for batches of 10–99 (existing behaviour)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '90');
+
+      api.post.mockResolvedValueOnce({ data: { groups: [] } });
+      await user.click(screen.getByRole('button', { name: /create 90 groups/i }));
+
+      await waitFor(() => {
+        const body = api.post.mock.calls[0][1];
+        expect(body.groups[0].name).toBe('Team01');
+        expect(body.groups[89].name).toBe('Team90');
+      });
+    });
+
     it('sends { assignmentId, groups } in a single POST /groups/bulk call', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -1126,10 +1199,10 @@ describe('Groups page (groups of one assignment)', () => {
         expect(firstCall[0]).toMatch(/\/groups\/bulk$/);
         expect(firstCall[1].assignmentId).toBe(ASSIGNMENT_ID);
         expect(firstCall[1].groups).toHaveLength(500);
-        expect(firstCall[1].groups[0]).toEqual({ name: 'Group01' });
-        expect(firstCall[1].groups[499]).toEqual({ name: 'Group500' });
+        expect(firstCall[1].groups[0]).toEqual({ name: 'Group0001' });
+        expect(firstCall[1].groups[499]).toEqual({ name: 'Group0500' });
         expect(secondCall[1].groups).toHaveLength(500);
-        expect(secondCall[1].groups[0]).toEqual({ name: 'Group501' });
+        expect(secondCall[1].groups[0]).toEqual({ name: 'Group0501' });
         expect(thirdCall[1].groups).toHaveLength(500);
         expect(thirdCall[1].groups[499]).toEqual({ name: 'Group1500' });
         expect(screen.getByText('Created 1500 groups')).toBeInTheDocument();

--- a/frontend/tests/unit/pages/Groups.test.jsx
+++ b/frontend/tests/unit/pages/Groups.test.jsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import api from '@/utils/api';
 import Groups from '../../../src/pages/Groups.jsx';
 import { useAuth } from '../../../src/context/AuthContext.jsx';
@@ -14,20 +14,35 @@ jest.mock('../../../src/utils/csv.js', () => ({
   downloadCsv: jest.fn(),
 }));
 
+const SUBJECT_ID = '11111111-1111-4111-8111-111111111111';
+const ASSIGNMENT_ID = '22222222-2222-4222-8222-222222222222';
+const OTHER_ASSIGNMENT_ID = '33333333-3333-4333-8333-333333333333';
+const GROUP_ID = '44444444-4444-4444-8444-444444444444';
+
 const makeGroup = (overrides = {}) => ({
-  id: 'g0000000-0000-0000-0000-000000000001',
+  id: GROUP_ID,
   name: 'Group A',
   enabled: true,
   member_count: 3,
   max_members: 5,
+  assignment_id: ASSIGNMENT_ID,
   created_at: '2025-01-01T00:00:00.000Z',
   ...overrides,
 });
 
-describe('Groups page', () => {
+const makeAssignment = (overrides = {}) => ({
+  id: ASSIGNMENT_ID,
+  name: 'Assignment 1',
+  subject_id: SUBJECT_ID,
+  subject_name: 'COMP1000',
+  group_count: 1,
+  ...overrides,
+});
+
+describe('Groups page (groups of one assignment)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAuth.mockReturnValue({ isAssignmentManager: true });
+    useAuth.mockReturnValue({ isAdmin: true, user: { username: 'admin', role: 'admin' } });
   });
 
   afterEach(() => {
@@ -35,41 +50,103 @@ describe('Groups page', () => {
     jest.restoreAllMocks();
   });
 
-  const setupPage = async (groups = [makeGroup()]) => {
-    api.get.mockResolvedValueOnce({ data: { groups } });
+  const asManagingAM = () =>
+    useAuth.mockReturnValue({
+      isAdmin: false,
+      user: {
+        username: 'am1',
+        role: 'assignment_manager',
+        managedAssignments: [{ id: ASSIGNMENT_ID, name: 'Assignment 1' }],
+      },
+    });
+
+  const asNonManagingAM = () =>
+    useAuth.mockReturnValue({
+      isAdmin: false,
+      user: {
+        username: 'am2',
+        role: 'assignment_manager',
+        managedAssignments: [{ id: OTHER_ASSIGNMENT_ID, name: 'Other Assignment' }],
+      },
+    });
+
+  const asRegularUser = () => useAuth.mockReturnValue({ isAdmin: false, user: { username: 'stu', role: 'user' } });
+
+  /**
+   * Route api.get calls by URL instead of queueing mockResolvedValueOnce —
+   * avoids queue-pollution between the parallel fetches this page performs.
+   * Calling setupApi again mid-test swaps the dataset (e.g. after a refetch).
+   */
+  const setupApi = ({
+    groups = [makeGroup()],
+    assignment = makeAssignment(),
+    members = [],
+    subjectUsers = [],
+    mappings = [],
+  } = {}) => {
+    api.get.mockImplementation((url) => {
+      if (url.endsWith(`/assignments/${ASSIGNMENT_ID}/groups`)) {
+        return Promise.resolve({ data: { groups } });
+      }
+      if (url.endsWith(`/assignments/${ASSIGNMENT_ID}/export-mappings`)) {
+        return Promise.resolve({ data: { mappings } });
+      }
+      if (url.endsWith(`/assignments/${ASSIGNMENT_ID}`)) {
+        return Promise.resolve({ data: { assignment } });
+      }
+      if (url.endsWith(`/subjects/${SUBJECT_ID}/users`)) {
+        return Promise.resolve({ data: { users: subjectUsers } });
+      }
+      if (/\/groups\/[^/]+$/.test(url)) {
+        return Promise.resolve({ data: { group: {}, members } });
+      }
+      return Promise.reject(new Error(`Unmocked GET ${url}`));
+    });
+  };
+
+  const renderPage = () =>
     render(
-      <MemoryRouter>
-        <Groups />
+      <MemoryRouter initialEntries={[`/subjects/${SUBJECT_ID}/assignments/${ASSIGNMENT_ID}`]}>
+        <Routes>
+          <Route path="/subjects/:subjectId/assignments/:assignmentId" element={<Groups />} />
+        </Routes>
       </MemoryRouter>
     );
-    await waitFor(() => expect(screen.getByText(/manage groups/i)).toBeInTheDocument());
+
+  const setupPage = async (options = {}) => {
+    setupApi(options);
+    renderPage();
+    await waitFor(() => expect(screen.getByRole('link', { name: 'Subjects' })).toBeInTheDocument());
   };
 
   // ── Loading / fetch ────────────────────────────────────────────────────
   it('shows loading spinner before data resolves', () => {
     api.get.mockImplementation(() => new Promise(() => {}));
-    const { container } = render(
-      <MemoryRouter>
-        <Groups />
-      </MemoryRouter>
-    );
+    const { container } = renderPage();
     expect(container.querySelector('.animate-spin')).toBeInTheDocument();
-    expect(screen.queryByText(/manage groups/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Subjects' })).not.toBeInTheDocument();
   });
 
   it('shows empty-state text when there are no groups', async () => {
-    await setupPage([]);
+    await setupPage({ groups: [] });
     expect(screen.getByText('No groups created yet')).toBeInTheDocument();
   });
 
-  it('shows fetch error state', async () => {
+  it('shows fetch error banner when initial load fails', async () => {
     api.get.mockRejectedValue(new Error('boom'));
-    render(
-      <MemoryRouter>
-        <Groups />
-      </MemoryRouter>
-    );
+    renderPage();
     await waitFor(() => expect(screen.getByText('Failed to load groups')).toBeInTheDocument());
+  });
+
+  it('fetches assignment info and groups from the assignment-scoped endpoints', async () => {
+    await setupPage();
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/assignments/${ASSIGNMENT_ID}$`)));
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/assignments/${ASSIGNMENT_ID}/groups$`)));
+    // Old flat GET /groups endpoint must no longer be used
+    const flatGroupCalls = api.get.mock.calls.filter(
+      ([url]) => url.endsWith('/groups') && !url.includes('/assignments/')
+    );
+    expect(flatGroupCalls).toHaveLength(0);
   });
 
   it('renders group name and member count after successful fetch', async () => {
@@ -79,43 +156,64 @@ describe('Groups page', () => {
   });
 
   it('shows ∞ when max_members is null', async () => {
-    await setupPage([makeGroup({ max_members: null })]);
+    await setupPage({ groups: [makeGroup({ max_members: null })] });
     expect(screen.getByText('3 / ∞')).toBeInTheDocument();
+  });
+
+  // ── Breadcrumb ─────────────────────────────────────────────────────────
+  describe('Breadcrumb', () => {
+    it('renders Subjects › subject › assignment breadcrumb with correct links', async () => {
+      await setupPage();
+      const subjectsLink = screen.getByRole('link', { name: 'Subjects' });
+      expect(subjectsLink).toHaveAttribute('href', '/subjects');
+      const subjectLink = screen.getByRole('link', { name: 'COMP1000' });
+      expect(subjectLink).toHaveAttribute('href', `/subjects/${SUBJECT_ID}`);
+      const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+      expect(within(breadcrumb).getByText('Assignment 1')).toBeInTheDocument();
+    });
+
+    it('passes the assignment name to the page header', async () => {
+      await setupPage();
+      // Breadcrumb leaf + Header pageName
+      expect(screen.getAllByText('Assignment 1').length).toBeGreaterThanOrEqual(2);
+    });
   });
 
   // ── Three sections ─────────────────────────────────────────────────────
   it('places open group in "Groups with space" section', async () => {
-    await setupPage([makeGroup({ member_count: 2, max_members: 5 })]);
+    await setupPage({ groups: [makeGroup({ member_count: 2, max_members: 5 })] });
     expect(screen.getByText(/groups with space/i)).toBeInTheDocument();
   });
 
   it('places unlimited group in "Groups with space" section', async () => {
-    await setupPage([makeGroup({ member_count: 10, max_members: null })]);
+    await setupPage({ groups: [makeGroup({ member_count: 10, max_members: null })] });
     expect(screen.getByText(/groups with space/i)).toBeInTheDocument();
   });
 
   it('places full group in "Groups full" section', async () => {
-    await setupPage([makeGroup({ member_count: 5, max_members: 5 })]);
+    await setupPage({ groups: [makeGroup({ member_count: 5, max_members: 5 })] });
     expect(screen.getByText(/groups full/i)).toBeInTheDocument();
   });
 
   it('places disabled group in "Disabled groups" section', async () => {
-    await setupPage([makeGroup({ enabled: false })]);
+    await setupPage({ groups: [makeGroup({ enabled: false })] });
     expect(screen.getByText(/disabled groups/i)).toBeInTheDocument();
   });
 
   it('shows correct counts in section headings', async () => {
-    await setupPage([
-      makeGroup({ id: 'g1', name: 'Open', member_count: 1, max_members: 5 }),
-      makeGroup({ id: 'g2', name: 'Full', member_count: 3, max_members: 3 }),
-      makeGroup({ id: 'g3', name: 'Disabled', enabled: false }),
-    ]);
+    await setupPage({
+      groups: [
+        makeGroup({ id: 'g1', name: 'Open', member_count: 1, max_members: 5 }),
+        makeGroup({ id: 'g2', name: 'Full', member_count: 3, max_members: 3 }),
+        makeGroup({ id: 'g3', name: 'Disabled', enabled: false }),
+      ],
+    });
     expect(screen.getByText(/groups with space/i).closest('h3')).toHaveTextContent('(1)');
     expect(screen.getByText(/groups full/i).closest('h3')).toHaveTextContent('(1)');
     expect(screen.getByText(/disabled groups/i).closest('h3')).toHaveTextContent('(1)');
   });
 
-  // ── Action icon buttons ────────────────────────────────────────────────
+  // ── Enable / disable ───────────────────────────────────────────────────
   it('shows disable, set-limit, and delete icon buttons', async () => {
     await setupPage();
     expect(screen.getByRole('button', { name: 'Disable Group' })).toBeInTheDocument();
@@ -124,7 +222,7 @@ describe('Groups page', () => {
   });
 
   it('shows enable button for a disabled group', async () => {
-    await setupPage([makeGroup({ enabled: false })]);
+    await setupPage({ groups: [makeGroup({ enabled: false })] });
     expect(screen.getByRole('button', { name: 'Enable Group' })).toBeInTheDocument();
   });
 
@@ -133,12 +231,11 @@ describe('Groups page', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
     api.put.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ enabled: false })] } });
 
     await user.click(screen.getByRole('button', { name: 'Disable Group' }));
 
     await waitFor(() => {
-      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/groups/${GROUP_ID}$`)), {
         enabled: false,
       });
       expect(screen.getByText('Group disabled successfully')).toBeInTheDocument();
@@ -150,9 +247,8 @@ describe('Groups page', () => {
 
   it('enables a disabled group', async () => {
     const user = userEvent.setup();
-    await setupPage([makeGroup({ enabled: false })]);
+    await setupPage({ groups: [makeGroup({ enabled: false })] });
     api.put.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: 'Enable Group' }));
 
@@ -175,7 +271,7 @@ describe('Groups page', () => {
     await waitFor(() => expect(screen.queryByText('Cannot update group')).not.toBeInTheDocument());
   });
 
-  // ── Delete ─────────────────────────────────────────────────────────────
+  // ── Delete (single-step modal) ─────────────────────────────────────────
   it('opens delete confirmation modal when delete icon is clicked', async () => {
     const user = userEvent.setup();
     await setupPage();
@@ -186,9 +282,9 @@ describe('Groups page', () => {
     expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
   });
 
-  it('shows member warning in single-group delete modal when group has members', async () => {
+  it('shows member warning in delete modal when group has members', async () => {
     const user = userEvent.setup();
-    await setupPage([makeGroup({ member_count: 3 })]);
+    await setupPage({ groups: [makeGroup({ member_count: 3 })] });
 
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
 
@@ -196,9 +292,9 @@ describe('Groups page', () => {
     expect(screen.getByText(/3 members/i)).toBeInTheDocument();
   });
 
-  it('does not show warning in single-group delete modal when group has no members', async () => {
+  it('does not show warning in delete modal when group has no members', async () => {
     const user = userEvent.setup();
-    await setupPage([makeGroup({ member_count: 0 })]);
+    await setupPage({ groups: [makeGroup({ member_count: 0 })] });
 
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
 
@@ -210,13 +306,12 @@ describe('Groups page', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
     api.delete.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
     await user.click(screen.getByRole('button', { name: 'Delete Group' }));
     await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
 
     await waitFor(() => {
-      expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/));
+      expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/groups/${GROUP_ID}$`)));
       expect(screen.getByText('Group deleted successfully')).toBeInTheDocument();
     });
 
@@ -224,7 +319,7 @@ describe('Groups page', () => {
     await waitFor(() => expect(screen.queryByText('Group deleted successfully')).not.toBeInTheDocument());
   });
 
-  it('cancels single-group delete modal without deleting', async () => {
+  it('cancels delete modal without deleting', async () => {
     const user = userEvent.setup();
     await setupPage();
 
@@ -262,7 +357,6 @@ describe('Groups page', () => {
     const user = userEvent.setup();
     await setupPage();
     api.put.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: 10 })] } });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
     const input = screen.getByPlaceholderText('Unlimited');
@@ -271,7 +365,7 @@ describe('Groups page', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
 
     await waitFor(() => {
-      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/), {
+      expect(api.put).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/groups/${GROUP_ID}$`)), {
         maxMembers: 10,
       });
       expect(screen.getByText('Group limit updated')).toBeInTheDocument();
@@ -282,7 +376,6 @@ describe('Groups page', () => {
     const user = userEvent.setup();
     await setupPage();
     api.put.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ max_members: null })] } });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
     await user.clear(screen.getByPlaceholderText('Unlimited'));
@@ -293,7 +386,7 @@ describe('Groups page', () => {
     });
   });
 
-  it('rejects invalid limit input', async () => {
+  it('rejects invalid limit input client-side', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
@@ -319,38 +412,47 @@ describe('Groups page', () => {
     expect(screen.queryByRole('heading', { name: 'Set Member Limit' })).not.toBeInTheDocument();
   });
 
-  it('shows error when set limit API fails', async () => {
+  it('shows API error when the limit is below the current member count', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     await setupPage();
-    api.put.mockRejectedValue({ response: { data: { error: 'Limit too low' } } });
+    api.put.mockRejectedValue({
+      response: { data: { error: 'Max members cannot be less than current member count' } },
+    });
 
     await user.click(screen.getByRole('button', { name: 'Set Member Limit' }));
+    const input = screen.getByPlaceholderText('Unlimited');
+    await user.clear(input);
+    await user.type(input, '1');
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    await waitFor(() => expect(screen.getByText('Limit too low')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText('Max members cannot be less than current member count')).toBeInTheDocument()
+    );
   });
 
   // ── Create group modal ─────────────────────────────────────────────────
   it('opens create-group modal', async () => {
-    await setupPage([]);
+    await setupPage({ groups: [] });
     await userEvent.click(screen.getByRole('button', { name: /create group/i }));
     expect(screen.getByText('Create New Group')).toBeInTheDocument();
   });
 
-  it('creates a group and shows success feedback', async () => {
+  it('creates a group sending assignmentId and shows success feedback', async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await setupPage([]);
+    await setupPage({ groups: [] });
     api.post.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), ' New Team ');
     await user.click(screen.getByRole('button', { name: /^create$/i }));
 
     await waitFor(() => {
-      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), { name: 'New Team' });
+      expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), {
+        assignmentId: ASSIGNMENT_ID,
+        name: 'New Team',
+      });
       expect(screen.getByText('Group created successfully')).toBeInTheDocument();
     });
 
@@ -360,9 +462,8 @@ describe('Groups page', () => {
 
   it('creates a group with maxMembers', async () => {
     const user = userEvent.setup();
-    await setupPage([]);
+    await setupPage({ groups: [] });
     api.post.mockResolvedValueOnce({});
-    api.get.mockResolvedValueOnce({ data: { groups: [makeGroup()] } });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), 'Limited Team');
@@ -371,6 +472,7 @@ describe('Groups page', () => {
 
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups$/), {
+        assignmentId: ASSIGNMENT_ID,
         name: 'Limited Team',
         maxMembers: 10,
       });
@@ -379,7 +481,7 @@ describe('Groups page', () => {
 
   it('does not create a group when name is blank', async () => {
     const user = userEvent.setup();
-    await setupPage([]);
+    await setupPage({ groups: [] });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), '   ');
@@ -388,9 +490,25 @@ describe('Groups page', () => {
     expect(api.post).not.toHaveBeenCalled();
   });
 
-  it('shows error inside modal when create group fails', async () => {
+  it('shows duplicate-name error inside modal when create returns 409', async () => {
     const user = userEvent.setup();
-    await setupPage([]);
+    await setupPage({ groups: [] });
+    api.post.mockRejectedValue({
+      response: { status: 409, data: { error: 'A group with this name already exists in this assignment' } },
+    });
+
+    await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
+    await user.type(screen.getByPlaceholderText(/enter group name/i), 'Team X');
+    await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('A group with this name already exists in this assignment')).toBeInTheDocument()
+    );
+  });
+
+  it('shows generic error inside modal when create group fails without response body', async () => {
+    const user = userEvent.setup();
+    await setupPage({ groups: [] });
     api.post.mockRejectedValue(new Error('network'));
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
@@ -406,7 +524,7 @@ describe('Groups page', () => {
 
   it('cancels create modal and resets fields', async () => {
     const user = userEvent.setup();
-    await setupPage([]);
+    await setupPage({ groups: [] });
 
     await user.click(screen.getByRole('button', { name: /^\+ create group$/i }));
     await user.type(screen.getByPlaceholderText(/enter group name/i), 'Test');
@@ -434,10 +552,10 @@ describe('Groups page', () => {
         first_name: 'Bob',
         last_name: 'Jones',
         student_id: null,
-        role_name: 'assignment_manager',
+        role_name: 'user',
       },
     ];
-    const allUsersData = [
+    const subjectUsersData = [
       ...membersData,
       {
         id: 'u0000000-0000-0000-0000-000000000012',
@@ -447,6 +565,7 @@ describe('Groups page', () => {
         last_name: 'Brown',
         student_id: 'S003',
         role_name: 'user',
+        status: 'enabled',
       },
     ];
 
@@ -454,12 +573,9 @@ describe('Groups page', () => {
       await user.click(screen.getByText('Group A'));
     };
 
-    it('expands group row to show members', async () => {
+    it('expands group row to show members fetched from GET /groups/:id', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
 
@@ -468,14 +584,22 @@ describe('Groups page', () => {
         expect(screen.getByText('bob')).toBeInTheDocument();
         expect(screen.getByText('alice@test.com')).toBeInTheDocument();
       });
+      expect(api.get).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/groups/${GROUP_ID}$`)));
+    });
+
+    it('fetches the add-member candidates from the parent subject', async () => {
+      const user = userEvent.setup();
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
+
+      await expandGroup(user);
+      await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+      expect(api.get).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/subjects/${SUBJECT_ID}/users$`)));
     });
 
     it('shows full name and student ID for each member', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
 
@@ -490,8 +614,7 @@ describe('Groups page', () => {
 
     it('shows "No members in this group" when group is empty', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get.mockResolvedValueOnce({ data: { members: [] } }).mockResolvedValueOnce({ data: { users: [] } });
+      await setupPage({ members: [], subjectUsers: [] });
 
       await expandGroup(user);
 
@@ -500,10 +623,7 @@ describe('Groups page', () => {
 
     it('collapses row on second click', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
@@ -512,28 +632,21 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.queryByText('alice')).not.toBeInTheDocument());
     });
 
-    it('removes a member from the group', async () => {
+    it('removes a member with PUT /users/:id/group { assignmentId, groupId: null }', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
 
       api.put.mockResolvedValueOnce({});
-      api.get
-        .mockResolvedValueOnce({ data: { members: [membersData[1]] } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
-
       await user.click(screen.getByRole('button', { name: /remove alice/i }));
 
       await waitFor(() => {
         expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000010\/group$/),
-          { groupId: null }
+          { assignmentId: ASSIGNMENT_ID, groupId: null }
         );
         expect(screen.getByText('Member removed successfully')).toBeInTheDocument();
       });
@@ -542,31 +655,24 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.queryByText('Member removed successfully')).not.toBeInTheDocument());
     });
 
-    it('adds a member to the group', async () => {
+    it('adds a member with PUT /users/:id/group { assignmentId, groupId }', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
 
-      // charlie is the only user not in the group
+      // charlie is the only subject member not already in the group
       await user.selectOptions(screen.getByRole('combobox'), 'u0000000-0000-0000-0000-000000000012');
 
       api.put.mockResolvedValueOnce({});
-      api.get
-        .mockResolvedValueOnce({ data: { members: [...membersData, allUsersData[2]] } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
-
       await user.click(screen.getByRole('button', { name: /^add$/i }));
 
       await waitFor(() => {
         expect(api.put).toHaveBeenCalledWith(
           expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000012\/group$/),
-          { groupId: 'g0000000-0000-0000-0000-000000000001' }
+          { assignmentId: ASSIGNMENT_ID, groupId: GROUP_ID }
         );
         expect(screen.getByText('Member added successfully')).toBeInTheDocument();
       });
@@ -577,10 +683,7 @@ describe('Groups page', () => {
 
     it('does not submit add when no user selected', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument());
@@ -589,25 +692,57 @@ describe('Groups page', () => {
       expect(api.put).not.toHaveBeenCalled();
     });
 
-    it('hides add/remove controls for non-assignment-managers', async () => {
-      useAuth.mockReturnValue({ isAssignmentManager: false });
+    it('excludes users already in the expanded group from the dropdown', async () => {
       const user = userEvent.setup();
-      await setupPage();
-      api.get.mockResolvedValueOnce({ data: { members: membersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
-      await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
 
-      expect(screen.queryByRole('button', { name: /remove alice/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      const optionTexts = screen.getAllByRole('option').map((o) => o.textContent);
+      expect(optionTexts.some((t) => t.includes('charlie'))).toBe(true);
+      expect(optionTexts.every((t) => !t.includes('alice'))).toBe(true);
+      expect(optionTexts.every((t) => !t.includes('bob'))).toBe(true);
+    });
+
+    it('excludes admins and managers from the Add Member dropdown', async () => {
+      const user = userEvent.setup();
+      const adminUser = {
+        id: 'u0000000-0000-0000-0000-000000000020',
+        username: 'adminuser',
+        email: 'admin@test.com',
+        role_name: 'admin',
+      };
+      const managerUser = {
+        id: 'u0000000-0000-0000-0000-000000000021',
+        username: 'manageruser',
+        email: 'mgr@test.com',
+        role_name: 'assignment_manager',
+      };
+      const regularUser = {
+        id: 'u0000000-0000-0000-0000-000000000022',
+        username: 'regularuser',
+        email: 'reg@test.com',
+        role_name: 'user',
+      };
+      await setupPage({ members: [], subjectUsers: [adminUser, managerUser, regularUser] });
+
+      await expandGroup(user);
+      await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+
+      const optionTexts = screen.getAllByRole('option').map((o) => o.textContent);
+      expect(optionTexts.some((t) => t.includes('regularuser'))).toBe(true);
+      expect(optionTexts.every((t) => !t.includes('adminuser'))).toBe(true);
+      expect(optionTexts.every((t) => !t.includes('manageruser'))).toBe(true);
     });
 
     it('hides add member dropdown when group is full', async () => {
       const user = userEvent.setup();
-      await setupPage([makeGroup({ member_count: 2, max_members: 2 })]);
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({
+        groups: [makeGroup({ member_count: 2, max_members: 2 })],
+        members: membersData,
+        subjectUsers: subjectUsersData,
+      });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
@@ -633,10 +768,7 @@ describe('Groups page', () => {
     it('shows error when remove member fails', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
@@ -647,59 +779,116 @@ describe('Groups page', () => {
       await waitFor(() => expect(screen.getByText('Remove failed')).toBeInTheDocument());
     });
 
-    it('shows error when add member fails', async () => {
+    it('surfaces the 403 subject-membership error from the backend', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage();
-      api.get
-        .mockResolvedValueOnce({ data: { members: membersData } })
-        .mockResolvedValueOnce({ data: { users: allUsersData } });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
 
       await user.selectOptions(screen.getByRole('combobox'), 'u0000000-0000-0000-0000-000000000012');
-      api.put.mockRejectedValue({ response: { data: { error: 'Add failed' } } });
+      api.put.mockRejectedValue({
+        response: { status: 403, data: { error: 'User is not a member of this subject' } },
+      });
       await user.click(screen.getByRole('button', { name: /^add$/i }));
 
-      await waitFor(() => expect(screen.getByText('Add failed')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('User is not a member of this subject')).toBeInTheDocument());
     });
 
-    it('excludes admins and managers from the Add Member dropdown', async () => {
-      const user = userEvent.setup();
-      await setupPage();
-      const adminUser = {
-        id: 'u0000000-0000-0000-0000-000000000020',
-        username: 'adminuser',
-        email: 'admin@test.com',
-        role_name: 'admin',
-      };
-      const managerUser = {
-        id: 'u0000000-0000-0000-0000-000000000021',
-        username: 'manageruser',
-        email: 'mgr@test.com',
-        role_name: 'assignment_manager',
-      };
-      const regularUser = {
-        id: 'u0000000-0000-0000-0000-000000000022',
-        username: 'regularuser',
-        email: 'reg@test.com',
-        role_name: 'user',
-      };
-      // Group has no current members; all three users are "available" by membership,
-      // but only regularUser has role_name === 'user'
-      api.get
-        .mockResolvedValueOnce({ data: { members: [] } })
-        .mockResolvedValueOnce({ data: { users: [adminUser, managerUser, regularUser] } });
+    it('surfaces the 409 already-in-a-group error from the backend', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ members: membersData, subjectUsers: subjectUsersData });
 
       await expandGroup(user);
       await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
 
-      const options = screen.getAllByRole('option');
-      const optionTexts = options.map((o) => o.textContent);
-      expect(optionTexts.some((t) => t.includes('regularuser'))).toBe(true);
-      expect(optionTexts.every((t) => !t.includes('adminuser'))).toBe(true);
-      expect(optionTexts.every((t) => !t.includes('manageruser'))).toBe(true);
+      await user.selectOptions(screen.getByRole('combobox'), 'u0000000-0000-0000-0000-000000000012');
+      api.put.mockRejectedValue({
+        response: { status: 409, data: { error: 'User is already in a group for this assignment' } },
+      });
+      await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+      await waitFor(() =>
+        expect(screen.getByText('User is already in a group for this assignment')).toBeInTheDocument()
+      );
+    });
+  });
+
+  // ── Permission gating ──────────────────────────────────────────────────
+  describe('Permission gating (canManage)', () => {
+    it('shows management controls for an AM who manages this assignment', async () => {
+      asManagingAM();
+      await setupPage();
+
+      expect(screen.getByRole('button', { name: /^\+ create group$/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /bulk create/i })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /import mappings/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Disable Group' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Set Member Limit' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete Group' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /select group a/i })).toBeInTheDocument();
+    });
+
+    it('hides all management controls for an AM who does not manage this assignment', async () => {
+      asNonManagingAM();
+      await setupPage();
+
+      // Read-only listing still renders
+      expect(screen.getByText('Group A')).toBeInTheDocument();
+      expect(screen.getByText('3 / 5')).toBeInTheDocument();
+
+      expect(screen.queryByRole('button', { name: /^\+ create group$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /bulk create/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /import mappings/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Edit Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Disable Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Set Member Limit' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('hides all management controls for a regular user', async () => {
+      asRegularUser();
+      await setupPage();
+
+      expect(screen.getByText('Group A')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /^\+ create group$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Group' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('hides add/remove member controls and skips the subject users fetch when not managing', async () => {
+      asNonManagingAM();
+      const user = userEvent.setup();
+      await setupPage({
+        members: [
+          {
+            id: 'u0000000-0000-0000-0000-000000000010',
+            username: 'alice',
+            email: 'alice@test.com',
+            first_name: 'Alice',
+            last_name: 'Smith',
+            role_name: 'user',
+          },
+        ],
+      });
+
+      await user.click(screen.getByText('Group A'));
+      await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+      expect(screen.queryByRole('button', { name: /remove alice/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(api.get).not.toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/subjects/${SUBJECT_ID}/users$`)));
+    });
+
+    it('hides the empty-state create button when not managing', async () => {
+      asNonManagingAM();
+      await setupPage({ groups: [] });
+
+      expect(screen.getByText('No groups created yet')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /create your first group/i })).not.toBeInTheDocument();
     });
   });
 
@@ -728,10 +917,12 @@ describe('Groups page', () => {
 
     it('section select-all selects all groups in that section', async () => {
       const user = userEvent.setup();
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
-      ]);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
+        ],
+      });
 
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
 
@@ -740,10 +931,12 @@ describe('Groups page', () => {
 
     it('section select-all deselects all when all already selected', async () => {
       const user = userEvent.setup();
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
-      ]);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
+        ],
+      });
 
       const sectionCb = screen.getByRole('checkbox', { name: /select all groups with space/i });
       await user.click(sectionCb);
@@ -765,61 +958,20 @@ describe('Groups page', () => {
 
   // ── Bulk delete ────────────────────────────────────────────────────────
   describe('Bulk delete', () => {
-    it('opens bulk delete confirmation modal', async () => {
-      const user = userEvent.setup();
-      await setupPage();
-
-      await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-
-      expect(screen.getByText(/delete 1 group\?/i)).toBeInTheDocument();
-    });
-
-    it('cancels bulk delete modal', async () => {
-      const user = userEvent.setup();
-      await setupPage();
-
-      await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-      await user.click(screen.getByRole('button', { name: /cancel/i }));
-
-      expect(screen.queryByText(/delete 1 group\?/i)).not.toBeInTheDocument();
-    });
-
-    it('shows warning when selected groups have members', async () => {
-      const user = userEvent.setup();
-      await setupPage([makeGroup({ member_count: 3 })]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-
-      expect(screen.getByText(/will be unassigned/i)).toBeInTheDocument();
-    });
-
-    it('does not show warning when selected groups have no members', async () => {
-      const user = userEvent.setup();
-      await setupPage([makeGroup({ member_count: 0 })]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-
-      expect(screen.queryByText(/will be unassigned/i)).not.toBeInTheDocument();
-    });
-
-    it('deletes all selected groups and shows success', async () => {
+    it('deletes all selected groups via DELETE /groups/bulk and shows success', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
-      ]);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
+        ],
+      });
 
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
       api.delete.mockResolvedValue({});
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
       await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
       await waitFor(() => {
@@ -831,76 +983,81 @@ describe('Groups page', () => {
       });
     });
 
+    it('single delete still uses DELETE /groups/:id (not bulk)', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage();
+      api.delete.mockResolvedValueOnce({});
+
+      await user.click(screen.getByRole('button', { name: 'Delete Group' }));
+      await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
+
+      await waitFor(() => {
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/groups/${GROUP_ID}$`)));
+        expect(api.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk/), expect.anything());
+      });
+    });
+
     it('shows error when bulk delete fails', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([makeGroup({ member_count: 0 })]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(1\)/i }));
-      api.delete.mockRejectedValue({ response: { data: { error: 'Delete failed' } } });
-
-      await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
-
-      await waitFor(() => expect(screen.getByText('Delete failed')).toBeInTheDocument());
-    });
-
-    it('delete modal has scrollable layout so action buttons remain accessible with many items', async () => {
-      const user = userEvent.setup();
-      const manyGroups = Array.from({ length: 50 }, (_, i) =>
-        makeGroup({ id: `g${i}`, name: `Group ${i}`, member_count: 3 })
-      );
-      await setupPage(manyGroups);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
+        ],
+      });
 
       await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(50\)/i }));
+      await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
-      const dialog = screen.getByText(/delete 50 groups\?/i).closest('.bg-white');
-      expect(dialog).toHaveClass('max-h-[90vh]');
-      expect(dialog).toHaveClass('flex-col');
+      api.delete.mockRejectedValue({ response: { data: { error: 'Bulk delete failed' } } });
+      await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
 
-      const scrollable = dialog.querySelector('.overflow-y-auto');
-      expect(scrollable).toBeInTheDocument();
-
-      expect(screen.getByRole('button', { name: /delete 50 groups/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText('Bulk delete failed')).toBeInTheDocument());
     });
   });
 
   // ── Bulk create ────────────────────────────────────────────────────────
   describe('Bulk create', () => {
-    it('opens bulk create modal', async () => {
+    it('opens and cancels bulk create modal', async () => {
       const user = userEvent.setup();
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
-
       expect(screen.getByText('Bulk Create Groups')).toBeInTheDocument();
-    });
 
-    it('cancels bulk create modal', async () => {
-      const user = userEvent.setup();
-      await setupPage([]);
-
-      await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.click(screen.getByRole('button', { name: /cancel/i }));
-
       expect(screen.queryByText('Bulk Create Groups')).not.toBeInTheDocument();
     });
 
     it('disables submit button when prefix is empty', async () => {
       const user = userEvent.setup();
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
 
-      // no prefix typed, preview is empty → submit disabled
       expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('disables submit button when count is invalid (0)', async () => {
+      const user = userEvent.setup();
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '0');
+
+      expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
+      expect(api.post).not.toHaveBeenCalled();
     });
 
     it('shows inline preview when prefix and count are set (<=5 groups)', async () => {
       const user = userEvent.setup();
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
@@ -913,7 +1070,7 @@ describe('Groups page', () => {
 
     it('shows truncated preview for more than 5 groups', async () => {
       const user = userEvent.setup();
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
@@ -925,12 +1082,10 @@ describe('Groups page', () => {
       expect(screen.getByText(/\(6 groups\)/i)).toBeInTheDocument();
     });
 
-    // ── Bulk create via POST /groups/bulk ──────────────────────────────────
-
-    it('happy path — small batch (≤500): sends single POST /groups/bulk call', async () => {
+    it('sends { assignmentId, groups } in a single POST /groups/bulk call', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
@@ -938,26 +1093,23 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '3');
 
-      api.post.mockResolvedValueOnce({ data: { created: 3 } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
+      api.post.mockResolvedValueOnce({ data: { groups: [] } });
       await user.click(screen.getByRole('button', { name: /create 3 groups/i }));
 
       await waitFor(() => {
         expect(api.post).toHaveBeenCalledTimes(1);
-        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
-          { name: 'Team1' },
-          { name: 'Team2' },
-          { name: 'Team3' },
-        ]);
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
+          assignmentId: ASSIGNMENT_ID,
+          groups: [{ name: 'Team1' }, { name: 'Team2' }, { name: 'Team3' }],
+        });
         expect(screen.getByText('Created 3 groups')).toBeInTheDocument();
       });
     });
 
-    it('happy path — large batch (>500): sends three sequential POST /groups/bulk calls', async () => {
+    it('splits large batches (>500) into sequential { assignmentId, groups } calls', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Group');
@@ -965,69 +1117,29 @@ describe('Groups page', () => {
       await user.clear(countInput);
       await user.type(countInput, '1500');
 
-      // First batch: 500 items; second batch: 500 items; third batch: 500 items
-      api.post
-        .mockResolvedValueOnce({ data: { created: 500 } })
-        .mockResolvedValueOnce({ data: { created: 500 } })
-        .mockResolvedValueOnce({ data: { created: 500 } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
+      api.post.mockResolvedValue({ data: { groups: [] } });
       await user.click(screen.getByRole('button', { name: /create 1500 groups/i }));
 
       await waitFor(() => {
         expect(api.post).toHaveBeenCalledTimes(3);
-        // First call — 500 items (pad=2 for n=1500)
-        const firstCall = api.post.mock.calls[0];
+        const [firstCall, secondCall, thirdCall] = api.post.mock.calls;
         expect(firstCall[0]).toMatch(/\/groups\/bulk$/);
-        expect(firstCall[1]).toHaveLength(500);
-        expect(firstCall[1][0]).toEqual({ name: 'Group01' });
-        expect(firstCall[1][499]).toEqual({ name: 'Group500' });
-        // Second call — 500 items
-        const secondCall = api.post.mock.calls[1];
-        expect(secondCall[0]).toMatch(/\/groups\/bulk$/);
-        expect(secondCall[1]).toHaveLength(500);
-        expect(secondCall[1][0]).toEqual({ name: 'Group501' });
-        expect(secondCall[1][499]).toEqual({ name: 'Group1000' });
-        // Third call — 500 items
-        const thirdCall = api.post.mock.calls[2];
-        expect(thirdCall[0]).toMatch(/\/groups\/bulk$/);
-        expect(thirdCall[1]).toHaveLength(500);
-        expect(thirdCall[1][0]).toEqual({ name: 'Group1001' });
-        expect(thirdCall[1][499]).toEqual({ name: 'Group1500' });
+        expect(firstCall[1].assignmentId).toBe(ASSIGNMENT_ID);
+        expect(firstCall[1].groups).toHaveLength(500);
+        expect(firstCall[1].groups[0]).toEqual({ name: 'Group01' });
+        expect(firstCall[1].groups[499]).toEqual({ name: 'Group500' });
+        expect(secondCall[1].groups).toHaveLength(500);
+        expect(secondCall[1].groups[0]).toEqual({ name: 'Group501' });
+        expect(thirdCall[1].groups).toHaveLength(500);
+        expect(thirdCall[1].groups[499]).toEqual({ name: 'Group1500' });
         expect(screen.getByText('Created 1500 groups')).toBeInTheDocument();
       });
     });
 
-    it('happy path — exactly 500: sends a single batch call', async () => {
-      const user = userEvent.setup();
-      await setupPage([]);
-
-      await user.click(screen.getByRole('button', { name: /bulk create/i }));
-      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
-      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
-      await user.clear(countInput);
-      await user.type(countInput, '500');
-
-      api.post.mockResolvedValueOnce({ data: { created: 500 } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
-      await user.click(screen.getByRole('button', { name: /create 500 groups/i }));
-
-      await waitFor(() => {
-        expect(api.post).toHaveBeenCalledTimes(1);
-        expect(api.post).toHaveBeenCalledWith(
-          expect.stringMatching(/\/groups\/bulk$/),
-          expect.arrayContaining([expect.objectContaining({ name: 'Team01' })])
-        );
-        const callArg = api.post.mock.calls[0][1];
-        expect(callArg).toHaveLength(500);
-      });
-    });
-
-    it('with maxMembers: includes maxMembers in each item when set', async () => {
+    it('includes maxMembers in each item when set', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
@@ -1036,23 +1148,65 @@ describe('Groups page', () => {
       await user.type(countInput, '2');
       await user.type(screen.getByPlaceholderText(/unlimited/i), '30');
 
-      api.post.mockResolvedValueOnce({ data: { created: 2 } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
+      api.post.mockResolvedValueOnce({ data: { groups: [] } });
       await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
 
       await waitFor(() => {
-        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), [
-          { name: 'Team1', maxMembers: 30 },
-          { name: 'Team2', maxMembers: 30 },
-        ]);
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
+          assignmentId: ASSIGNMENT_ID,
+          groups: [
+            { name: 'Team1', maxMembers: 30 },
+            { name: 'Team2', maxMembers: 30 },
+          ],
+        });
       });
+    });
+
+    it('shows in-batch duplicate error (400) from the backend', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '2');
+
+      api.post.mockRejectedValueOnce({
+        response: { status: 400, data: { error: 'Duplicate group names in request' } },
+      });
+      await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Duplicate group names in request')).toBeInTheDocument();
+        expect(screen.queryByText(/created \d+ group/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows existing-name conflict error (409) from the backend', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage({ groups: [] });
+
+      await user.click(screen.getByRole('button', { name: /bulk create/i }));
+      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
+      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
+      await user.clear(countInput);
+      await user.type(countInput, '2');
+
+      api.post.mockRejectedValueOnce({
+        response: { status: 409, data: { error: 'Groups already exist: Team1, Team2' } },
+      });
+      await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
+
+      await waitFor(() => expect(screen.getByText('Groups already exist: Team1, Team2')).toBeInTheDocument());
     });
 
     it('partial failure: first batch succeeds, second batch fails — shows both toasts', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([]);
+      await setupPage({ groups: [] });
 
       await user.click(screen.getByRole('button', { name: /bulk create/i }));
       await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
@@ -1061,9 +1215,8 @@ describe('Groups page', () => {
       await user.type(countInput, '1500');
 
       api.post
-        .mockResolvedValueOnce({ data: { created: 500 } })
+        .mockResolvedValueOnce({ data: { groups: [] } })
         .mockRejectedValueOnce({ response: { data: { error: 'DB overloaded' } } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
 
       await user.click(screen.getByRole('button', { name: /create 1500 groups/i }));
 
@@ -1075,68 +1228,18 @@ describe('Groups page', () => {
         { timeout: 5000 }
       );
     });
-
-    it('all fail: first batch fails — shows only error toast, no success toast', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([]);
-
-      await user.click(screen.getByRole('button', { name: /bulk create/i }));
-      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
-      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
-      await user.clear(countInput);
-      await user.type(countInput, '2');
-
-      api.post.mockRejectedValueOnce({ response: { data: { error: 'Create failed' } } });
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
-      await user.click(screen.getByRole('button', { name: /create 2 groups/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Create failed')).toBeInTheDocument();
-        expect(screen.queryByText(/created \d+ group/i)).not.toBeInTheDocument();
-      });
-    });
-
-    it('empty prefix: does not make any API call', async () => {
-      const user = userEvent.setup();
-      await setupPage([]);
-
-      await user.click(screen.getByRole('button', { name: /bulk create/i }));
-      // Leave prefix empty, just set a count
-      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
-      await user.clear(countInput);
-      await user.type(countInput, '5');
-
-      // Submit button is disabled when prefix is empty, so we verify no API call
-      expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
-      expect(api.post).not.toHaveBeenCalled();
-    });
-
-    it('invalid count (0): does not make any API call', async () => {
-      const user = userEvent.setup();
-      await setupPage([]);
-
-      await user.click(screen.getByRole('button', { name: /bulk create/i }));
-      await user.type(screen.getByPlaceholderText(/e\.g\. team/i), 'Team');
-      const countInput = screen.getByPlaceholderText(/e\.g\. 10/i);
-      await user.clear(countInput);
-      await user.type(countInput, '0');
-
-      // Submit button disabled when count < 1
-      expect(screen.getByRole('button', { name: /create.*groups/i })).toBeDisabled();
-      expect(api.post).not.toHaveBeenCalled();
-    });
   });
 
   // ── Bulk set limit ─────────────────────────────────────────────────────
   describe('Bulk set limit', () => {
     it('opens limit modal with multi-group text when bulk set limit is clicked', async () => {
       const user = userEvent.setup();
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
-      ]);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
+        ],
+      });
 
       await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
       await user.click(screen.getByRole('checkbox', { name: /select group b/i }));
@@ -1144,16 +1247,17 @@ describe('Groups page', () => {
 
       const heading = screen.getByRole('heading', { name: 'Set Member Limit' });
       expect(heading).toBeInTheDocument();
-      // "Applies to N selected groups." paragraph is only shown for bulk (>1) operations
       expect(heading.parentElement).toHaveTextContent(/applies to.*selected groups/i);
     });
 
     it('saves limit for all selected groups and shows success', async () => {
       const user = userEvent.setup();
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
-      ]);
+      await setupPage({
+        groups: [
+          makeGroup({ id: 'g1', name: 'Group A', member_count: 1, max_members: 5 }),
+          makeGroup({ id: 'g2', name: 'Group B', member_count: 2, max_members: 5 }),
+        ],
+      });
 
       await user.click(screen.getByRole('checkbox', { name: /select group a/i }));
       await user.click(screen.getByRole('checkbox', { name: /select group b/i }));
@@ -1164,8 +1268,6 @@ describe('Groups page', () => {
       await user.type(input, '8');
 
       api.put.mockResolvedValue({});
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
       await user.click(screen.getByRole('button', { name: /save/i }));
 
       await waitFor(() => {
@@ -1180,17 +1282,17 @@ describe('Groups page', () => {
   // ── Search ─────────────────────────────────────────────────────────────
   describe('Group search', () => {
     it('shows all groups when search is empty', async () => {
-      await setupPage([makeGroup({ name: 'Alpha' }), makeGroup({ id: 'g2', name: 'Beta' })]);
+      await setupPage({ groups: [makeGroup({ name: 'Alpha' }), makeGroup({ id: 'g2', name: 'Beta' })] });
 
       expect(screen.getByText('Alpha')).toBeInTheDocument();
       expect(screen.getByText('Beta')).toBeInTheDocument();
     });
 
-    it('filters groups by name when search term is entered', async () => {
+    it('filters groups by name when search term is entered (case-insensitive)', async () => {
       const user = userEvent.setup();
-      await setupPage([makeGroup({ name: 'Alpha Team' }), makeGroup({ id: 'g2', name: 'Beta Group' })]);
+      await setupPage({ groups: [makeGroup({ name: 'Alpha Team' }), makeGroup({ id: 'g2', name: 'Beta Group' })] });
 
-      await user.type(screen.getByPlaceholderText('Search groups...'), 'alpha');
+      await user.type(screen.getByPlaceholderText('Search groups...'), 'ALPHA');
 
       await waitFor(() => {
         expect(screen.getByText('Alpha Team')).toBeInTheDocument();
@@ -1200,7 +1302,7 @@ describe('Groups page', () => {
 
     it('shows no-results message when search matches nothing', async () => {
       const user = userEvent.setup();
-      await setupPage([makeGroup({ name: 'Alpha Team' })]);
+      await setupPage({ groups: [makeGroup({ name: 'Alpha Team' })] });
 
       await user.type(screen.getByPlaceholderText('Search groups...'), 'zzz');
 
@@ -1209,39 +1311,25 @@ describe('Groups page', () => {
         expect(screen.queryByText('Alpha Team')).not.toBeInTheDocument();
       });
     });
-
-    it('search is case-insensitive', async () => {
-      const user = userEvent.setup();
-      await setupPage([makeGroup({ name: 'Alpha Team' })]);
-
-      await user.type(screen.getByPlaceholderText('Search groups...'), 'ALPHA');
-
-      await waitFor(() => expect(screen.getByText('Alpha Team')).toBeInTheDocument());
-    });
   });
 
   // ── Export Mappings ────────────────────────────────────────────────────
   describe('Export Mappings', () => {
-    it('renders the "Export Mappings" button', async () => {
-      await setupPage();
-      expect(screen.getByRole('button', { name: /export mappings/i })).toBeInTheDocument();
-    });
-
-    it('calls export-mappings API and triggers download on click', async () => {
+    it('calls the assignment-scoped export endpoint and triggers download', async () => {
       const { downloadCsv } = require('../../../src/utils/csv.js');
       const user = userEvent.setup();
-      await setupPage();
-
       const mappings = [
         { groupName: 'Team Alpha', email: 'alice@test.com' },
         { groupName: 'Team Beta', email: 'bob@test.com' },
       ];
-      api.get.mockResolvedValueOnce({ data: { mappings } });
+      await setupPage({ mappings });
 
       await user.click(screen.getByRole('button', { name: /export mappings/i }));
 
       await waitFor(() => {
-        expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/export-mappings$/));
+        expect(api.get).toHaveBeenCalledWith(
+          expect.stringMatching(new RegExp(`/assignments/${ASSIGNMENT_ID}/export-mappings$`))
+        );
         expect(downloadCsv).toHaveBeenCalledWith(
           mappings,
           ['groupName', 'email'],
@@ -1264,113 +1352,20 @@ describe('Groups page', () => {
 
   // ── Import Mappings link ────────────────────────────────────────────────
   describe('Import Mappings', () => {
-    it('renders the "Import Mappings" link pointing to /groups/import', async () => {
+    it('renders the import link with subjectId and assignmentId query params', async () => {
       await setupPage();
       const link = screen.getByRole('link', { name: /import mappings/i });
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', '/groups/import');
+      expect(link).toHaveAttribute('href', `/groups/import?subjectId=${SUBJECT_ID}&assignmentId=${ASSIGNMENT_ID}`);
     });
   });
 
-  // ── handleDeleteConfirmed — single vs bulk routing ────────────────────
-  describe('handleDeleteConfirmed routing (single vs bulk)', () => {
-    it('single delete still uses DELETE /groups/:id', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage();
-      api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
-      await user.click(screen.getByRole('button', { name: 'Delete Group' }));
-      await user.click(screen.getByRole('button', { name: /delete 1 group$/i }));
-
-      await waitFor(() => {
-        expect(api.delete).toHaveBeenCalledWith(
-          expect.stringMatching(/\/groups\/g0000000-0000-0000-0000-000000000001$/)
-        );
-        expect(api.delete).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk/));
-      });
-    });
-
-    it('multi-delete uses DELETE /groups/bulk with correct ids array', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
-      ]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
-
-      api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
-      await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
-
-      await waitFor(() => {
-        expect(api.delete).toHaveBeenCalledTimes(1);
-        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(/\/groups\/bulk$/), {
-          data: { ids: expect.arrayContaining(['g1', 'g2']) },
-        });
-      });
-    });
-
-    it('success toast is shown after bulk delete', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
-      ]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
-
-      api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { groups: [] } });
-
-      await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
-
-      await waitFor(() => expect(screen.getByText('Deleted 2 groups')).toBeInTheDocument());
-    });
-
-    it('error toast is shown when bulk delete fails', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupPage([
-        makeGroup({ id: 'g1', name: 'Group A', member_count: 0, max_members: 5 }),
-        makeGroup({ id: 'g2', name: 'Group B', member_count: 0, max_members: 5 }),
-      ]);
-
-      await user.click(screen.getByRole('checkbox', { name: /select all groups with space/i }));
-      await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
-
-      api.delete.mockRejectedValue({ response: { data: { error: 'Bulk delete failed' } } });
-
-      await user.click(screen.getByRole('button', { name: /delete 2 groups/i }));
-
-      await waitFor(() => expect(screen.getByText('Bulk delete failed')).toBeInTheDocument());
-    });
-  });
-
-  describe('data freshness on navigation and tab visibility', () => {
+  // ── Data freshness ─────────────────────────────────────────────────────
+  describe('data freshness on tab visibility', () => {
     it('re-fetches groups when the browser tab becomes visible', async () => {
-      // Initial load — one group
-      api.get.mockResolvedValueOnce({ data: { groups: [makeGroup({ name: 'Group A' })] } });
-      render(
-        <MemoryRouter>
-          <Groups />
-        </MemoryRouter>
-      );
-      await waitFor(() => expect(screen.getByText('Group A')).toBeInTheDocument());
+      await setupPage({ groups: [makeGroup({ name: 'Group A' })] });
 
       // Simulate another tab creating a group, then this tab regaining focus
-      api.get.mockResolvedValueOnce({
-        data: {
-          groups: [makeGroup({ name: 'Group A' }), makeGroup({ id: 'g2', name: 'Group B' })],
-        },
-      });
+      setupApi({ groups: [makeGroup({ name: 'Group A' }), makeGroup({ id: 'g2', name: 'Group B' })] });
 
       Object.defineProperty(document, 'hidden', { value: false, configurable: true, writable: true });
       document.dispatchEvent(new Event('visibilitychange'));

--- a/frontend/tests/unit/pages/ImportGroupMappings.test.jsx
+++ b/frontend/tests/unit/pages/ImportGroupMappings.test.jsx
@@ -28,6 +28,49 @@ jest.mock('../../../src/utils/csv.js', () => ({
   downloadCsv: jest.fn(),
 }));
 
+// ── API route mocks ──────────────────────────────────────────────────────────
+
+const SUBJECTS = [
+  { id: 'sub-1', name: 'Subject One' },
+  { id: 'sub-2', name: 'Subject Two' },
+];
+
+const ASSIGNMENTS = [
+  { id: 'asg-1', name: 'Assignment One' },
+  { id: 'asg-2', name: 'Assignment Two' },
+];
+
+/**
+ * Install a url-router implementation on api.get. Groups are served per
+ * assignment id via `groupsByAssignment`; the plain `groups` option applies
+ * to every assignment.
+ */
+function mockApiRoutes({
+  users = [],
+  groups = [],
+  groupsByAssignment = null,
+  subjects = SUBJECTS,
+  assignments = ASSIGNMENTS,
+} = {}) {
+  api.get.mockImplementation((url) => {
+    if (url.endsWith('/subjects')) {
+      return Promise.resolve({ data: { subjects } });
+    }
+    if (url.includes('/subjects/')) {
+      return Promise.resolve({ data: { subject: subjects[0], assignments } });
+    }
+    const groupsMatch = url.match(/\/assignments\/([^/]+)\/groups$/);
+    if (groupsMatch) {
+      const list = groupsByAssignment ? groupsByAssignment[groupsMatch[1]] || [] : groups;
+      return Promise.resolve({ data: { groups: list } });
+    }
+    if (url.endsWith('/users')) {
+      return Promise.resolve({ data: { users } });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  });
+}
+
 // ── FileReader mock ──────────────────────────────────────────────────────────
 function setupFileReaderMock() {
   const OriginalFileReader = global.FileReader;
@@ -69,12 +112,15 @@ function uploadCsv(content, name = 'mappings.csv') {
   });
 }
 
-function renderPage() {
-  return render(
-    <MemoryRouter initialEntries={['/groups/import']}>
+async function renderPage(query = '?subjectId=sub-1&assignmentId=asg-1') {
+  const utils = render(
+    <MemoryRouter initialEntries={[`/groups/import${query}`]}>
       <ImportGroupMappings />
     </MemoryRouter>
   );
+  // Flush the GET /subjects (and cascade) fetches fired on mount
+  await act(async () => {});
+  return utils;
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -84,6 +130,7 @@ describe('ImportGroupMappings page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockApiRoutes();
     restoreFileReader = setupFileReaderMock();
   });
 
@@ -91,22 +138,60 @@ describe('ImportGroupMappings page', () => {
     restoreFileReader();
   });
 
+  // ── Target assignment cascade ──────────────────────────────────────────────
+
+  describe('Target assignment cascade', () => {
+    it('preselects the subject and assignment from query params', async () => {
+      await renderPage('?subjectId=sub-1&assignmentId=asg-1');
+      expect(screen.getByLabelText('Subject')).toHaveValue('sub-1');
+      await waitFor(() => expect(screen.getByLabelText('Assignment')).toHaveValue('asg-1'));
+    });
+
+    it('gates the wizard until an assignment is chosen', async () => {
+      await renderPage('');
+      expect(screen.queryByText('Upload CSV File')).not.toBeInTheDocument();
+      expect(screen.getByText(/select a subject and assignment to continue/i)).toBeInTheDocument();
+
+      await userEvent.selectOptions(screen.getByLabelText('Subject'), 'sub-1');
+      await screen.findByRole('option', { name: 'Assignment One' });
+      // Still gated with only a subject selected
+      expect(screen.queryByText('Upload CSV File')).not.toBeInTheDocument();
+
+      await userEvent.selectOptions(screen.getByLabelText('Assignment'), 'asg-1');
+      expect(screen.getByText('Upload CSV File')).toBeInTheDocument();
+      expect(screen.queryByText(/select a subject and assignment to continue/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render a group select (showGroup is false)', async () => {
+      await renderPage('');
+      expect(screen.queryByLabelText('Group')).not.toBeInTheDocument();
+    });
+
+    it('re-gates the wizard when the subject changes and clears the assignment', async () => {
+      await renderPage('?subjectId=sub-1&assignmentId=asg-1');
+      expect(screen.getByText('Upload CSV File')).toBeInTheDocument();
+      await userEvent.selectOptions(screen.getByLabelText('Subject'), 'sub-2');
+      expect(screen.queryByText('Upload CSV File')).not.toBeInTheDocument();
+      expect(screen.getByText(/select a subject and assignment to continue/i)).toBeInTheDocument();
+    });
+  });
+
   // ── Step 1: Upload ─────────────────────────────────────────────────────────
 
   describe('Step 1: Upload', () => {
-    it('renders the upload heading', () => {
-      renderPage();
+    it('renders the upload heading', async () => {
+      await renderPage();
       expect(screen.getByText('Import Group Mappings')).toBeInTheDocument();
       expect(screen.getByText('Upload CSV File')).toBeInTheDocument();
     });
 
-    it('shows the file input', () => {
-      renderPage();
+    it('shows the file input', async () => {
+      await renderPage();
       expect(document.querySelector('input[type="file"]')).toBeInTheDocument();
     });
 
-    it('shows error for non-CSV files', () => {
-      renderPage();
+    it('shows error for non-CSV files', async () => {
+      await renderPage();
       const input = document.querySelector('input[type="file"]');
       const txtFile = new File(['data'], 'data.txt', { type: 'text/plain' });
       Object.defineProperty(input, 'files', { configurable: true, value: [txtFile] });
@@ -116,39 +201,37 @@ describe('ImportGroupMappings page', () => {
       expect(screen.getByText('Please upload a CSV file')).toBeInTheDocument();
     });
 
-    it('shows error when CSV has fewer than 2 rows', () => {
-      renderPage();
+    it('shows error when CSV has fewer than 2 rows', async () => {
+      await renderPage();
       uploadCsv('group name,email');
       expect(screen.getByText(/CSV must have a header row/i)).toBeInTheDocument();
     });
 
-    it('auto-detects columns and shows row count when columns cannot be detected', () => {
-      renderPage();
+    it('auto-detects columns and shows row count when columns cannot be detected', async () => {
+      await renderPage();
       uploadCsv('col1,col2\nval1@test.com,Group A\nval2@test.com,Group B');
       expect(screen.getByText(/Loaded 2 rows/i)).toBeInTheDocument();
     });
 
-    it('shows column mapping UI when columns cannot be auto-detected', () => {
-      renderPage();
+    it('shows column mapping UI when columns cannot be auto-detected', async () => {
+      await renderPage();
       uploadCsv('col1,col2\nval1,val2');
       expect(screen.getByText(/could not be auto-detected/i)).toBeInTheDocument();
       expect(screen.getByLabelText('Email column')).toBeInTheDocument();
       expect(screen.getByLabelText('Group name column')).toBeInTheDocument();
     });
 
-    it('Next button is disabled without a valid file', () => {
-      renderPage();
+    it('Next button is disabled without a valid file', async () => {
+      await renderPage();
       expect(screen.getByRole('button', { name: /next: preview/i })).toBeDisabled();
     });
 
     it('accepts a valid CSV via drag and drop and auto-advances to preview', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
-          groups: [{ id: 'g1', name: 'Team A' }],
-        },
+      mockApiRoutes({
+        users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
+        groups: [{ id: 'g1', name: 'Team A' }],
       });
-      renderPage();
+      await renderPage();
       const file = makeCsvFile('group name,email\nTeam A,alice@test.com');
       const dropzone = screen.getByRole('button', { name: /click to browse/i });
       act(() => {
@@ -157,8 +240,8 @@ describe('ImportGroupMappings page', () => {
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
     });
 
-    it('shows error when a non-CSV file is dropped', () => {
-      renderPage();
+    it('shows error when a non-CSV file is dropped', async () => {
+      await renderPage();
       const file = new File(['data'], 'data.txt', { type: 'text/plain' });
       const dropzone = screen.getByRole('button', { name: /click to browse/i });
       act(() => {
@@ -168,13 +251,11 @@ describe('ImportGroupMappings page', () => {
     });
 
     it('auto-advances to step 2 when a valid CSV with detectable columns is uploaded', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
-          groups: [{ id: 'g1', name: 'Team Alpha' }],
-        },
+      mockApiRoutes({
+        users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
+        groups: [{ id: 'g1', name: 'Team Alpha' }],
       });
-      renderPage();
+      await renderPage();
       uploadCsv('group name,email\nTeam Alpha,alice@test.com');
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
     });
@@ -196,8 +277,8 @@ describe('ImportGroupMappings page', () => {
     ];
 
     async function goToPreview(csv = validCsv) {
-      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
-      renderPage();
+      mockApiRoutes({ users: mockUsers, groups: mockGroups });
+      await renderPage();
       uploadCsv(csv);
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
     }
@@ -213,44 +294,100 @@ describe('ImportGroupMappings page', () => {
       await waitFor(() => expect(screen.getAllByText('Ready').length).toBeGreaterThan(0));
     });
 
+    it('validates group names against the selected assignment groups', async () => {
+      mockApiRoutes({
+        users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
+        groupsByAssignment: { 'asg-1': [{ id: 'g1', name: 'Team Alpha' }] },
+      });
+      await renderPage();
+      uploadCsv('group name,email\nTeam Beta,alice@test.com');
+      await waitFor(() => expect(screen.getByText(/Group not found/i)).toBeInTheDocument());
+      expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/assignments\/asg-1\/groups$/));
+      // Group lists are never fetched from the old global /groups endpoint
+      const groupCalls = api.get.mock.calls.filter(([url]) => /\/groups$/.test(url));
+      expect(groupCalls.length).toBeGreaterThan(0);
+      expect(groupCalls.every(([url]) => /\/assignments\/[^/]+\/groups$/.test(url))).toBe(true);
+    });
+
+    it('refetches groups and rebuilds the preview when the assignment changes', async () => {
+      mockApiRoutes({
+        users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
+        groupsByAssignment: {
+          'asg-1': [{ id: 'g1', name: 'Team Alpha' }],
+          'asg-2': [],
+        },
+      });
+      await renderPage();
+      uploadCsv('group name,email\nTeam Alpha,alice@test.com');
+      await waitFor(() => expect(screen.getAllByText('Ready').length).toBeGreaterThan(0));
+
+      await userEvent.selectOptions(screen.getByLabelText('Assignment'), 'asg-2');
+
+      await waitFor(() => expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/assignments\/asg-2\/groups$/)));
+      // "Team Alpha" does not exist in asg-2 → row becomes a skip
+      await waitFor(() => expect(screen.getByText(/Group not found/i)).toBeInTheDocument());
+    });
+
     it('highlights rows with unknown user as Skip', async () => {
       const csvWithUnknown = 'group name,email\nTeam Alpha,alice@test.com\nTeam Alpha,nobody@ghost.com';
-      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
-      renderPage();
+      mockApiRoutes({ users: mockUsers, groups: mockGroups });
+      await renderPage();
       uploadCsv(csvWithUnknown);
       await waitFor(() => expect(screen.getByText(/User not found/i)).toBeInTheDocument());
     });
 
     it('highlights rows with unknown group as Skip', async () => {
       const csvWithBadGroup = 'group name,email\nGhost Group,alice@test.com';
-      api.get.mockResolvedValue({ data: { users: mockUsers, groups: mockGroups } });
-      renderPage();
+      mockApiRoutes({ users: mockUsers, groups: mockGroups });
+      await renderPage();
       uploadCsv(csvWithBadGroup);
       await waitFor(() => expect(screen.getByText(/Group not found/i)).toBeInTheDocument());
     });
 
-    it('shows Conflict status for users already in a group', async () => {
+    it('shows Conflict status for users already in a group of the selected assignment', async () => {
       const conflictCsv = 'group name,email\nTeam Alpha,assigned@test.com';
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'u3', email: 'assigned@test.com', group_id: 'g1' }],
-          groups: mockGroups,
-        },
+      mockApiRoutes({
+        users: [
+          {
+            id: 'u3',
+            email: 'assigned@test.com',
+            memberships: [{ assignment_id: 'asg-1', group_id: 'g1', group_name: 'Team Beta' }],
+          },
+        ],
+        groups: mockGroups,
       });
-      renderPage();
+      await renderPage();
       uploadCsv(conflictCsv);
       await waitFor(() => expect(screen.getAllByText(/Conflict/i).length).toBeGreaterThan(0));
+      expect(screen.getAllByText(/User already in a group/i).length).toBeGreaterThan(0);
+    });
+
+    it('does NOT flag a conflict when the membership is in a different assignment', async () => {
+      const csv = 'group name,email\nTeam Alpha,other@test.com';
+      mockApiRoutes({
+        users: [
+          {
+            id: 'u4',
+            email: 'other@test.com',
+            memberships: [{ assignment_id: 'asg-2', group_id: 'g9', group_name: 'Elsewhere' }],
+          },
+        ],
+        groups: mockGroups,
+      });
+      await renderPage();
+      uploadCsv(csv);
+      await waitFor(() => expect(screen.getAllByText(/Import/).length).toBeGreaterThan(0));
+      expect(screen.queryByText(/User already in a group/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Conflict/i)).not.toBeInTheDocument();
     });
 
     it('marks admin users as Skip with appropriate reason', async () => {
       const csvWithAdmin = 'group name,email\nTeam Alpha,admin@test.com';
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null }],
-          groups: mockGroups,
-        },
+      mockApiRoutes({
+        users: [{ id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null }],
+        groups: mockGroups,
       });
-      renderPage();
+      await renderPage();
       uploadCsv(csvWithAdmin);
       await waitFor(() =>
         expect(screen.getByText(/Admins and Assignment Managers cannot be assigned/i)).toBeInTheDocument()
@@ -259,13 +396,11 @@ describe('ImportGroupMappings page', () => {
 
     it('marks assignment_manager users as Skip with appropriate reason', async () => {
       const csvWithAM = 'group name,email\nTeam Alpha,am@test.com';
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'am1', email: 'am@test.com', role_name: 'assignment_manager', group_id: null }],
-          groups: mockGroups,
-        },
+      mockApiRoutes({
+        users: [{ id: 'am1', email: 'am@test.com', role_name: 'assignment_manager', group_id: null }],
+        groups: mockGroups,
       });
-      renderPage();
+      await renderPage();
       uploadCsv(csvWithAM);
       await waitFor(() =>
         expect(screen.getByText(/Admins and Assignment Managers cannot be assigned/i)).toBeInTheDocument()
@@ -274,16 +409,14 @@ describe('ImportGroupMappings page', () => {
 
     it('does not count privileged-user rows as importable', async () => {
       const csvMixed = 'group name,email\nTeam Alpha,admin@test.com\nTeam Alpha,alice@test.com';
-      api.get.mockResolvedValue({
-        data: {
-          users: [
-            { id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null },
-            { id: 'u1', email: 'alice@test.com', role_name: 'user', group_id: null },
-          ],
-          groups: mockGroups,
-        },
+      mockApiRoutes({
+        users: [
+          { id: 'a1', email: 'admin@test.com', role_name: 'admin', group_id: null },
+          { id: 'u1', email: 'alice@test.com', role_name: 'user', group_id: null },
+        ],
+        groups: mockGroups,
       });
-      renderPage();
+      await renderPage();
       uploadCsv(csvMixed);
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
       // Import button should reflect only 1 importable row
@@ -292,13 +425,17 @@ describe('ImportGroupMappings page', () => {
 
     it('shows a skip/overwrite dropdown for conflict rows', async () => {
       const conflictCsv = 'group name,email\nTeam Alpha,assigned@test.com';
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'u3', email: 'assigned@test.com', group_id: 'g1' }],
-          groups: mockGroups,
-        },
+      mockApiRoutes({
+        users: [
+          {
+            id: 'u3',
+            email: 'assigned@test.com',
+            memberships: [{ assignment_id: 'asg-1', group_id: 'g1', group_name: 'Team Beta' }],
+          },
+        ],
+        groups: mockGroups,
       });
-      renderPage();
+      await renderPage();
       uploadCsv(conflictCsv);
       await waitFor(() => expect(screen.getByLabelText(/Action for assigned@test.com/i)).toBeInTheDocument());
     });
@@ -306,15 +443,23 @@ describe('ImportGroupMappings page', () => {
     describe('Bulk conflict actions', () => {
       const conflictCsv = 'group name,email\nTeam Alpha,alice@test.com\nTeam Beta,bob@test.com';
       const conflictUsers = [
-        { id: 'u1', email: 'alice@test.com', role_name: 'user', group_id: 'g0' },
-        { id: 'u2', email: 'bob@test.com', role_name: 'user', group_id: 'g0' },
+        {
+          id: 'u1',
+          email: 'alice@test.com',
+          role_name: 'user',
+          memberships: [{ assignment_id: 'asg-1', group_id: 'g0', group_name: 'Old Team' }],
+        },
+        {
+          id: 'u2',
+          email: 'bob@test.com',
+          role_name: 'user',
+          memberships: [{ assignment_id: 'asg-1', group_id: 'g0', group_name: 'Old Team' }],
+        },
       ];
 
       async function goToConflictPreview() {
-        api.get.mockResolvedValue({
-          data: { users: conflictUsers, groups: mockGroups },
-        });
-        renderPage();
+        mockApiRoutes({ users: conflictUsers, groups: mockGroups });
+        await renderPage();
         uploadCsv(conflictCsv);
         await waitFor(() => expect(screen.getAllByText(/Conflict/i).length).toBeGreaterThan(0));
       }
@@ -344,8 +489,8 @@ describe('ImportGroupMappings page', () => {
         await userEvent.click(screen.getByRole('button', { name: /overwrite all/i }));
         await waitFor(() => expect(screen.getByRole('button', { name: /import 2 rows/i })).toBeInTheDocument());
         // Then revert first row back to skip individually
-        const selects = screen.getAllByRole('combobox');
-        await userEvent.selectOptions(selects[0], 'skip');
+        const actionSelect = screen.getByLabelText(/Action for alice@test.com/i);
+        await userEvent.selectOptions(actionSelect, 'skip');
         await waitFor(() => expect(screen.getByRole('button', { name: /import 1 row/i })).toBeInTheDocument());
       });
 
@@ -369,21 +514,19 @@ describe('ImportGroupMappings page', () => {
 
   describe('Step 3: Result', () => {
     async function runImport(importResponse = { imported: 2, skipped: [], errors: [] }) {
-      api.get.mockResolvedValue({
-        data: {
-          users: [
-            { id: 'u1', email: 'alice@test.com', group_id: null },
-            { id: 'u2', email: 'bob@test.com', group_id: null },
-          ],
-          groups: [
-            { id: 'g1', name: 'Team Alpha' },
-            { id: 'g2', name: 'Team Beta' },
-          ],
-        },
+      mockApiRoutes({
+        users: [
+          { id: 'u1', email: 'alice@test.com', group_id: null },
+          { id: 'u2', email: 'bob@test.com', group_id: null },
+        ],
+        groups: [
+          { id: 'g1', name: 'Team Alpha' },
+          { id: 'g2', name: 'Team Beta' },
+        ],
       });
       api.post.mockResolvedValue({ data: importResponse });
 
-      renderPage();
+      await renderPage();
       uploadCsv('group name,email\nTeam Alpha,alice@test.com\nTeam Beta,bob@test.com');
       await waitFor(() => expect(screen.getByRole('heading', { name: 'Preview' })).toBeInTheDocument());
       await waitFor(() => expect(screen.getAllByText('Ready').length).toBeGreaterThan(0));
@@ -410,6 +553,42 @@ describe('ImportGroupMappings page', () => {
     it('shows import result counts', async () => {
       await runImport({ imported: 2, skipped: [], errors: [] });
       expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('submits to POST /assignments/:assignmentId/import-mappings', async () => {
+      await runImport();
+      expect(api.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/assignments\/asg-1\/import-mappings$/),
+        expect.objectContaining({ rows: expect.any(Array) })
+      );
+    });
+
+    it('sends only email, groupName and action for each row', async () => {
+      await runImport();
+      const [, body] = api.post.mock.calls[0];
+      expect(body.rows.length).toBeGreaterThan(0);
+      expect(body.rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ email: 'alice@test.com', groupName: 'Team Alpha', action: 'import' }),
+        ])
+      );
+      for (const row of body.rows) {
+        expect(Object.keys(row).sort()).toEqual(['action', 'email', 'groupName']);
+      }
+    });
+
+    it('surfaces the "User is not a member of this subject" skip reason in the skipped CSV', async () => {
+      await runImport({
+        imported: 1,
+        skipped: [{ email: 'bob@test.com', groupName: 'Team Beta', reason: 'User is not a member of this subject' }],
+        errors: [],
+      });
+      expect(screen.getByText(/skipped and errored rows has been downloaded/i)).toBeInTheDocument();
+      expect(downloadCsv).toHaveBeenCalledTimes(1);
+      const [rows] = downloadCsv.mock.calls[0];
+      expect(rows).toEqual(
+        expect.arrayContaining([expect.objectContaining({ reason: 'User is not a member of this subject' })])
+      );
     });
 
     it('shows "Back to Groups" button', async () => {
@@ -441,8 +620,8 @@ describe('ImportGroupMappings page', () => {
     ];
 
     async function goToImportReady() {
-      api.get.mockResolvedValue({ data: { users: confirmUsers, groups: confirmGroups } });
-      renderPage();
+      mockApiRoutes({ users: confirmUsers, groups: confirmGroups });
+      await renderPage();
       uploadCsv(confirmCsv);
       await waitFor(() => expect(screen.getAllByText('Ready').length).toBeGreaterThan(0));
     }
@@ -544,11 +723,9 @@ describe('ImportGroupMappings page', () => {
 
   describe('Skipped CSV download', () => {
     it('does not include duplicate rows when a skipped row appears in both preview and API response', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
-          groups: [{ id: 'g1', name: 'Team Alpha' }],
-        },
+      mockApiRoutes({
+        users: [{ id: 'u1', email: 'alice@test.com', group_id: null }],
+        groups: [{ id: 'g1', name: 'Team Alpha' }],
       });
       api.post.mockResolvedValue({
         data: {
@@ -558,7 +735,7 @@ describe('ImportGroupMappings page', () => {
         },
       });
 
-      renderPage();
+      await renderPage();
       uploadCsv('group name,email\nTeam Alpha,alice@test.com\nTeam Alpha,nobody@test.com');
       await waitFor(() => expect(screen.getByRole('button', { name: /import 1 row/i })).toBeInTheDocument());
 

--- a/frontend/tests/unit/pages/ImportUsers.test.jsx
+++ b/frontend/tests/unit/pages/ImportUsers.test.jsx
@@ -20,6 +20,30 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+// ── API route mocks ──────────────────────────────────────────────────────────
+
+const SUBJECTS = [
+  { id: 'sub-1', name: 'Subject One' },
+  { id: 'sub-2', name: 'Subject Two' },
+];
+
+/**
+ * Install a url-router implementation on api.get so every endpoint the page
+ * touches (GET /subjects on mount, GET /users for the conflict check) is
+ * served independently.
+ */
+function mockApiRoutes({ users = [], subjects = SUBJECTS, usersError = null, subjectsError = null } = {}) {
+  api.get.mockImplementation((url) => {
+    if (url.endsWith('/subjects')) {
+      return subjectsError ? Promise.reject(subjectsError) : Promise.resolve({ data: { subjects } });
+    }
+    if (url.endsWith('/users')) {
+      return usersError ? Promise.reject(usersError) : Promise.resolve({ data: { users } });
+    }
+    return Promise.reject(new Error(`Unexpected url: ${url}`));
+  });
+}
+
 // ── FileReader mock ──────────────────────────────────────────────────────────
 // JSDOM's FileReader is asynchronous and can be unreliable in tests. We mock
 // it so readAsText fires onload via a resolved microtask, using content stored
@@ -74,12 +98,15 @@ function uploadCsv(content, name = 'users.csv') {
   });
 }
 
-function renderPage() {
-  return render(
+async function renderPage() {
+  const utils = render(
     <MemoryRouter>
       <ImportUsers />
     </MemoryRouter>
   );
+  // Flush the GET /subjects fetch fired on mount
+  await act(async () => {});
+  return utils;
 }
 
 /**
@@ -100,6 +127,11 @@ async function waitForStep3() {
   await screen.findByRole('button', { name: 'Import' });
 }
 
+/** Select the target subject in the step-3 options panel. */
+async function chooseSubject(id = 'sub-1') {
+  await userEvent.selectOptions(screen.getByLabelText(/target subject/i), id);
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('ImportUsers page', () => {
@@ -107,6 +139,7 @@ describe('ImportUsers page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockApiRoutes();
     restoreFileReader = setupFileReaderMock();
   });
 
@@ -117,26 +150,26 @@ describe('ImportUsers page', () => {
   // ── Step 1: Upload ─────────────────────────────────────────────────────────
 
   describe('Step 1 — Upload', () => {
-    it('renders upload area on initial render', () => {
-      renderPage();
+    it('renders upload area on initial render', async () => {
+      await renderPage();
       expect(screen.getByText(/upload csv file/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     });
 
     it('Cancel button navigates to /users', async () => {
-      renderPage();
+      await renderPage();
       await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
       expect(mockNavigate).toHaveBeenCalledWith('/users');
     });
 
     it('"Back to Users" button navigates to /users', async () => {
-      renderPage();
+      await renderPage();
       await userEvent.click(screen.getAllByRole('button', { name: /back to users/i })[0]);
       expect(mockNavigate).toHaveBeenCalledWith('/users');
     });
 
     it('shows error when a non-CSV file is uploaded', async () => {
-      renderPage();
+      await renderPage();
       const file = new File(['hello'], 'data.txt', { type: 'text/plain' });
       file.__testContent = 'hello';
       const input = document.querySelector('input[type="file"]');
@@ -148,33 +181,33 @@ describe('ImportUsers page', () => {
     });
 
     it('shows error when CSV has no data rows', async () => {
-      renderPage();
+      await renderPage();
       // Header row + blank data row → parser filters blank rows → 0 data rows
       uploadCsv('username,email,firstName,lastName\n,,,,');
       expect(await screen.findByText(/no data rows found/i)).toBeInTheDocument();
     });
 
     it('advances to step 2 after a valid CSV upload', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe');
       // Wait for a combobox to appear — they only exist in step 2
-      await waitForStep2();
+      waitForStep2();
       expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
     });
 
     it('accepts a valid CSV via drag and drop and advances to step 2', async () => {
-      renderPage();
+      await renderPage();
       const file = makeCsvFile('username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe');
       const dropzone = screen.getByRole('button', { name: /click to browse/i });
       act(() => {
         fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
       });
-      await waitForStep2();
+      waitForStep2();
       expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
     });
 
     it('shows error when a non-CSV file is dropped', async () => {
-      renderPage();
+      await renderPage();
       const file = new File(['hello'], 'data.txt', { type: 'text/plain' });
       file.__testContent = 'hello';
       const dropzone = screen.getByRole('button', { name: /click to browse/i });
@@ -191,9 +224,9 @@ describe('ImportUsers page', () => {
     const validCsv = 'username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe';
 
     it('auto-detects column mappings from header names', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(validCsv);
-      await waitForStep2();
+      waitForStep2();
       const values = screen.getAllByRole('combobox').map((s) => s.value);
       expect(values).toContain('username');
       expect(values).toContain('email');
@@ -202,45 +235,44 @@ describe('ImportUsers page', () => {
     });
 
     it('shows validation error when required fields are not mapped', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv('col1,col2\nval1,val2');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       expect(await screen.findByText(/required fields not mapped/i)).toBeInTheDocument();
     });
 
     it('"Send setup email" checkbox defaults to unchecked', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(validCsv);
-      await waitForStep2();
+      waitForStep2();
       const checkbox = screen.getByRole('checkbox');
       expect(checkbox).not.toBeChecked();
     });
 
     it('Back button returns to step 1', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(validCsv);
-      await waitForStep2();
+      waitForStep2();
       // "Back" exact name to avoid matching "Back to Users" breadcrumb
       await userEvent.click(screen.getByRole('button', { name: 'Back' }));
       expect(screen.getByText(/upload csv file/i)).toBeInTheDocument();
     });
 
     it('loads preview and advances to step 3 on success', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       uploadCsv(validCsv);
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText(/import preview/i)).toBeInTheDocument();
     });
 
     it('shows error when fetching existing users fails', async () => {
-      api.get.mockRejectedValue({ response: { data: { error: 'Server error' } } });
-      renderPage();
+      mockApiRoutes({ usersError: { response: { data: { error: 'Server error' } } } });
+      await renderPage();
       uploadCsv(validCsv);
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       expect(await screen.findByText('Server error')).toBeInTheDocument();
     });
@@ -252,10 +284,10 @@ describe('ImportUsers page', () => {
     const twoCsv = 'username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe\njane,jane@test.com,Jane,Smith';
 
     async function goToPreview({ existingUsers = [], csv = twoCsv } = {}) {
-      api.get.mockResolvedValue({ data: { users: existingUsers } });
-      renderPage();
+      mockApiRoutes({ users: existingUsers });
+      await renderPage();
       uploadCsv(csv);
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
     }
@@ -307,13 +339,15 @@ describe('ImportUsers page', () => {
     it('submits import and shows result step', async () => {
       api.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
       await goToPreview();
+      await chooseSubject();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       expect(await screen.findByText('Import Complete')).toBeInTheDocument();
     });
 
-    it('calls POST /users/import with correct payload', async () => {
+    it('calls POST /users/import with correct payload including subjectId', async () => {
       api.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
       await goToPreview();
+      await chooseSubject('sub-2');
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       await screen.findByText('Import Complete');
       expect(api.post).toHaveBeenCalledWith(
@@ -321,6 +355,7 @@ describe('ImportUsers page', () => {
         expect.objectContaining({
           conflictAction: 'skip',
           sendSetupEmail: false,
+          subjectId: 'sub-2',
           users: expect.any(Array),
         })
       );
@@ -329,6 +364,7 @@ describe('ImportUsers page', () => {
     it('shows submit error when import API fails', async () => {
       api.post.mockRejectedValue({ response: { data: { error: 'Import failed' } } });
       await goToPreview();
+      await chooseSubject();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       expect(await screen.findByText('Import failed')).toBeInTheDocument();
     });
@@ -343,8 +379,84 @@ describe('ImportUsers page', () => {
       await goToPreview();
       await userEvent.click(screen.getByRole('button', { name: 'Back' }));
       // Step 2 comboboxes reappear
-      await waitForStep2();
+      waitForStep2();
       expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Target subject selection ───────────────────────────────────────────────
+
+  describe('Target subject selection', () => {
+    const twoCsv = 'username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe\njane,jane@test.com,Jane,Smith';
+
+    async function goToPreview() {
+      await renderPage();
+      uploadCsv(twoCsv);
+      waitForStep2();
+      await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
+      await waitForStep3();
+    }
+
+    it('renders the subject select with options fetched from GET /subjects', async () => {
+      await goToPreview();
+      const select = screen.getByLabelText(/target subject/i);
+      expect(select).toBeInTheDocument();
+      expect(select).toHaveValue('');
+      expect(screen.getByRole('option', { name: 'Select subject' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Subject One' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Subject Two' })).toBeInTheDocument();
+      expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/subjects$/));
+    });
+
+    it('blocks import with "Subject is required" when no subject is chosen', async () => {
+      await goToPreview();
+      await userEvent.click(screen.getByRole('button', { name: 'Import' }));
+      expect(await screen.findByText('Subject is required')).toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('clears the "Subject is required" error once a subject is chosen', async () => {
+      await goToPreview();
+      await userEvent.click(screen.getByRole('button', { name: 'Import' }));
+      expect(await screen.findByText('Subject is required')).toBeInTheDocument();
+      await chooseSubject();
+      expect(screen.queryByText('Subject is required')).not.toBeInTheDocument();
+    });
+
+    it('sends the selected subjectId in the POST body', async () => {
+      api.post.mockResolvedValue({ data: { imported: 2, skipped: 0, errors: [] } });
+      await goToPreview();
+      await chooseSubject('sub-1');
+      await userEvent.click(screen.getByRole('button', { name: 'Import' }));
+      await screen.findByText('Import Complete');
+      expect(api.post).toHaveBeenCalledWith(
+        expect.stringContaining('/users/import'),
+        expect.objectContaining({ subjectId: 'sub-1' })
+      );
+    });
+
+    it('surfaces a 403 error message from the API', async () => {
+      api.post.mockRejectedValue({
+        response: { status: 403, data: { error: 'You do not manage an assignment in this subject' } },
+      });
+      await goToPreview();
+      await chooseSubject();
+      await userEvent.click(screen.getByRole('button', { name: 'Import' }));
+      expect(await screen.findByText('You do not manage an assignment in this subject')).toBeInTheDocument();
+    });
+
+    it('shows a permission fallback message for a 403 without a server error message', async () => {
+      api.post.mockRejectedValue({ response: { status: 403, data: {} } });
+      await goToPreview();
+      await chooseSubject();
+      await userEvent.click(screen.getByRole('button', { name: 'Import' }));
+      expect(await screen.findByText(/do not have permission to import users into this subject/i)).toBeInTheDocument();
+    });
+
+    it('shows an error when subjects fail to load', async () => {
+      mockApiRoutes({ subjectsError: new Error('network') });
+      await goToPreview();
+      expect(screen.getByText(/failed to load subjects/i)).toBeInTheDocument();
     });
   });
 
@@ -352,13 +464,13 @@ describe('ImportUsers page', () => {
 
   describe('Step 4 — Result', () => {
     async function goToResult({ imported = 2, skipped = 0, errors = [] } = {}) {
-      api.get.mockResolvedValue({ data: { users: [] } });
       api.post.mockResolvedValue({ data: { imported, skipped, errors } });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,jdoe@test.com,John,Doe\njane,jane@test.com,Jane,Smith');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
+      await chooseSubject();
       await userEvent.click(screen.getByRole('button', { name: 'Import' }));
       await screen.findByText('Import Complete');
     }
@@ -396,11 +508,10 @@ describe('ImportUsers page', () => {
 
   describe('Full Name column mapping', () => {
     it('splits "First Last" format correctly in preview', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       // "name" header auto-detects to fullNameFL
       uploadCsv('username,email,name\njdoe,jdoe@test.com,John Doe');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('John')).toBeInTheDocument();
@@ -408,10 +519,9 @@ describe('ImportUsers page', () => {
     });
 
     it('splits "First, Last" comma format correctly for fullNameFL', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,name\njdoe,jdoe@test.com,"John, Doe"');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('John')).toBeInTheDocument();
@@ -419,11 +529,10 @@ describe('ImportUsers page', () => {
     });
 
     it('splits "Last, First" format correctly when mapped to fullNameLF', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       // "fullname" auto-detects to fullNameFL; we'll change it to fullNameLF
       uploadCsv('username,email,fullname\njdoe,jdoe@test.com,"Doe, John"');
-      await waitForStep2();
+      waitForStep2();
 
       // Third column (index 2) — change mapping to fullNameLF
       const selects = screen.getAllByRole('combobox');
@@ -447,9 +556,9 @@ describe('ImportUsers page', () => {
     }
 
     it('hides a selected field from other column dropdowns', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(fiveColCsv);
-      await waitForStep2();
+      waitForStep2();
 
       // Map column 0 to "username"
       fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'username' } });
@@ -461,9 +570,9 @@ describe('ImportUsers page', () => {
     });
 
     it('hides fullName options when firstName is selected', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(fiveColCsv);
-      await waitForStep2();
+      waitForStep2();
 
       fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'firstName' } });
 
@@ -476,9 +585,9 @@ describe('ImportUsers page', () => {
     });
 
     it('hides firstName, lastName, and both fullName options when fullNameFL is selected', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(fiveColCsv);
-      await waitForStep2();
+      waitForStep2();
 
       fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'fullNameFL' } });
 
@@ -490,9 +599,9 @@ describe('ImportUsers page', () => {
     });
 
     it('clears conflicting selections when a new value creates a conflict', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv(fiveColCsv);
-      await waitForStep2();
+      waitForStep2();
 
       // Re-query combobox references after each change (React re-renders replace DOM nodes)
       fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'firstName' } });
@@ -510,10 +619,10 @@ describe('ImportUsers page', () => {
     });
 
     it('autoDetect does not assign duplicate fields to multiple columns', async () => {
-      renderPage();
+      await renderPage();
       // Two columns named "email" — only the first should get the mapping
       uploadCsv('email,email,firstName,lastName\na@t.com,b@t.com,John,Doe');
-      await waitForStep2();
+      waitForStep2();
 
       const selects = screen.getAllByRole('combobox');
       expect(selects[0].value).toBe('email');
@@ -521,9 +630,9 @@ describe('ImportUsers page', () => {
     });
 
     it('autoDetect blocks fullName when firstName/lastName are already assigned', async () => {
-      renderPage();
+      await renderPage();
       uploadCsv('firstName,lastName,name\nJohn,Doe,John Doe');
-      await waitForStep2();
+      waitForStep2();
 
       const selects = screen.getAllByRole('combobox');
       expect(selects[0].value).toBe('firstName');
@@ -537,63 +646,55 @@ describe('ImportUsers page', () => {
 
   describe('Duplicate and conflict detection', () => {
     it('shows "Duplicate in file" badge for intra-CSV duplicate usernames', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,jdoe@a.com,John,Doe\njdoe,jdoe@b.com,Jane,Doe');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('Duplicate in file')).toBeInTheDocument();
     });
 
     it('shows "Duplicate in file" badge for intra-CSV duplicate emails', async () => {
-      api.get.mockResolvedValue({ data: { users: [] } });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\njdoe,same@test.com,John,Doe\njane,same@test.com,Jane,Smith');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('Duplicate in file')).toBeInTheDocument();
     });
 
     it('shows "Conflict (email/ID taken)" for email conflict with existing user', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
-        },
+      mockApiRoutes({
+        users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
       });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\nnewuser,taken@test.com,New,User');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('Conflict (email/ID taken)')).toBeInTheDocument();
     });
 
     it('shows "Conflict (email/ID taken)" for student ID conflict with existing user', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ username: 'other', email: 'other@test.com', role_name: 'user', student_id: 'S123' }],
-        },
+      mockApiRoutes({
+        users: [{ username: 'other', email: 'other@test.com', role_name: 'user', student_id: 'S123' }],
       });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName,student id\nnewuser,new@test.com,New,User,S123');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       expect(screen.getByText('Conflict (email/ID taken)')).toBeInTheDocument();
     });
 
     it('does not send conflict rows to the import API', async () => {
-      api.get.mockResolvedValue({
-        data: {
-          users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
-        },
+      mockApiRoutes({
+        users: [{ username: 'other', email: 'taken@test.com', role_name: 'user' }],
       });
       api.post.mockResolvedValue({ data: { imported: 0, skipped: 0, errors: [] } });
-      renderPage();
+      await renderPage();
       uploadCsv('username,email,firstName,lastName\nnewuser,taken@test.com,New,User');
-      await waitForStep2();
+      waitForStep2();
       await userEvent.click(screen.getByRole('button', { name: /preview import/i }));
       await waitForStep3();
       // Import button should be disabled since the only row is a conflict

--- a/frontend/tests/unit/pages/SubjectDetail.test.jsx
+++ b/frontend/tests/unit/pages/SubjectDetail.test.jsx
@@ -1,0 +1,294 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import api from '@/utils/api';
+import SubjectDetail from '../../../src/pages/SubjectDetail.jsx';
+import { useAuth } from '../../../src/context/AuthContext.jsx';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@/utils/api');
+jest.mock('../../../src/context/AuthContext.jsx', () => ({
+  useAuth: jest.fn(),
+}));
+
+const SUBJECT_ID = '11111111-1111-4111-8111-111111111111';
+const ASSIGNMENT_ID = 'a0000000-0000-0000-0000-000000000001';
+
+const makeSubject = (overrides = {}) => ({
+  id: SUBJECT_ID,
+  name: 'Mathematics',
+  created_at: '2025-01-15T00:00:00.000Z',
+  updated_at: '2025-01-15T00:00:00.000Z',
+  ...overrides,
+});
+
+const makeAssignment = (overrides = {}) => ({
+  id: ASSIGNMENT_ID,
+  name: 'Assignment 1',
+  subject_id: SUBJECT_ID,
+  subject_name: 'Mathematics',
+  group_count: 4,
+  created_at: '2025-02-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={[`/subjects/${SUBJECT_ID}`]}>
+      <Routes>
+        <Route path="/subjects/:subjectId" element={<SubjectDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('SubjectDetail page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuth.mockReturnValue({ isAdmin: true, isAssignmentManager: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const setupPage = async (assignments = [makeAssignment()], subject = makeSubject()) => {
+    api.get.mockResolvedValueOnce({ data: { subject, assignments } });
+    renderPage();
+    // Subject name appears in both the breadcrumb and the page heading.
+    await waitFor(() => expect(screen.getAllByText('Mathematics').length).toBeGreaterThan(0));
+  };
+
+  // ── Loading / fetch ────────────────────────────────────────────────────
+  it('shows loading spinner before data resolves', () => {
+    api.get.mockImplementation(() => new Promise(() => {}));
+    const { container } = renderPage();
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.queryByText('Mathematics')).not.toBeInTheDocument();
+  });
+
+  it('fetches the subject by route param', async () => {
+    await setupPage();
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/subjects/${SUBJECT_ID}$`)));
+  });
+
+  it('shows error banner with a link back to subjects when fetch fails', async () => {
+    api.get.mockRejectedValue(new Error('boom'));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Failed to load subject')).toBeInTheDocument());
+    const link = screen.getByRole('link', { name: /back to subjects/i });
+    expect(link).toHaveAttribute('href', '/subjects');
+  });
+
+  // ── Breadcrumb ─────────────────────────────────────────────────────────
+  it('renders breadcrumb with a Subjects link and the subject name', async () => {
+    await setupPage();
+    const link = screen.getByRole('link', { name: 'Subjects' });
+    expect(link).toHaveAttribute('href', '/subjects');
+    const breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(breadcrumb).toHaveTextContent('Subjects');
+    expect(breadcrumb).toHaveTextContent('Mathematics');
+  });
+
+  // ── Assignments table ──────────────────────────────────────────────────
+  it('renders assignment rows with group count and created date', async () => {
+    const assignment = makeAssignment();
+    await setupPage([assignment]);
+    expect(screen.getByText('Assignment 1')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText(new Date(assignment.created_at).toLocaleDateString())).toBeInTheDocument();
+  });
+
+  it('shows empty state when the subject has no assignments', async () => {
+    await setupPage([]);
+    expect(screen.getByText('No assignments yet')).toBeInTheDocument();
+  });
+
+  // ── Role gating ────────────────────────────────────────────────────────
+  describe('Role gating', () => {
+    it('shows create and delete controls for admins', async () => {
+      await setupPage();
+      expect(screen.getByRole('button', { name: /\+ create assignment/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete Assignment' })).toBeInTheDocument();
+    });
+
+    it('hides create and delete controls for non-admin assignment managers', async () => {
+      useAuth.mockReturnValue({ isAdmin: false, isAssignmentManager: true });
+      await setupPage();
+      expect(screen.getByText('Assignment 1')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /\+ create assignment/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Assignment' })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Create assignment ──────────────────────────────────────────────────
+  describe('Create assignment', () => {
+    it('creates an assignment, refetches, and shows success feedback', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage([]);
+      api.post.mockResolvedValueOnce({ data: { message: 'ok', assignment: makeAssignment() } });
+      api.get.mockResolvedValueOnce({ data: { subject: makeSubject(), assignments: [makeAssignment()] } });
+
+      await user.click(screen.getByRole('button', { name: /\+ create assignment/i }));
+      await user.type(screen.getByPlaceholderText(/enter assignment name/i), ' Assignment 2 ');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/assignments$/), {
+          subjectId: SUBJECT_ID,
+          name: 'Assignment 2',
+        });
+        expect(screen.getByText('Assignment created successfully')).toBeInTheDocument();
+      });
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText('Create New Assignment')).not.toBeInTheDocument();
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => expect(screen.queryByText('Assignment created successfully')).not.toBeInTheDocument());
+    });
+
+    it('shows validation error and does not POST when name is empty', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+
+      await user.click(screen.getByRole('button', { name: /\+ create assignment/i }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Assignment name is required')).toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('shows server error inside modal on duplicate assignment (409)', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+      api.post.mockRejectedValue({
+        response: { status: 409, data: { error: 'Assignment already exists in this subject' } },
+      });
+
+      await user.click(screen.getByRole('button', { name: /\+ create assignment/i }));
+      await user.type(screen.getByPlaceholderText(/enter assignment name/i), 'Assignment 1');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Assignment already exists in this subject')).toBeInTheDocument();
+      // Modal stays open so the user can fix the name
+      expect(screen.getByText('Create New Assignment')).toBeInTheDocument();
+    });
+
+    it('shows generic error when create fails without a server message', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+      api.post.mockRejectedValue(new Error('network'));
+
+      await user.click(screen.getByRole('button', { name: /\+ create assignment/i }));
+      await user.type(screen.getByPlaceholderText(/enter assignment name/i), 'Assignment 2');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Failed to create assignment')).toBeInTheDocument();
+    });
+
+    it('cancels the create modal without calling the API', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+
+      await user.click(screen.getByRole('button', { name: /\+ create assignment/i }));
+      await user.type(screen.getByPlaceholderText(/enter assignment name/i), 'Assignment 2');
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByText('Create New Assignment')).not.toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Delete assignment ──────────────────────────────────────────────────
+  describe('Delete assignment', () => {
+    it('deletes an assignment via the two-step typed confirmation and refetches', async () => {
+      const user = userEvent.setup();
+      await setupPage([makeAssignment({ group_count: 4 })]);
+      api.delete.mockResolvedValueOnce({ data: { message: 'ok' } });
+      api.get.mockResolvedValueOnce({ data: { subject: makeSubject(), assignments: [] } });
+
+      await user.click(screen.getByRole('button', { name: 'Delete Assignment' }));
+
+      expect(screen.getByText('Delete assignment')).toBeInTheDocument();
+      expect(screen.getByText(/4 groups and their memberships will be permanently deleted/i)).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText('Confirmation name'), 'Assignment 1');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => {
+        expect(api.delete).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`/assignments/${ASSIGNMENT_ID}$`)));
+        expect(screen.getByText('Assignment deleted successfully')).toBeInTheDocument();
+      });
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps Continue disabled until the typed name matches exactly', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Assignment' }));
+
+      await user.type(screen.getByLabelText('Confirmation name'), 'Wrong');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
+
+    it('cancels the delete modal without calling the API', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Assignment' }));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(api.delete).not.toHaveBeenCalled();
+      expect(screen.queryByText('Delete assignment')).not.toBeInTheDocument();
+    });
+
+    it('shows server error when delete fails', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage();
+      api.delete.mockRejectedValue({ response: { status: 500, data: { error: 'Cannot delete assignment' } } });
+
+      await user.click(screen.getByRole('button', { name: 'Delete Assignment' }));
+      await user.type(screen.getByLabelText('Confirmation name'), 'Assignment 1');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => expect(screen.getByText('Cannot delete assignment')).toBeInTheDocument());
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => expect(screen.queryByText('Cannot delete assignment')).not.toBeInTheDocument());
+    });
+  });
+
+  // ── Navigation ─────────────────────────────────────────────────────────
+  describe('Row navigation', () => {
+    it('navigates to the assignment groups page when a row is clicked', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByText('Assignment 1'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(`/subjects/${SUBJECT_ID}/assignments/${ASSIGNMENT_ID}`);
+    });
+
+    it('does not navigate when the delete button is clicked', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Assignment' }));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/unit/pages/SubjectDetail.test.jsx
+++ b/frontend/tests/unit/pages/SubjectDetail.test.jsx
@@ -16,6 +16,22 @@ jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
 
+// Keep the page tests light: replace the members section with a probe div that
+// exposes the props it received.
+jest.mock('../../../src/components/SubjectMembersSection.jsx', () => {
+  const MockSubjectMembersSection = ({ subject, isAdmin, canManage }) => (
+    <div
+      data-testid="subject-members-section"
+      data-subject-id={subject?.id}
+      data-subject-name={subject?.name}
+      data-is-admin={String(isAdmin)}
+      data-can-manage={String(canManage)}
+    />
+  );
+  MockSubjectMembersSection.displayName = 'MockSubjectMembersSection';
+  return MockSubjectMembersSection;
+});
+
 const SUBJECT_ID = '11111111-1111-4111-8111-111111111111';
 const ASSIGNMENT_ID = 'a0000000-0000-0000-0000-000000000001';
 
@@ -124,6 +140,61 @@ describe('SubjectDetail page', () => {
       expect(screen.getByText('Assignment 1')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /\+ create assignment/i })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Delete Assignment' })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Members section ────────────────────────────────────────────────────
+  describe('Members section', () => {
+    it('renders the members section for admins with the expected props', async () => {
+      await setupPage();
+
+      const probe = screen.getByTestId('subject-members-section');
+      expect(probe).toHaveAttribute('data-subject-id', SUBJECT_ID);
+      expect(probe).toHaveAttribute('data-subject-name', 'Mathematics');
+      expect(probe).toHaveAttribute('data-is-admin', 'true');
+      expect(probe).toHaveAttribute('data-can-manage', 'true');
+    });
+
+    it('renders the members section for an AM managing an assignment in this subject', async () => {
+      useAuth.mockReturnValue({
+        isAdmin: false,
+        isAssignmentManager: true,
+        user: {
+          username: 'tm',
+          managedAssignments: [
+            { id: 'a0000000-0000-0000-0000-000000000009', subject_id: 'other-subject' },
+            { id: ASSIGNMENT_ID, subject_id: SUBJECT_ID },
+          ],
+        },
+      });
+      await setupPage();
+
+      const probe = screen.getByTestId('subject-members-section');
+      expect(probe).toHaveAttribute('data-subject-id', SUBJECT_ID);
+      expect(probe).toHaveAttribute('data-is-admin', 'false');
+      expect(probe).toHaveAttribute('data-can-manage', 'true');
+    });
+
+    it('hides the members section from an AM who manages no assignment in this subject', async () => {
+      useAuth.mockReturnValue({
+        isAdmin: false,
+        isAssignmentManager: true,
+        user: {
+          username: 'tm',
+          managedAssignments: [{ id: 'a0000000-0000-0000-0000-000000000009', subject_id: 'other-subject' }],
+        },
+      });
+      await setupPage();
+
+      expect(screen.getByText('Assignment 1')).toBeInTheDocument();
+      expect(screen.queryByTestId('subject-members-section')).not.toBeInTheDocument();
+    });
+
+    it('hides the members section from an AM without managedAssignments', async () => {
+      useAuth.mockReturnValue({ isAdmin: false, isAssignmentManager: true, user: { username: 'tm' } });
+      await setupPage();
+
+      expect(screen.queryByTestId('subject-members-section')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/tests/unit/pages/Subjects.test.jsx
+++ b/frontend/tests/unit/pages/Subjects.test.jsx
@@ -1,0 +1,331 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import api from '@/utils/api';
+import Subjects from '../../../src/pages/Subjects.jsx';
+import { useAuth } from '../../../src/context/AuthContext.jsx';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@/utils/api');
+jest.mock('../../../src/context/AuthContext.jsx', () => ({
+  useAuth: jest.fn(),
+}));
+
+const makeSubject = (overrides = {}) => ({
+  id: 's0000000-0000-0000-0000-000000000001',
+  name: 'Mathematics',
+  assignment_count: 2,
+  member_count: 10,
+  created_at: '2025-01-15T00:00:00.000Z',
+  updated_at: '2025-01-15T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('Subjects page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuth.mockReturnValue({ isAdmin: true, isAssignmentManager: true });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const setupPage = async (subjects = [makeSubject()]) => {
+    api.get.mockResolvedValueOnce({ data: { subjects } });
+    render(
+      <MemoryRouter>
+        <Subjects />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText(/manage subjects/i)).toBeInTheDocument());
+  };
+
+  // ── Loading / fetch ────────────────────────────────────────────────────
+  it('shows loading spinner before data resolves', () => {
+    api.get.mockImplementation(() => new Promise(() => {}));
+    const { container } = render(
+      <MemoryRouter>
+        <Subjects />
+      </MemoryRouter>
+    );
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.queryByText(/manage subjects/i)).not.toBeInTheDocument();
+  });
+
+  it('renders subject rows with counts and created date', async () => {
+    const subject = makeSubject();
+    await setupPage([subject]);
+    expect(screen.getByText('Mathematics')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText(new Date(subject.created_at).toLocaleDateString())).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no subjects', async () => {
+    await setupPage([]);
+    expect(screen.getByText('No subjects found')).toBeInTheDocument();
+  });
+
+  it('shows fetch error banner when loading fails', async () => {
+    api.get.mockRejectedValue(new Error('boom'));
+    render(
+      <MemoryRouter>
+        <Subjects />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText('Failed to load subjects')).toBeInTheDocument());
+  });
+
+  it('re-fetches when the browser tab becomes visible', async () => {
+    await setupPage([makeSubject()]);
+    api.get.mockResolvedValueOnce({ data: { subjects: [makeSubject({ id: 's2', name: 'Physics' })] } });
+
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true, writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await waitFor(() => expect(screen.getByText('Physics')).toBeInTheDocument());
+  });
+
+  it('does not re-fetch when the tab becomes hidden', async () => {
+    await setupPage();
+    const callsBefore = api.get.mock.calls.length;
+
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true, writable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(api.get.mock.calls.length).toBe(callsBefore);
+  });
+
+  // ── Search ─────────────────────────────────────────────────────────────
+  describe('Search', () => {
+    it('filters subjects by name (case-insensitive)', async () => {
+      const user = userEvent.setup();
+      await setupPage([makeSubject(), makeSubject({ id: 's2', name: 'Physics' })]);
+
+      await user.type(screen.getByPlaceholderText('Search subjects...'), 'MATH');
+
+      await waitFor(() => {
+        expect(screen.getByText('Mathematics')).toBeInTheDocument();
+        expect(screen.queryByText('Physics')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows empty state when search matches nothing', async () => {
+      const user = userEvent.setup();
+      await setupPage([makeSubject()]);
+
+      await user.type(screen.getByPlaceholderText('Search subjects...'), 'zzz');
+
+      await waitFor(() => {
+        expect(screen.getByText('No subjects found')).toBeInTheDocument();
+        expect(screen.queryByText('Mathematics')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // ── Role gating ────────────────────────────────────────────────────────
+  describe('Role gating', () => {
+    it('shows create and delete controls for admins', async () => {
+      await setupPage();
+      expect(screen.getByRole('button', { name: /\+ create subject/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete Subject' })).toBeInTheDocument();
+    });
+
+    it('hides create and delete controls for non-admin assignment managers', async () => {
+      useAuth.mockReturnValue({ isAdmin: false, isAssignmentManager: true });
+      await setupPage();
+      expect(screen.getByText('Mathematics')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /\+ create subject/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Subject' })).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Create subject ─────────────────────────────────────────────────────
+  describe('Create subject', () => {
+    it('creates a subject, refetches, and shows auto-dismissing success feedback', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage([]);
+      api.post.mockResolvedValueOnce({ data: { message: 'ok', subject: makeSubject() } });
+      api.get.mockResolvedValueOnce({ data: { subjects: [makeSubject()] } });
+
+      await user.click(screen.getByRole('button', { name: /\+ create subject/i }));
+      await user.type(screen.getByPlaceholderText(/enter subject name/i), ' Mathematics ');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringMatching(/\/subjects$/), { name: 'Mathematics' });
+        expect(screen.getByText('Subject created successfully')).toBeInTheDocument();
+      });
+      expect(api.get).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText('Create New Subject')).not.toBeInTheDocument();
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => expect(screen.queryByText('Subject created successfully')).not.toBeInTheDocument());
+    });
+
+    it('shows validation error and does not POST when name is empty', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+
+      await user.click(screen.getByRole('button', { name: /\+ create subject/i }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Subject name is required')).toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+
+    it('shows server error inside modal on duplicate subject (409)', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+      api.post.mockRejectedValue({ response: { data: { error: 'Subject already exists' } } });
+
+      await user.click(screen.getByRole('button', { name: /\+ create subject/i }));
+      await user.type(screen.getByPlaceholderText(/enter subject name/i), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Subject already exists')).toBeInTheDocument();
+      // Modal stays open so the user can fix the name
+      expect(screen.getByText('Create New Subject')).toBeInTheDocument();
+    });
+
+    it('shows generic error when create fails without a server message', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+      api.post.mockRejectedValue(new Error('network'));
+
+      await user.click(screen.getByRole('button', { name: /\+ create subject/i }));
+      await user.type(screen.getByPlaceholderText(/enter subject name/i), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(await screen.findByText('Failed to create subject')).toBeInTheDocument();
+    });
+
+    it('cancels the create modal and clears its state', async () => {
+      const user = userEvent.setup();
+      await setupPage([]);
+
+      await user.click(screen.getByRole('button', { name: /\+ create subject/i }));
+      await user.type(screen.getByPlaceholderText(/enter subject name/i), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByText('Create New Subject')).not.toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Delete subject ─────────────────────────────────────────────────────
+  describe('Delete subject', () => {
+    it('deletes a subject via the two-step typed confirmation and refetches', async () => {
+      const user = userEvent.setup();
+      await setupPage([makeSubject({ assignment_count: 2, member_count: 10 })]);
+      api.delete.mockResolvedValueOnce({ data: { message: 'ok' } });
+      api.get.mockResolvedValueOnce({ data: { subjects: [] } });
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+
+      expect(screen.getByText('Delete subject')).toBeInTheDocument();
+      expect(screen.getByText(/2 assignments and 10 members will be permanently deleted/i)).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText('Confirmation name'), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => {
+        expect(api.delete).toHaveBeenCalledWith(
+          expect.stringMatching(/\/subjects\/s0000000-0000-0000-0000-000000000001$/)
+        );
+        expect(screen.getByText('Subject deleted successfully')).toBeInTheDocument();
+      });
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps Continue disabled until the typed name matches exactly', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+
+      const input = screen.getByLabelText('Confirmation name');
+      await user.type(input, 'Wrong');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+
+      await user.clear(input);
+      await user.type(input, 'Mathematics');
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled();
+    });
+
+    it('cancels the delete modal without calling the API', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(api.delete).not.toHaveBeenCalled();
+      expect(screen.queryByText('Delete subject')).not.toBeInTheDocument();
+    });
+
+    it('shows server error when delete fails', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage();
+      api.delete.mockRejectedValue({ response: { status: 403, data: { error: 'Forbidden' } } });
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+      await user.type(screen.getByLabelText('Confirmation name'), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => expect(screen.getByText('Forbidden')).toBeInTheDocument());
+
+      jest.advanceTimersByTime(3000);
+      await waitFor(() => expect(screen.queryByText('Forbidden')).not.toBeInTheDocument());
+    });
+
+    it('shows generic error when delete fails without a server message', async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      await setupPage();
+      api.delete.mockRejectedValue(new Error('network'));
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+      await user.type(screen.getByLabelText('Confirmation name'), 'Mathematics');
+      await user.click(screen.getByRole('button', { name: 'Continue' }));
+      await user.type(screen.getByLabelText('Confirmation word'), 'delete');
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => expect(screen.getByText('Failed to delete subject')).toBeInTheDocument());
+    });
+  });
+
+  // ── Navigation ─────────────────────────────────────────────────────────
+  describe('Row navigation', () => {
+    it('navigates to the subject detail page when a row is clicked', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByText('Mathematics'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/subjects/s0000000-0000-0000-0000-000000000001');
+    });
+
+    it('does not navigate when the delete button is clicked', async () => {
+      const user = userEvent.setup();
+      await setupPage();
+
+      await user.click(screen.getByRole('button', { name: 'Delete Subject' }));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/unit/pages/Users.test.jsx
+++ b/frontend/tests/unit/pages/Users.test.jsx
@@ -10,6 +10,29 @@ jest.mock('../../../src/context/AuthContext.jsx', () => ({
   useAuth: jest.fn(),
 }));
 
+const SUBJECT_A = {
+  id: 'aaaaaaaa-0000-4000-8000-000000000001',
+  name: 'Subject A',
+  assignment_count: 1,
+  member_count: 2,
+};
+const SUBJECT_B = {
+  id: 'aaaaaaaa-0000-4000-8000-000000000002',
+  name: 'Subject B',
+  assignment_count: 1,
+  member_count: 1,
+};
+const ASSIGNMENT_1 = { id: 'bbbbbbbb-0000-4000-8000-000000000001', name: 'Assignment 1', group_count: 1 };
+const GROUP_1 = { id: 'cccccccc-0000-4000-8000-000000000001', name: 'Group 1', max_members: 5, member_count: 2 };
+const MEMBERSHIP_1 = {
+  assignment_id: ASSIGNMENT_1.id,
+  assignment_name: 'Assignment 1',
+  subject_id: SUBJECT_A.id,
+  subject_name: 'Subject A',
+  group_id: GROUP_1.id,
+  group_name: 'Group 1',
+};
+
 describe('Users page', () => {
   const initialUsers = [
     {
@@ -19,15 +42,51 @@ describe('Users page', () => {
       first_name: 'First',
       last_name: 'Last',
       role_name: 'user',
-      group_name: null,
       student_id: 's1',
       role_id: 3,
       enabled: true,
+      subjects: [],
+      memberships: [],
     },
   ];
-  const initialGroups = [
-    { id: 'g0000000-0000-0000-0000-000000000002', name: 'Group A', max_members: null, member_count: 3 },
-  ];
+  const initialSubjects = [SUBJECT_A, SUBJECT_B];
+
+  /**
+   * URL-router mock for api.get covering the page fetch (GET /users + GET /subjects)
+   * plus the endpoints used by CascadingAssignmentSelect inside the modals.
+   */
+  const mockApiGet = ({
+    users = initialUsers,
+    subjects = initialSubjects,
+    assignments = [ASSIGNMENT_1],
+    groups = [GROUP_1],
+  } = {}) => {
+    api.get.mockImplementation((url) => {
+      if (/\/users$/.test(url)) {
+        return Promise.resolve({ data: { users } });
+      }
+      if (/\/subjects$/.test(url)) {
+        return Promise.resolve({ data: { subjects } });
+      }
+      if (/\/subjects\/[^/]+$/.test(url)) {
+        return Promise.resolve({ data: { subject: SUBJECT_A, assignments } });
+      }
+      if (/\/assignments\/[^/]+\/groups$/.test(url)) {
+        return Promise.resolve({ data: { groups } });
+      }
+      return Promise.reject(new Error(`Unexpected url: ${url}`));
+    });
+  };
+
+  const renderPage = async (options) => {
+    mockApiGet(options);
+    render(
+      <MemoryRouter>
+        <Users />
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -55,23 +114,16 @@ describe('Users page', () => {
     expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
   });
 
-  it('renders users after successful fetch', async () => {
-    api.get
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
+  it('fetches users and subjects in parallel and renders users', async () => {
+    await renderPage();
 
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      expect(screen.getByText('u1')).toBeInTheDocument();
-      expect(screen.getByText('u1@test.com')).toBeInTheDocument();
-      expect(screen.getByText('Not assigned')).toBeInTheDocument();
-    });
+    expect(screen.getByText('u1')).toBeInTheDocument();
+    expect(screen.getByText('u1@test.com')).toBeInTheDocument();
+    // Subjects column placeholder for a user without subjects
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/users$/));
+    expect(api.get).toHaveBeenCalledWith(expect.stringMatching(/\/subjects$/));
+    expect(api.get).not.toHaveBeenCalledWith(expect.stringMatching(/\/groups\/enabled$/));
   });
 
   it('shows error when fetch fails', async () => {
@@ -89,194 +141,333 @@ describe('Users page', () => {
   });
 
   it('shows empty state when no users are returned', async () => {
-    api.get.mockResolvedValue({ data: { users: [], groups: [] } });
+    await renderPage({ users: [], subjects: [] });
 
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
+    expect(screen.getByText('No admin or manager accounts')).toBeInTheDocument();
+  });
 
-    await waitFor(() => {
-      expect(screen.getByText('No admin or manager accounts')).toBeInTheDocument();
+  describe('sections by subject membership', () => {
+    it('splits regular users into "without a subject" and "in subjects" sections', async () => {
+      const users = [
+        { ...initialUsers[0], id: 'u1', username: 'bob', email: 'bob@t.com', subjects: [] },
+        {
+          ...initialUsers[0],
+          id: 'u2',
+          username: 'carol',
+          email: 'carol@t.com',
+          subjects: [SUBJECT_A],
+          memberships: [MEMBERSHIP_1],
+        },
+      ];
+      await renderPage({ users });
+
+      const withoutSection = screen.getByRole('heading', { name: /users without a subject/i }).closest('.mb-8');
+      expect(within(withoutSection).getByText('bob')).toBeInTheDocument();
+      expect(within(withoutSection).queryByText('carol')).not.toBeInTheDocument();
+
+      const inSection = screen.getByRole('heading', { name: /users in subjects/i }).closest('.mb-8');
+      expect(within(inSection).getByText('carol')).toBeInTheDocument();
+      expect(within(inSection).queryByText('bob')).not.toBeInTheDocument();
+    });
+
+    it('keeps admins and managers in the Administrators section', async () => {
+      const users = [
+        { ...initialUsers[0], id: 'u1', username: 'boss', role_name: 'admin', subjects: [] },
+        { ...initialUsers[0], id: 'u2', username: 'mgr', email: 'm@t.com', role_name: 'assignment_manager' },
+      ];
+      await renderPage({ users });
+
+      const adminSection = screen.getByRole('heading', { name: /administrators/i }).closest('.mb-8');
+      expect(within(adminSection).getByText('boss')).toBeInTheDocument();
+      expect(within(adminSection).getByText('mgr')).toBeInTheDocument();
     });
   });
 
-  it('assigns a group and shows success feedback', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  describe('Subjects column', () => {
+    it('renders subject names joined with a comma', async () => {
+      const users = [{ ...initialUsers[0], subjects: [SUBJECT_A, SUBJECT_B] }];
+      await renderPage({ users });
 
-    api.get
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } })
-      .mockResolvedValueOnce({
-        data: { users: [{ ...initialUsers[0], group_name: 'Group A' }] },
-      })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    api.put.mockResolvedValue({});
-
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /assign group/i })).toBeInTheDocument();
+      expect(screen.getByText('Subject A, Subject B')).toBeInTheDocument();
+      expect(screen.getAllByRole('columnheader', { name: 'Subjects' }).length).toBeGreaterThan(0);
+      expect(screen.queryByRole('columnheader', { name: 'Current Group' })).not.toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole('button', { name: /assign group/i }));
-    await user.selectOptions(
-      screen.getByRole('combobox', { name: /assign to group/i }),
-      'g0000000-0000-0000-0000-000000000002'
-    );
-    await user.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(api.put).toHaveBeenCalledWith(
-        expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
-        { groupId: 'g0000000-0000-0000-0000-000000000002' }
-      );
-      expect(screen.getByText('User group updated successfully')).toBeInTheDocument();
+    it('renders an em dash when the user has no subjects', async () => {
+      await renderPage();
+      expect(screen.getByText('—')).toBeInTheDocument();
     });
 
-    jest.advanceTimersByTime(3000);
-    await waitFor(() => {
-      expect(screen.queryByText('User group updated successfully')).not.toBeInTheDocument();
+    it('adds a title tooltip listing memberships as Subject › Assignment › Group lines', async () => {
+      const secondMembership = {
+        assignment_id: 'bbbbbbbb-0000-4000-8000-000000000002',
+        assignment_name: 'Assignment 2',
+        subject_id: SUBJECT_B.id,
+        subject_name: 'Subject B',
+        group_id: 'cccccccc-0000-4000-8000-000000000002',
+        group_name: 'Group 2',
+      };
+      const users = [
+        { ...initialUsers[0], subjects: [SUBJECT_A, SUBJECT_B], memberships: [MEMBERSHIP_1, secondMembership] },
+      ];
+      await renderPage({ users });
+
+      const cell = screen.getByText('Subject A, Subject B');
+      expect(cell).toHaveAttribute('title', 'Subject A › Assignment 1 › Group 1\nSubject B › Assignment 2 › Group 2');
     });
   });
 
-  it('hides full groups from the assign group dropdown', async () => {
-    const user = userEvent.setup();
-    const fullGroup = {
-      id: 'g0000000-0000-0000-0000-000000000003',
-      name: 'Full Group',
-      max_members: 2,
-      member_count: 2,
-    };
-    const openGroup = {
-      id: 'g0000000-0000-0000-0000-000000000004',
-      name: 'Open Group',
-      max_members: 5,
-      member_count: 2,
-    };
-
-    api.get
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: [fullGroup, openGroup] } });
-
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => expect(screen.getByRole('button', { name: /assign group/i })).toBeInTheDocument());
-    await user.click(screen.getByRole('button', { name: /assign group/i }));
-
-    const select = screen.getByRole('combobox', { name: /assign to group/i });
-    expect(select).toBeInTheDocument();
-    expect(select).not.toHaveDisplayValue('Full Group');
-    expect(within(select).queryByRole('option', { name: /full group/i })).not.toBeInTheDocument();
-    expect(within(select).getByRole('option', { name: /open group/i })).toBeInTheDocument();
-  });
-
-  it('removes user from group when "No Group" is selected', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    const usersInGroup = [
-      { ...initialUsers[0], group_name: 'Group A', group_id: 'g0000000-0000-0000-0000-000000000002' },
+  describe('subject filter', () => {
+    const filterUsers = [
+      { ...initialUsers[0], id: 'u1', username: 'bob', email: 'bob@t.com', subjects: [SUBJECT_A] },
+      { ...initialUsers[0], id: 'u2', username: 'carol', email: 'carol@t.com', subjects: [SUBJECT_B] },
     ];
 
-    api.get
-      .mockResolvedValueOnce({ data: { users: usersInGroup } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } })
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    api.put.mockResolvedValue({});
+    it('offers All subjects plus each subject as options', async () => {
+      await renderPage({ users: filterUsers });
 
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /assign group/i })).toBeInTheDocument();
+      const select = screen.getByRole('combobox', { name: /filter by subject/i });
+      const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+      expect(options).toEqual(['All subjects', 'Subject A', 'Subject B']);
     });
 
-    await user.click(screen.getByRole('button', { name: /assign group/i }));
-    // "No Group" (value="") is already the default selection
-    await user.click(screen.getByRole('button', { name: /save/i }));
+    it('filters users client-side by selected subject', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: filterUsers });
 
-    await waitFor(() => {
-      expect(api.put).toHaveBeenCalledWith(
-        expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
-        {
-          groupId: null,
-        }
-      );
-      expect(screen.getByText('User group updated successfully')).toBeInTheDocument();
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by subject/i }), SUBJECT_A.id);
+
+      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.queryByText('carol')).not.toBeInTheDocument();
     });
 
-    jest.advanceTimersByTime(3000);
-    await waitFor(() => {
-      expect(screen.queryByText('User group updated successfully')).not.toBeInTheDocument();
+    it('clear filters resets the subject filter', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: filterUsers });
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by subject/i }), SUBJECT_B.id);
+      expect(screen.queryByText('bob')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /clear filters/i }));
+
+      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.getByText('carol')).toBeInTheDocument();
     });
   });
 
-  it('shows API error when group update fails', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  describe('Assign Group modal', () => {
+    const memberUser = {
+      ...initialUsers[0],
+      subjects: [SUBJECT_A],
+      memberships: [],
+    };
 
-    api.get
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-    api.put.mockRejectedValue({ response: { data: { error: 'Update denied' } } });
+    it('opens AssignGroupModal for the right user when the row action is clicked', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: [memberUser] });
 
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
+      await user.click(screen.getByRole('button', { name: /assign group/i }));
 
-    await waitFor(() => {
+      const heading = screen.getByRole('heading', { name: 'Assign Group — u1' });
+      expect(heading).toBeInTheDocument();
+      // Cascade offers only the target user's subjects
+      const modal = heading.closest('.fixed');
+      expect(within(modal).getByRole('option', { name: 'Subject A' })).toBeInTheDocument();
+      expect(within(modal).queryByRole('option', { name: 'Subject B' })).not.toBeInTheDocument();
+    });
+
+    it('assigns via the cascade, PUTs assignmentId+groupId, refetches and shows success', async () => {
+      const user = userEvent.setup();
+      api.put.mockResolvedValue({ data: {} });
+      await renderPage({ users: [memberUser] });
+
+      await user.click(screen.getByRole('button', { name: /assign group/i }));
+      await user.selectOptions(screen.getByLabelText('Subject'), SUBJECT_A.id);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Assignment'), ASSIGNMENT_1.id);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Group'), GROUP_1.id);
+
+      const callsBefore = api.get.mock.calls.filter((c) => /\/users$/.test(c[0])).length;
+      await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+      await waitFor(() => {
+        expect(api.put).toHaveBeenCalledWith(
+          expect.stringMatching(/\/users\/u0000000-0000-0000-0000-000000000001\/group$/),
+          { assignmentId: ASSIGNMENT_1.id, groupId: GROUP_1.id }
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText('User group updated successfully')).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Assign Group — u1' })).not.toBeInTheDocument();
+        expect(api.get.mock.calls.filter((c) => /\/users$/.test(c[0])).length).toBeGreaterThan(callsBefore);
+      });
+    });
+
+    it('shows the API error inside the modal and keeps it open on failure', async () => {
+      const user = userEvent.setup();
+      api.put.mockRejectedValue({ response: { data: { error: 'Update denied' } } });
+      await renderPage({ users: [memberUser] });
+
+      await user.click(screen.getByRole('button', { name: /assign group/i }));
+      await user.selectOptions(screen.getByLabelText('Subject'), SUBJECT_A.id);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Assignment'), ASSIGNMENT_1.id);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Group'), GROUP_1.id);
+      await user.click(screen.getByRole('button', { name: 'Assign' }));
+
+      await waitFor(() => expect(screen.getByText('Update denied')).toBeInTheDocument());
+      expect(screen.getByRole('heading', { name: 'Assign Group — u1' })).toBeInTheDocument();
+    });
+
+    it('closes the modal without a PUT when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: [memberUser] });
+
+      await user.click(screen.getByRole('button', { name: /assign group/i }));
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.queryByRole('heading', { name: 'Assign Group — u1' })).not.toBeInTheDocument();
+      expect(api.put).not.toHaveBeenCalled();
+    });
+
+    it('shows Assign Group for assignment managers', async () => {
+      useAuth.mockReturnValue({
+        user: { id: 'u0000000-0000-0000-0000-000000000098', username: 'mgr', role: 'assignment_manager' },
+        isAdmin: false,
+        isAssignmentManager: true,
+      });
+      await renderPage({ users: [memberUser] });
+
       expect(screen.getByRole('button', { name: /assign group/i })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole('button', { name: /assign group/i }));
-    await user.selectOptions(
-      screen.getByRole('combobox', { name: /assign to group/i }),
-      'g0000000-0000-0000-0000-000000000002'
-    );
-    await user.click(screen.getByRole('button', { name: /save/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Update denied')).toBeInTheDocument();
+    it('hides Assign Group for admin-role rows', async () => {
+      await renderPage({ users: [{ ...initialUsers[0], role_name: 'admin' }] });
+      expect(screen.queryByRole('button', { name: /assign group/i })).not.toBeInTheDocument();
     });
 
-    jest.advanceTimersByTime(3000);
-    await waitFor(() => {
-      expect(screen.queryByText('Update denied')).not.toBeInTheDocument();
+    it('hides Assign Group for assignment_manager-role rows', async () => {
+      await renderPage({ users: [{ ...initialUsers[0], role_name: 'assignment_manager' }] });
+      expect(screen.queryByRole('button', { name: /assign group/i })).not.toBeInTheDocument();
+    });
+
+    it('hides Assign Group when the viewer is a regular user', async () => {
+      useAuth.mockReturnValue({
+        user: { id: 'u0000000-0000-0000-0000-000000000001', username: 'u1', role: 'user' },
+        isAdmin: false,
+        isAssignmentManager: false,
+      });
+      await renderPage({ users: [memberUser] });
+
+      expect(screen.queryByRole('button', { name: /assign group/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Manage Subjects modal', () => {
+    const enrolledUser = {
+      ...initialUsers[0],
+      subjects: [SUBJECT_A],
+      memberships: [MEMBERSHIP_1],
+    };
+
+    it('shows the Manage Subjects action for admins on user rows only', async () => {
+      const users = [enrolledUser, { ...initialUsers[0], id: 'u9', username: 'mgr', role_name: 'assignment_manager' }];
+      await renderPage({ users });
+
+      expect(screen.getAllByRole('button', { name: /manage subjects/i })).toHaveLength(1);
+    });
+
+    it('hides the Manage Subjects action for assignment managers', async () => {
+      useAuth.mockReturnValue({
+        user: { id: 'u0000000-0000-0000-0000-000000000098', username: 'mgr', role: 'assignment_manager' },
+        isAdmin: false,
+        isAssignmentManager: true,
+      });
+      await renderPage({ users: [enrolledUser] });
+
+      expect(screen.queryByRole('button', { name: /manage subjects/i })).not.toBeInTheDocument();
+    });
+
+    it('opens the modal with checkboxes pre-checked for the user subjects', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: [enrolledUser] });
+
+      await user.click(screen.getByRole('button', { name: /manage subjects/i }));
+
+      expect(screen.getByRole('heading', { name: 'Manage Subjects — u1' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Subject A' })).toBeChecked();
+      expect(screen.getByRole('checkbox', { name: 'Subject B' })).not.toBeChecked();
+    });
+
+    it('diff-saves: POST for added subjects and DELETE for removed, then refetches with success', async () => {
+      const user = userEvent.setup();
+      api.post.mockResolvedValue({ data: {} });
+      api.delete.mockResolvedValue({ data: {} });
+      await renderPage({ users: [enrolledUser] });
+
+      await user.click(screen.getByRole('button', { name: /manage subjects/i }));
+      await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+      await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(expect.stringContaining(`/subjects/${SUBJECT_B.id}/users`), {
+          userIds: [enrolledUser.id],
+        });
+      });
+      expect(api.delete).toHaveBeenCalledWith(
+        expect.stringContaining(`/subjects/${SUBJECT_A.id}/users/${enrolledUser.id}`)
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Subjects updated successfully')).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Manage Subjects — u1' })).not.toBeInTheDocument();
+      });
+    });
+
+    it('warns inside the modal when unchecking a subject that holds group memberships', async () => {
+      const user = userEvent.setup();
+      await renderPage({ users: [enrolledUser] });
+
+      await user.click(screen.getByRole('button', { name: /manage subjects/i }));
+      expect(screen.queryByText(/removing a subject also removes/i)).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox', { name: 'Subject A' }));
+      expect(
+        screen.getByText(/removing a subject also removes the user's group memberships in it\./i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows the API error and keeps the modal open when saving fails', async () => {
+      const user = userEvent.setup();
+      api.post.mockRejectedValue({ response: { data: { error: 'Enrolment failed' } } });
+      await renderPage({ users: [enrolledUser] });
+
+      await user.click(screen.getByRole('button', { name: /manage subjects/i }));
+      await user.click(screen.getByRole('checkbox', { name: 'Subject B' }));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(screen.getByText('Enrolment failed')).toBeInTheDocument());
+      expect(screen.getByRole('heading', { name: 'Manage Subjects — u1' })).toBeInTheDocument();
+      expect(screen.queryByText('Subjects updated successfully')).not.toBeInTheDocument();
     });
   });
 
   describe('Create User', () => {
     const setupRenderedPage = async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      await renderPage();
+    };
 
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
+    const fillRequiredFields = async (user) => {
+      await user.type(screen.getByPlaceholderText('Enter username'), 'newuser');
+      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
+      await user.type(screen.getByPlaceholderText('Enter first name'), 'Test');
+      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+    };
 
-      await waitFor(() => {
-        expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      });
+    const selectSubject = async (user) => {
+      await user.selectOptions(screen.getByLabelText('Subject'), SUBJECT_A.id);
     };
 
     it('shows Create User button for admin', async () => {
@@ -316,22 +507,32 @@ describe('Users page', () => {
       expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
     });
 
-    it('creates a user and shows success feedback', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    it('blocks creating a role=user account without a subject', async () => {
+      const user = userEvent.setup();
       await setupRenderedPage();
 
-      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
-      // Mock refetch after create
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillRequiredFields(user);
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(screen.getByText('Subject is required')).toBeInTheDocument();
+      expect(api.post).not.toHaveBeenCalled();
+      expect(screen.getByText('Create New User')).toBeInTheDocument();
+    });
+
+    it('creates a user with subjectIds and optional placement and shows success', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      api.post.mockResolvedValue({ data: { message: 'User created successfully', user: {} } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'newuser');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Test');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Assignment'), ASSIGNMENT_1.id);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Group 1 (2/5)' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Group'), GROUP_1.id);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -341,18 +542,129 @@ describe('Users page', () => {
             username: 'newuser',
             email: 'new@test.com',
             role: 'user',
+            subjectIds: [SUBJECT_A.id],
+            assignmentId: ASSIGNMENT_1.id,
+            groupId: GROUP_1.id,
           })
         );
-        expect(screen.getByText('User created successfully')).toBeInTheDocument();
       });
-
-      // Modal should be closed
-      expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
-
-      jest.advanceTimersByTime(3000);
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('assignmentIds');
       await waitFor(() => {
-        expect(screen.queryByText('User created successfully')).not.toBeInTheDocument();
+        expect(screen.getByText('User created successfully')).toBeInTheDocument();
+        expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
       });
+    });
+
+    it('omits assignmentId and groupId when only a subject is selected', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      api.post.mockResolvedValue({ data: { message: 'ok', user: {} } });
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillRequiredFields(user);
+      await selectSubject(user);
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(
+          expect.stringMatching(/\/users$/),
+          expect.objectContaining({ subjectIds: [SUBJECT_A.id] })
+        );
+      });
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('assignmentId');
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('groupId');
+    });
+
+    it('shows a yellow warning banner when creation succeeds with a warning', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      api.post.mockResolvedValue({
+        data: { message: 'ok', user: {}, warning: 'User created but the setup email failed to send' },
+      });
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillRequiredFields(user);
+      await selectSubject(user);
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('User created but the setup email failed to send')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Create New User')).not.toBeInTheDocument();
+      const banner = screen.getByText('User created but the setup email failed to send').closest('div');
+      expect(banner.className).toContain('bg-yellow-50');
+    });
+
+    it('creates an assignment manager with assignmentIds scope and no subjectIds', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      api.post.mockResolvedValue({ data: { message: 'ok', user: {} } });
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillRequiredFields(user);
+      const roleSelect = screen
+        .getAllByRole('combobox')
+        .find((el) => el.querySelector('option[value="assignment_manager"]') && !el.querySelector('option[value=""]'));
+      await user.selectOptions(roleSelect, 'assignment_manager');
+
+      // AM cascade hides the group select
+      expect(screen.queryByLabelText('Group')).not.toBeInTheDocument();
+
+      await selectSubject(user);
+      await waitFor(() => expect(screen.getByRole('option', { name: 'Assignment 1' })).toBeInTheDocument());
+      await user.selectOptions(screen.getByLabelText('Assignment'), ASSIGNMENT_1.id);
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(
+          expect.stringMatching(/\/users$/),
+          expect.objectContaining({ role: 'assignment_manager', assignmentIds: [ASSIGNMENT_1.id] })
+        );
+      });
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('subjectIds');
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('groupId');
+    });
+
+    it('creates an assignment manager without assignmentIds when no assignment is chosen', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      api.post.mockResolvedValue({ data: { message: 'ok', user: {} } });
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await fillRequiredFields(user);
+      const roleSelect = screen
+        .getAllByRole('combobox')
+        .find((el) => el.querySelector('option[value="assignment_manager"]') && !el.querySelector('option[value=""]'));
+      await user.selectOptions(roleSelect, 'assignment_manager');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        expect(api.post).toHaveBeenCalledWith(
+          expect.stringMatching(/\/users$/),
+          expect.objectContaining({ role: 'assignment_manager' })
+        );
+      });
+      expect(api.post.mock.calls[0][1]).not.toHaveProperty('assignmentIds');
+    });
+
+    it('resets the cascade when the role changes', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      await user.click(screen.getByRole('button', { name: /create user/i }));
+      await selectSubject(user);
+      expect(screen.getByLabelText('Subject')).toHaveValue(SUBJECT_A.id);
+
+      const roleSelect = screen
+        .getAllByRole('combobox')
+        .find((el) => el.querySelector('option[value="assignment_manager"]') && !el.querySelector('option[value=""]'));
+      await user.selectOptions(roleSelect, 'assignment_manager');
+
+      expect(screen.getByLabelText('Subject')).toHaveValue('');
     });
 
     it('shows generic error when user creation fails with 409', async () => {
@@ -362,10 +674,8 @@ describe('Users page', () => {
       api.post.mockRejectedValue({ response: { data: { error: 'Username already exists' }, status: 409 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'existing');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'e@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Test');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -380,10 +690,8 @@ describe('Users page', () => {
       api.post.mockRejectedValue({ response: { data: { error: 'Invalid input' }, status: 400 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'baduser');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'bad@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Bad');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -398,10 +706,8 @@ describe('Users page', () => {
       api.post.mockRejectedValue({ response: { data: { error: 'Server error' }, status: 500 } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'baduser');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'bad@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Bad');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -422,29 +728,11 @@ describe('Users page', () => {
       expect(options).toEqual(['user', 'assignment_manager', 'admin']);
     });
 
-    it('allows selecting a group in create form', async () => {
+    it('sends firstName, lastName and studentId when creating a user', async () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      await user.click(screen.getByRole('button', { name: /create user/i }));
-
-      const groupSelect = screen
-        .getAllByRole('combobox')
-        .find((el) => el.querySelector('option[value="g0000000-0000-0000-0000-000000000002"]'));
-      expect(groupSelect).toBeTruthy();
-      await user.selectOptions(groupSelect, 'g0000000-0000-0000-0000-000000000002');
-      expect(groupSelect.value).toBe('g0000000-0000-0000-0000-000000000002');
-    });
-
-    it('sends firstName and lastName when creating a user', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      await setupRenderedPage();
-
-      api.post.mockResolvedValue({ data: { message: 'User created' } });
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.post.mockResolvedValue({ data: { message: 'User created', user: {} } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
       await user.type(screen.getByPlaceholderText('Enter username'), 'jdoe');
@@ -452,6 +740,7 @@ describe('Users page', () => {
       await user.type(screen.getByPlaceholderText('Enter first name'), 'John');
       await user.type(screen.getByPlaceholderText('Enter last name'), 'Doe');
       await user.type(screen.getByPlaceholderText('Enter student ID'), 'ST99');
+      await selectSubject(user);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -479,20 +768,14 @@ describe('Users page', () => {
     });
 
     it('passes sendSetupEmail: false when checkbox is unchecked', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupRenderedPage();
 
-      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.post.mockResolvedValue({ data: { message: 'User created successfully', user: {} } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'newuser');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Test');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => {
@@ -504,20 +787,14 @@ describe('Users page', () => {
     });
 
     it('passes sendSetupEmail: true when checkbox is checked', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupRenderedPage();
 
-      api.post.mockResolvedValue({ data: { message: 'User created successfully' } });
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      api.post.mockResolvedValue({ data: { message: 'User created successfully', user: {} } });
 
       await user.click(screen.getByRole('button', { name: /create user/i }));
-      await user.type(screen.getByPlaceholderText('Enter username'), 'newuser');
-      await user.type(screen.getByPlaceholderText('Enter email'), 'new@test.com');
-      await user.type(screen.getByPlaceholderText('Enter first name'), 'Test');
-      await user.type(screen.getByPlaceholderText('Enter last name'), 'User');
+      await fillRequiredFields(user);
+      await selectSubject(user);
       await user.click(screen.getByRole('checkbox', { name: /send.*set password.*email now/i }));
       await user.click(screen.getByRole('button', { name: /^create$/i }));
 
@@ -532,54 +809,16 @@ describe('Users page', () => {
 
   it('displays formatted role names instead of raw values', async () => {
     const usersWithRoles = [
-      {
-        id: 'u0000000-0000-0000-0000-000000000001',
-        username: 'u1',
-        email: 'u1@test.com',
-        role_name: 'admin',
-        group_name: null,
-        student_id: null,
-        role_id: 1,
-        enabled: true,
-      },
-      {
-        id: 'u0000000-0000-0000-0000-000000000010',
-        username: 'u2',
-        email: 'u2@test.com',
-        role_name: 'assignment_manager',
-        group_name: null,
-        student_id: null,
-        role_id: 2,
-        enabled: true,
-      },
-      {
-        id: 'u0000000-0000-0000-0000-000000000011',
-        username: 'u3',
-        email: 'u3@test.com',
-        role_name: 'user',
-        group_name: null,
-        student_id: null,
-        role_id: 3,
-        enabled: true,
-      },
+      { ...initialUsers[0], id: 'u1', username: 'a1', email: 'a1@t.com', role_name: 'admin', role_id: 1 },
+      { ...initialUsers[0], id: 'u2', username: 'a2', email: 'a2@t.com', role_name: 'assignment_manager', role_id: 2 },
+      { ...initialUsers[0], id: 'u3', username: 'a3', email: 'a3@t.com', role_name: 'user', role_id: 3 },
     ];
 
-    api.get
-      .mockResolvedValueOnce({ data: { users: usersWithRoles } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
+    await renderPage({ users: usersWithRoles });
 
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Assignment Manager').length).toBeGreaterThan(0);
 
-    await waitFor(() => {
-      expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Assignment Manager').length).toBeGreaterThan(0);
-    });
-
-    // Verify raw role values don't appear in role badge spans
     const roleBadges = document.querySelectorAll('span.rounded-full');
     const badgeTexts = Array.from(roleBadges).map((el) => el.textContent);
     expect(badgeTexts).not.toContain('admin');
@@ -589,83 +828,9 @@ describe('Users page', () => {
     expect(badgeTexts).toContain('User');
   });
 
-  it('hides Assign Group button for admin-role users', async () => {
-    const adminUser = {
-      ...initialUsers[0],
-      role_name: 'admin',
-    };
-    api.get
-      .mockResolvedValueOnce({ data: { users: [adminUser] } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
-    expect(screen.queryByRole('button', { name: /assign group/i })).not.toBeInTheDocument();
-  });
-
-  it('hides Assign Group button for assignment_manager-role users', async () => {
-    const managerUser = {
-      ...initialUsers[0],
-      role_name: 'assignment_manager',
-    };
-    api.get
-      .mockResolvedValueOnce({ data: { users: [managerUser] } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
-    expect(screen.queryByRole('button', { name: /assign group/i })).not.toBeInTheDocument();
-  });
-
-  it('cancels group assignment inline', async () => {
-    const user = userEvent.setup();
-
-    api.get
-      .mockResolvedValueOnce({ data: { users: initialUsers } })
-      .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-    render(
-      <MemoryRouter>
-        <Users />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /assign group/i })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: /assign group/i }));
-    expect(screen.getByRole('combobox', { name: /assign to group/i })).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(screen.queryByRole('combobox', { name: /assign to group/i })).not.toBeInTheDocument();
-  });
-
   describe('Edit User', () => {
-    const setupRenderedPage = async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      });
+    const setupRenderedPage = async (users = initialUsers) => {
+      await renderPage({ users });
     };
 
     it('shows Edit button for admin on all users', async () => {
@@ -706,6 +871,35 @@ describe('Users page', () => {
       expect(screen.queryByText('Edit User')).not.toBeInTheDocument();
     });
 
+    it('shows a read-only memberships summary for role user', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage([{ ...initialUsers[0], subjects: [SUBJECT_A], memberships: [MEMBERSHIP_1] }]);
+
+      await user.click(screen.getByRole('button', { name: /edit user profile/i }));
+
+      expect(screen.getByText('Memberships')).toBeInTheDocument();
+      expect(screen.getByText('Subject A › Assignment 1 › Group 1')).toBeInTheDocument();
+    });
+
+    it('shows None in the memberships summary when the user has no memberships', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage();
+
+      await user.click(screen.getByRole('button', { name: /edit user profile/i }));
+
+      expect(screen.getByText('Memberships')).toBeInTheDocument();
+      expect(screen.getByText('None')).toBeInTheDocument();
+    });
+
+    it('does not show the memberships summary for admin-role users', async () => {
+      const user = userEvent.setup();
+      await setupRenderedPage([{ ...initialUsers[0], role_name: 'admin' }]);
+
+      await user.click(screen.getByRole('button', { name: /edit user profile/i }));
+
+      expect(screen.queryByText('Memberships')).not.toBeInTheDocument();
+    });
+
     it('admin can edit user and save successfully', async () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -713,7 +907,6 @@ describe('Users page', () => {
 
       await user.click(screen.getByRole('button', { name: /edit user profile/i }));
 
-      // Username field is disabled and cannot be changed
       const usernameInput = screen.getByDisplayValue('u1');
       expect(usernameInput.disabled).toBe(true);
 
@@ -726,9 +919,6 @@ describe('Users page', () => {
       await user.type(lastNameInput, 'NewLast');
 
       api.put.mockResolvedValue({});
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -740,7 +930,6 @@ describe('Users page', () => {
         expect(screen.getByText('User updated successfully')).toBeInTheDocument();
       });
 
-      // Modal should be closed
       expect(screen.queryByText('Edit User')).not.toBeInTheDocument();
 
       jest.advanceTimersByTime(3000);
@@ -750,30 +939,23 @@ describe('Users page', () => {
     });
 
     it('admin can edit email, studentId, and enabled fields', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupRenderedPage();
 
       await user.click(screen.getByRole('button', { name: /edit user profile/i }));
 
-      // Edit email
       const emailInput = screen.getByDisplayValue('u1@test.com');
       await user.clear(emailInput);
       await user.type(emailInput, 'new@test.com');
 
-      // Edit studentId
       const studentInput = screen.getByDisplayValue('s1');
       await user.clear(studentInput);
       await user.type(studentInput, 's999');
 
-      // Toggle enabled
       const enabledCheckbox = screen.getByRole('checkbox', { name: /enabled/i });
       await user.click(enabledCheckbox);
 
       api.put.mockResolvedValue({});
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -797,7 +979,6 @@ describe('Users page', () => {
 
       await user.click(screen.getByRole('button', { name: /edit user profile/i }));
 
-      // Admin should see role dropdown and enabled checkbox
       expect(screen.getByText('Enabled')).toBeInTheDocument();
       const roleSelects = screen.getAllByRole('combobox');
       const roleSelect = roleSelects.find((el) => el.querySelector('option[value="admin"]'));
@@ -815,7 +996,6 @@ describe('Users page', () => {
 
       await user.click(screen.getByRole('button', { name: /edit user profile/i }));
 
-      // Assignment managers cannot change role but can toggle enabled
       const modal = screen.getByText('Edit User').closest('div');
       expect(within(modal).queryByLabelText(/role/i)).not.toBeInTheDocument();
       expect(within(modal).getByText('Enabled')).toBeInTheDocument();
@@ -847,9 +1027,6 @@ describe('Users page', () => {
       await user.selectOptions(roleSelect, 'assignment_manager');
 
       api.put.mockResolvedValue({});
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -876,9 +1053,6 @@ describe('Users page', () => {
       await user.click(enabledCheckbox);
 
       api.put.mockResolvedValue({});
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /save/i }));
 
@@ -894,42 +1068,35 @@ describe('Users page', () => {
   describe('CSV Export', () => {
     const multiUsers = [
       {
+        ...initialUsers[0],
         id: 'u0000000-0000-0000-0000-000000000001',
         username: 'admin1',
         first_name: 'Ad',
         last_name: 'Min',
         email: 'admin@test.com',
         role_name: 'admin',
-        group_name: null,
         student_id: null,
         role_id: 1,
-        enabled: true,
       },
       {
+        ...initialUsers[0],
         id: 'u0000000-0000-0000-0000-000000000002',
-        username: 'nogroup',
+        username: 'nosubject',
         first_name: 'No',
-        last_name: 'Group',
-        email: 'nogroup@test.com',
-        role_name: 'user',
-        group_name: null,
+        last_name: 'Subject',
+        email: 'nosubject@test.com',
         student_id: 's2',
-        group_id: null,
-        role_id: 3,
-        enabled: true,
       },
       {
+        ...initialUsers[0],
         id: 'u0000000-0000-0000-0000-000000000003',
-        username: 'grouped',
+        username: 'enrolled',
         first_name: 'In',
-        last_name: 'Group',
-        email: 'grouped@test.com',
-        role_name: 'user',
-        group_name: 'Team A',
+        last_name: 'Subject',
+        email: 'enrolled@test.com',
         student_id: 's3',
-        group_id: 'g0000000-0000-0000-0000-000000000001',
-        role_id: 3,
-        enabled: true,
+        subjects: [SUBJECT_A],
+        memberships: [MEMBERSHIP_1],
       },
     ];
 
@@ -938,19 +1105,7 @@ describe('Users page', () => {
     let anchorClick;
 
     const setupRenderedPage = async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: multiUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      });
+      await renderPage({ users: multiUsers });
     };
 
     beforeEach(() => {
@@ -973,8 +1128,8 @@ describe('Users page', () => {
     it('shows per-section export buttons', async () => {
       await setupRenderedPage();
       expect(screen.getByRole('button', { name: /export administrators/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /export users without a group/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /export users in a group/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /export users without a subject/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /export users in subjects/i })).toBeInTheDocument();
     });
 
     it('triggers download when Export All is clicked', async () => {
@@ -1004,35 +1159,35 @@ describe('Users page', () => {
       expect(createObjectURL).toHaveBeenCalledTimes(1);
       const text = await readBlob(createObjectURL.mock.calls[0][0]);
       expect(text).toContain('admin1');
-      expect(text).not.toContain('nogroup');
-      expect(text).not.toContain('grouped');
+      expect(text).not.toContain('nosubject');
+      expect(text).not.toContain('enrolled');
     });
 
-    it('exports only ungrouped users when section export is clicked', async () => {
+    it('exports only subject-less users when section export is clicked', async () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      await user.click(screen.getByRole('button', { name: /export users without a group/i }));
+      await user.click(screen.getByRole('button', { name: /export users without a subject/i }));
 
       const text = await readBlob(createObjectURL.mock.calls[0][0]);
-      expect(text).toContain('nogroup');
+      expect(text).toContain('nosubject');
       expect(text).not.toContain('admin1');
-      expect(text).not.toContain('grouped');
+      expect(text).not.toContain('enrolled');
     });
 
-    it('exports only grouped users when section export is clicked', async () => {
+    it('exports only enrolled users when section export is clicked', async () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
-      await user.click(screen.getByRole('button', { name: /export users in a group/i }));
+      await user.click(screen.getByRole('button', { name: /export users in subjects/i }));
 
       const text = await readBlob(createObjectURL.mock.calls[0][0]);
-      expect(text).toContain('grouped');
+      expect(text).toContain('enrolled');
       expect(text).not.toContain('admin1');
-      expect(text).not.toContain('nogroup');
+      expect(text).not.toContain('nosubject');
     });
 
-    it('CSV includes correct headers and data', async () => {
+    it('CSV includes Subjects and Groups columns with joined values', async () => {
       const user = userEvent.setup();
       await setupRenderedPage();
 
@@ -1040,22 +1195,18 @@ describe('Users page', () => {
 
       const text = await readBlob(createObjectURL.mock.calls[0][0]);
       const lines = text.split('\n');
-      expect(lines[0]).toBe('Username,First Name,Last Name,Email,Role,Group,Student ID');
+      expect(lines[0]).toBe('Username,First Name,Last Name,Email,Role,Subjects,Groups,Student ID');
       expect(text).toContain('admin@test.com');
-      expect(text).toContain('Team A');
+      expect(text).toContain('Subject A');
+      expect(text).toContain('Assignment 1:Group 1');
+      expect(text).not.toContain('Group,Student ID');
     });
   });
 
   // ── Delete user ────────────────────────────────────────────────────────
   describe('Delete user', () => {
     const setupDeletePage = async (users = initialUsers) => {
-      api.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-      await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
+      await renderPage({ users });
     };
 
     it('shows Delete User button for other users when admin', async () => {
@@ -1069,7 +1220,6 @@ describe('Users page', () => {
         { ...initialUsers[0], id: 'u0000000-0000-0000-0000-000000000099', username: 'myself', email: 'm@t.com' },
       ];
       await setupDeletePage(usersWithSelf);
-      // only u1 (not myself) should have the button
       expect(screen.getAllByRole('button', { name: /delete user/i })).toHaveLength(1);
     });
 
@@ -1093,28 +1243,28 @@ describe('Users page', () => {
       expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
     });
 
-    it('shows group warning when user being deleted is in a group', async () => {
-      const userInGroup = {
+    it('warns and lists memberships when the user being deleted has group memberships', async () => {
+      const userWithMemberships = {
         ...initialUsers[0],
-        group_id: 'g0000000-0000-0000-0000-000000000002',
-        group_name: 'Group A',
+        subjects: [SUBJECT_A],
+        memberships: [MEMBERSHIP_1],
       };
       const user = userEvent.setup();
-      await setupDeletePage([userInGroup]);
+      await setupDeletePage([userWithMemberships]);
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
 
-      const modal = screen.getByText(/will be unassigned/i).closest('.bg-white');
-      expect(modal).toHaveTextContent(/group a/i);
+      const modal = screen.getByText(/will be removed/i).closest('.bg-white');
+      expect(modal).toHaveTextContent('Subject A › Assignment 1 › Group 1');
     });
 
-    it('does not show warning when user is not in a group', async () => {
+    it('does not show warning when user has no memberships', async () => {
       const user = userEvent.setup();
-      await setupDeletePage([{ ...initialUsers[0], group_id: null, group_name: null }]);
+      await setupDeletePage([{ ...initialUsers[0], subjects: [SUBJECT_A], memberships: [] }]);
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
 
-      expect(screen.queryByText(/will be unassigned/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/will be removed/i)).not.toBeInTheDocument();
     });
 
     it('delete modal has scrollable layout so action buttons remain accessible with many items', async () => {
@@ -1124,8 +1274,8 @@ describe('Users page', () => {
         id: `u0000000-0000-0000-0000-0000000000${String(i + 10).padStart(2, '0')}`,
         username: `user${i}`,
         email: `user${i}@test.com`,
-        group_id: 'g0000000-0000-0000-0000-000000000002',
-        group_name: 'Group A',
+        subjects: [SUBJECT_A],
+        memberships: [MEMBERSHIP_1],
       }));
       await setupDeletePage(manyUsers);
 
@@ -1143,13 +1293,12 @@ describe('Users page', () => {
     });
 
     it('deletes user after confirmation and shows success', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupDeletePage();
       api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
+      mockApiGet({ users: [] });
       await user.click(screen.getByRole('button', { name: /delete 1 user$/i }));
 
       await waitFor(() => {
@@ -1172,8 +1321,7 @@ describe('Users page', () => {
     });
 
     it('shows error when delete fails', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupDeletePage();
       api.delete.mockRejectedValue({ response: { data: { error: 'Cannot delete user' } } });
 
@@ -1212,7 +1360,7 @@ describe('Users page', () => {
       ];
       await setupDeletePage(twoUsers);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
 
       expect(screen.getByRole('button', { name: /delete \(2\)/i })).toBeInTheDocument();
     });
@@ -1225,26 +1373,24 @@ describe('Users page', () => {
       ];
       await setupDeletePage(usersWithSelf);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
 
-      // 'me' is the current user and must be excluded — only 1 user selected
       expect(screen.getByRole('button', { name: /delete \(1\)/i })).toBeInTheDocument();
     });
 
     it('bulk deletes all selected users and shows success', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       const twoUsers = [
         { ...initialUsers[0], id: 'u1', username: 'user1', email: 'u1@t.com' },
         { ...initialUsers[0], id: 'u2', username: 'user2', email: 'u2@t.com' },
       ];
       await setupDeletePage(twoUsers);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
       api.delete.mockResolvedValue({});
-      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
+      mockApiGet({ users: [] });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
@@ -1275,53 +1421,18 @@ describe('Users page', () => {
     };
 
     it('shows "Send Setup Email" button when pending users exist', async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: [pendingUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /send setup email/i })).toBeInTheDocument();
-      });
+      await renderPage({ users: [pendingUser] });
+      expect(screen.getByRole('button', { name: /send setup email/i })).toBeInTheDocument();
     });
 
     it('does not show "Send Setup Email" button when no pending users exist', async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: [activeUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      });
+      await renderPage({ users: [activeUser] });
       expect(screen.queryByRole('button', { name: /send setup email/i })).not.toBeInTheDocument();
     });
 
     it('shows confirmation modal when clicking Send Setup Emails button', async () => {
       const user = userEvent.setup();
-      api.get
-        .mockResolvedValueOnce({ data: { users: [pendingUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /send setup email/i })).toBeInTheDocument();
-      });
+      await renderPage({ users: [pendingUser] });
 
       await user.click(screen.getByRole('button', { name: /send setup email/i }));
 
@@ -1332,19 +1443,7 @@ describe('Users page', () => {
 
     it('cancels sending when Cancel is clicked in confirmation modal', async () => {
       const user = userEvent.setup();
-      api.get
-        .mockResolvedValueOnce({ data: { users: [pendingUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /send setup email/i })).toBeInTheDocument();
-      });
+      await renderPage({ users: [pendingUser] });
 
       await user.click(screen.getByRole('button', { name: /send setup email/i }));
       await user.click(screen.getByRole('button', { name: /cancel/i }));
@@ -1354,22 +1453,9 @@ describe('Users page', () => {
     });
 
     it('calls send-setup-emails API for all pending users after confirming', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      api.get
-        .mockResolvedValueOnce({ data: { users: [pendingUser, activeUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      const user = userEvent.setup();
+      await renderPage({ users: [pendingUser, activeUser] });
       api.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /send setup email/i })).toBeInTheDocument();
-      });
 
       await user.click(screen.getByRole('button', { name: /send setup email/i }));
       await user.click(screen.getByRole('button', { name: /^send$/i }));
@@ -1380,30 +1466,16 @@ describe('Users page', () => {
     });
 
     it('sends only to selected pending users when selection is active', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       const pendingUser2 = {
         ...pendingUser,
         id: 'u0000000-0000-0000-0000-000000000012',
         username: 'pending2',
         email: 'pending2@test.com',
       };
-      api.get
-        .mockResolvedValueOnce({ data: { users: [pendingUser, pendingUser2] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      await renderPage({ users: [pendingUser, pendingUser2] });
       api.post.mockResolvedValue({ data: { sent: 1, errors: [] } });
 
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText(/manage users/i)).toBeInTheDocument();
-      });
-
-      // Select just the first pending user
       const checkbox = screen.getByRole('checkbox', { name: /select pending1/i });
       await user.click(checkbox);
 
@@ -1421,41 +1493,29 @@ describe('Users page', () => {
   describe('User search', () => {
     const searchUsers = [
       {
+        ...initialUsers[0],
         id: 'u1',
         username: 'jdoe',
         email: 'jdoe@example.com',
         first_name: 'John',
         last_name: 'Doe',
         student_id: 'S001',
-        role_name: 'user',
-        group_name: null,
-        group_id: null,
-        enabled: true,
         status: 'active',
       },
       {
+        ...initialUsers[0],
         id: 'u2',
         username: 'msmith',
         email: 'msmith@example.com',
         first_name: 'Mary',
         last_name: 'Smith',
         student_id: 'S002',
-        role_name: 'user',
-        group_name: null,
-        group_id: null,
-        enabled: true,
         status: 'active',
       },
     ];
 
     const renderSearchPage = async () => {
-      api.get.mockResolvedValueOnce({ data: { users: searchUsers } }).mockResolvedValueOnce({ data: { groups: [] } });
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-      await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
+      await renderPage({ users: searchUsers });
     };
 
     it('shows all users when search is empty', async () => {
@@ -1521,23 +1581,16 @@ describe('Users page', () => {
   // ── handleDeleteConfirmed routing (single vs bulk) ─────────────────────
   describe('handleDeleteConfirmed routing (single vs bulk)', () => {
     const setupDeletePage = async (users = initialUsers) => {
-      api.get.mockResolvedValueOnce({ data: { users } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-      await waitFor(() => expect(screen.getByText(/manage users/i)).toBeInTheDocument());
+      await renderPage({ users });
     };
 
     it('single delete still uses DELETE /users/:id', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       await setupDeletePage();
       api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
 
       await user.click(screen.getByRole('button', { name: /delete user/i }));
+      mockApiGet({ users: [] });
       await user.click(screen.getByRole('button', { name: /delete 1 user$/i }));
 
       await waitFor(() => {
@@ -1549,19 +1602,18 @@ describe('Users page', () => {
     });
 
     it('multi-delete uses DELETE /users/bulk with correct ids array', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       const twoUsers = [
         { ...initialUsers[0], id: 'u1', username: 'user1', email: 'u1@t.com' },
         { ...initialUsers[0], id: 'u2', username: 'user2', email: 'u2@t.com' },
       ];
       await setupDeletePage(twoUsers);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
       api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
+      mockApiGet({ users: [] });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
@@ -1574,19 +1626,18 @@ describe('Users page', () => {
     });
 
     it('success toast is shown after bulk delete', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       const twoUsers = [
         { ...initialUsers[0], id: 'u1', username: 'user1', email: 'u1@t.com' },
         { ...initialUsers[0], id: 'u2', username: 'user2', email: 'u2@t.com' },
       ];
       await setupDeletePage(twoUsers);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
       api.delete.mockResolvedValueOnce({});
-      api.get.mockResolvedValueOnce({ data: { users: [] } }).mockResolvedValueOnce({ data: { groups: initialGroups } });
+      mockApiGet({ users: [] });
 
       await user.click(screen.getByRole('button', { name: /delete 2 users/i }));
 
@@ -1594,15 +1645,14 @@ describe('Users page', () => {
     });
 
     it('error toast is shown when bulk delete fails', async () => {
-      jest.useFakeTimers();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       const twoUsers = [
         { ...initialUsers[0], id: 'u1', username: 'user1', email: 'u1@t.com' },
         { ...initialUsers[0], id: 'u2', username: 'user2', email: 'u2@t.com' },
       ];
       await setupDeletePage(twoUsers);
 
-      await user.click(screen.getByRole('checkbox', { name: /select all users without a group/i }));
+      await user.click(screen.getByRole('checkbox', { name: /select all users without a subject/i }));
       await user.click(screen.getByRole('button', { name: /delete \(2\)/i }));
 
       api.delete.mockRejectedValue({ response: { data: { error: 'Bulk user delete failed' } } });
@@ -1615,49 +1665,23 @@ describe('Users page', () => {
 
   describe('data freshness on navigation and tab visibility', () => {
     it('re-fetches data when the browser tab becomes visible', async () => {
-      const staleUser = { ...initialUsers[0], group_name: null, group_id: null };
-      const freshUser = {
-        ...initialUsers[0],
-        group_name: 'Group A',
-        group_id: 'g0000000-0000-0000-0000-000000000002',
-      };
+      const staleUser = { ...initialUsers[0], subjects: [] };
+      const freshUser = { ...initialUsers[0], subjects: [SUBJECT_A], memberships: [MEMBERSHIP_1] };
 
-      // Initial load — user has no group
-      api.get
-        .mockResolvedValueOnce({ data: { users: [staleUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      await renderPage({ users: [staleUser] });
+      expect(screen.getByText('—')).toBeInTheDocument();
 
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => expect(screen.getByText('Not assigned')).toBeInTheDocument());
-
-      // Simulate another tab assigning the user to a group, then this tab regaining focus
-      api.get
-        .mockResolvedValueOnce({ data: { users: [freshUser] } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
+      // Simulate another tab enrolling the user, then this tab regaining focus
+      mockApiGet({ users: [freshUser] });
 
       Object.defineProperty(document, 'hidden', { value: false, configurable: true, writable: true });
       document.dispatchEvent(new Event('visibilitychange'));
 
-      await waitFor(() => expect(screen.getByText('Group A')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByTitle('Subject A › Assignment 1 › Group 1')).toBeInTheDocument());
     });
 
     it('does not re-fetch when the tab becomes hidden', async () => {
-      api.get
-        .mockResolvedValueOnce({ data: { users: initialUsers } })
-        .mockResolvedValueOnce({ data: { groups: initialGroups } });
-
-      render(
-        <MemoryRouter>
-          <Users />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => expect(screen.getByText('u1')).toBeInTheDocument());
+      await renderPage();
 
       const callsBefore = api.get.mock.calls.length;
 

--- a/frontend/tests/unit/pages/Users.test.jsx
+++ b/frontend/tests/unit/pages/Users.test.jsx
@@ -198,6 +198,40 @@ describe('Users page', () => {
       expect(screen.getByText('—')).toBeInTheDocument();
     });
 
+    it('renders suspended subjects with a (suspended) suffix and line-through styling', async () => {
+      const users = [
+        {
+          ...initialUsers[0],
+          subjects: [SUBJECT_A, { ...SUBJECT_B, membership_enabled: false }],
+        },
+      ];
+      await renderPage({ users });
+
+      const suspended = screen.getByText('Subject B (suspended)');
+      expect(suspended.className).toContain('line-through');
+      // The enabled subject (membership_enabled undefined) renders normally
+      const cell = suspended.closest('td');
+      const enabled = within(cell).getByText('Subject A');
+      expect(enabled.className || '').not.toContain('line-through');
+      expect(screen.queryByText('Subject A (suspended)')).not.toBeInTheDocument();
+    });
+
+    it('renders plain joined names when memberships are explicitly enabled', async () => {
+      const users = [
+        {
+          ...initialUsers[0],
+          subjects: [
+            { ...SUBJECT_A, membership_enabled: true },
+            { ...SUBJECT_B, membership_enabled: true },
+          ],
+        },
+      ];
+      await renderPage({ users });
+
+      expect(screen.getByText('Subject A, Subject B')).toBeInTheDocument();
+      expect(screen.queryByText(/\(suspended\)/)).not.toBeInTheDocument();
+    });
+
     it('adds a title tooltip listing memberships as Subject › Assignment › Group lines', async () => {
       const secondMembership = {
         assignment_id: 'bbbbbbbb-0000-4000-8000-000000000002',

--- a/frontend/tests/unit/utils/schemas.test.js
+++ b/frontend/tests/unit/utils/schemas.test.js
@@ -15,6 +15,8 @@ import {
   createUserSchema,
   changePasswordSchema,
   createGroupSchema,
+  createSubjectSchema,
+  createAssignmentSchema,
   updateGroupSchema,
   updateUserSchema,
   forgotPasswordSchema,
@@ -457,12 +459,79 @@ describe('createUserSchema', () => {
     expect(data.role).toBe('assignment_manager');
   });
 
-  it('accepts optional groupId as valid UUID', () => {
+  it('accepts optional groupId as valid UUID when assignmentId is provided', () => {
     const data = ok(createUserSchema, {
       ...validBody,
+      assignmentId: '660e8400-e29b-41d4-a716-446655440000',
       groupId: '550e8400-e29b-41d4-a716-446655440000',
     });
+    expect(data.assignmentId).toBe('660e8400-e29b-41d4-a716-446655440000');
     expect(data.groupId).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('rejects groupId without assignmentId', () => {
+    expect(
+      err(createUserSchema, {
+        ...validBody,
+        groupId: '550e8400-e29b-41d4-a716-446655440000',
+      })
+    ).toBe('Select an assignment first');
+  });
+
+  it('rejects groupId when assignmentId is an empty string (coerced to null)', () => {
+    expect(
+      err(createUserSchema, {
+        ...validBody,
+        assignmentId: '',
+        groupId: '550e8400-e29b-41d4-a716-446655440000',
+      })
+    ).toBe('Select an assignment first');
+  });
+
+  it('coerces empty string assignmentId to null', () => {
+    const data = ok(createUserSchema, { ...validBody, assignmentId: '' });
+    expect(data.assignmentId).toBeNull();
+  });
+
+  it('accepts assignmentId alone as a valid UUID', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      assignmentId: '660e8400-e29b-41d4-a716-446655440000',
+    });
+    expect(data.assignmentId).toBe('660e8400-e29b-41d4-a716-446655440000');
+  });
+
+  it('rejects invalid assignmentId (non-UUID)', () => {
+    expect(err(createUserSchema, { ...validBody, assignmentId: 'not-a-uuid' })).toEqual(expect.any(String));
+  });
+
+  it('accepts subjectIds as an array of UUIDs', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      subjectIds: ['550e8400-e29b-41d4-a716-446655440000', '660e8400-e29b-41d4-a716-446655440000'],
+    });
+    expect(data.subjectIds).toHaveLength(2);
+  });
+
+  it('accepts an empty subjectIds array', () => {
+    const data = ok(createUserSchema, { ...validBody, subjectIds: [] });
+    expect(data.subjectIds).toEqual([]);
+  });
+
+  it('rejects subjectIds containing a non-UUID entry', () => {
+    expect(err(createUserSchema, { ...validBody, subjectIds: ['not-a-uuid'] })).toBe('Invalid ID format');
+  });
+
+  it('accepts assignmentIds as an array of UUIDs', () => {
+    const data = ok(createUserSchema, {
+      ...validBody,
+      assignmentIds: ['550e8400-e29b-41d4-a716-446655440000'],
+    });
+    expect(data.assignmentIds).toEqual(['550e8400-e29b-41d4-a716-446655440000']);
+  });
+
+  it('rejects assignmentIds containing a non-UUID entry', () => {
+    expect(err(createUserSchema, { ...validBody, assignmentIds: ['nope'] })).toBe('Invalid ID format');
   });
 
   it('accepts optional studentId', () => {
@@ -525,12 +594,78 @@ describe('createUserSchema', () => {
 // ── createGroupSchema / updateGroupSchema ─────────────────────────────────────
 
 describe('createGroupSchema', () => {
-  it('accepts a valid group name', () => {
-    expect(ok(createGroupSchema, { name: 'Alpha' }).name).toBe('Alpha');
+  const validAssignmentId = '660e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a valid group name with assignmentId', () => {
+    const data = ok(createGroupSchema, { assignmentId: validAssignmentId, name: 'Alpha' });
+    expect(data.name).toBe('Alpha');
+    expect(data.assignmentId).toBe(validAssignmentId);
   });
 
   it('rejects empty name', () => {
-    expect(err(createGroupSchema, { name: '' })).toBe('Group name is required');
+    expect(err(createGroupSchema, { assignmentId: validAssignmentId, name: '' })).toBe('Group name is required');
+  });
+
+  it('rejects missing assignmentId', () => {
+    expect(err(createGroupSchema, { name: 'Alpha' })).toEqual(expect.any(String));
+  });
+
+  it('rejects non-UUID assignmentId', () => {
+    expect(err(createGroupSchema, { assignmentId: 'not-a-uuid', name: 'Alpha' })).toBe('Invalid assignment ID');
+  });
+});
+
+// ── createSubjectSchema ───────────────────────────────────────────────────────
+
+describe('createSubjectSchema', () => {
+  it('accepts a valid subject name', () => {
+    expect(ok(createSubjectSchema, { name: 'COMP90041' }).name).toBe('COMP90041');
+  });
+
+  it('sanitizes HTML from the name', () => {
+    expect(ok(createSubjectSchema, { name: '<b>Maths</b>' }).name).toBe('Maths');
+  });
+
+  it('rejects empty name', () => {
+    expect(err(createSubjectSchema, { name: '' })).toBe('Subject name is required');
+  });
+
+  it('rejects a name longer than 100 characters', () => {
+    expect(err(createSubjectSchema, { name: 'a'.repeat(101) })).toBe('Subject name must be at most 100 characters');
+  });
+
+  it('rejects missing name', () => {
+    expect(err(createSubjectSchema, {})).toEqual(expect.any(String));
+  });
+});
+
+// ── createAssignmentSchema ────────────────────────────────────────────────────
+
+describe('createAssignmentSchema', () => {
+  const validSubjectId = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a valid subjectId and name', () => {
+    const data = ok(createAssignmentSchema, { subjectId: validSubjectId, name: 'Assignment 1' });
+    expect(data.subjectId).toBe(validSubjectId);
+    expect(data.name).toBe('Assignment 1');
+  });
+
+  it('rejects empty name', () => {
+    expect(err(createAssignmentSchema, { subjectId: validSubjectId, name: '' })).toBe('Assignment name is required');
+  });
+
+  it('rejects a name longer than 100 characters', () => {
+    expect(err(createAssignmentSchema, { subjectId: validSubjectId, name: 'a'.repeat(101) })).toBe(
+      'Assignment name must be at most 100 characters'
+    );
+  });
+
+  it('rejects non-UUID subjectId', () => {
+    expect(err(createAssignmentSchema, { subjectId: 'not-a-uuid', name: 'Assignment 1' })).toBe('Invalid subject ID');
+  });
+
+  it('rejects missing subjectId', () => {
+    expect(err(createAssignmentSchema, { name: 'Assignment 1' })).toEqual(expect.any(String));
   });
 });
 

--- a/tests/e2e/access-control.spec.js
+++ b/tests/e2e/access-control.spec.js
@@ -66,9 +66,9 @@ test.describe('Access control', () => {
       await loginAs(page, 'amuser');
     });
 
-    test('can access /users', async ({ page }) => {
+    test('cannot access /users — redirected to dashboard (admin-only)', async ({ page }) => {
       await page.goto('/users');
-      await expect(page).toHaveURL(/\/users/);
+      await expect(page).toHaveURL(/\/dashboard/);
     });
 
     test('/groups redirects to /subjects', async ({ page }) => {
@@ -87,9 +87,9 @@ test.describe('Access control', () => {
       await expect(page).toHaveURL(/\/groups\/import/);
     });
 
-    test('can access /users/import', async ({ page }) => {
+    test('cannot access /users/import — redirected to dashboard (admin-only)', async ({ page }) => {
       await page.goto('/users/import');
-      await expect(page).toHaveURL(/\/users\/import/);
+      await expect(page).toHaveURL(/\/dashboard/);
     });
 
     test('can access /settings', async ({ page }) => {

--- a/tests/e2e/access-control.spec.js
+++ b/tests/e2e/access-control.spec.js
@@ -2,7 +2,7 @@
 
 const { test, expect } = require('@playwright/test');
 const { loginAs, loginAsAdmin } = require('../helpers/auth');
-const { cleanDatabase, createUser } = require('../helpers/db');
+const { cleanDatabase, createUser, createHierarchy, addUserToSubject, query } = require('../helpers/db');
 
 test.describe('Access control', () => {
   test.beforeEach(async () => {
@@ -20,8 +20,37 @@ test.describe('Access control', () => {
       await expect(page).toHaveURL(/\/dashboard/);
     });
 
-    test('cannot access /groups — redirected to dashboard', async ({ page }) => {
+    test('cannot access /groups — redirected to dashboard via /subjects', async ({ page }) => {
       await page.goto('/groups');
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('cannot access /subjects — redirected to dashboard', async ({ page }) => {
+      await page.goto('/subjects');
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('cannot access a subject detail URL — redirected to dashboard', async ({ page }) => {
+      const { subject } = await createHierarchy({ subjectName: 'ACL Subject', assignmentName: 'ACL Assignment' });
+      await page.goto(`/subjects/${subject.id}`);
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('cannot access an assignment groups URL — redirected to dashboard', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'ACL Subject',
+        assignmentName: 'ACL Assignment',
+      });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('enrolled user is still redirected from /subjects to /dashboard', async ({ page }) => {
+      // Subject membership grants API read access but not the admin/AM pages.
+      const rows = await query("SELECT id FROM users WHERE username = 'regularuser'");
+      const { subject } = await createHierarchy({ subjectName: 'Enrolled Subject', assignmentName: 'A1' });
+      await addUserToSubject(rows[0].id, subject.id);
+      await page.goto('/subjects');
       await expect(page).toHaveURL(/\/dashboard/);
     });
 
@@ -42,14 +71,18 @@ test.describe('Access control', () => {
       await expect(page).toHaveURL(/\/users/);
     });
 
-    test('cannot access /groups — redirected to dashboard', async ({ page }) => {
+    test('/groups redirects to /subjects', async ({ page }) => {
       await page.goto('/groups');
-      await expect(page).toHaveURL(/\/dashboard/);
+      await expect(page).toHaveURL(/\/subjects/);
     });
 
-    test('can access /groups/import — child route is AM-accessible even though /groups is admin-only', async ({
-      page,
-    }) => {
+    test('can access /subjects', async ({ page }) => {
+      await page.goto('/subjects');
+      await expect(page).toHaveURL(/\/subjects/);
+      await expect(page.getByRole('heading', { name: 'Manage Subjects' })).toBeVisible();
+    });
+
+    test('can access /groups/import', async ({ page }) => {
       await page.goto('/groups/import');
       await expect(page).toHaveURL(/\/groups\/import/);
     });
@@ -75,9 +108,16 @@ test.describe('Access control', () => {
       await expect(page).toHaveURL(/\/users/);
     });
 
-    test('can access /groups', async ({ page }) => {
+    test('/groups redirects to /subjects', async ({ page }) => {
       await page.goto('/groups');
-      await expect(page).toHaveURL(/\/groups/);
+      await expect(page).toHaveURL(/\/subjects/);
+    });
+
+    test('can access a subject detail page', async ({ page }) => {
+      const { subject } = await createHierarchy({ subjectName: 'Admin ACL Subject', assignmentName: 'A1' });
+      await page.goto(`/subjects/${subject.id}`);
+      await expect(page).toHaveURL(new RegExp(`/subjects/${subject.id}`));
+      await expect(page.getByRole('heading', { name: 'Admin ACL Subject' })).toBeVisible();
     });
   });
 });

--- a/tests/e2e/admin.spec.js
+++ b/tests/e2e/admin.spec.js
@@ -2,7 +2,7 @@
 
 const { test, expect } = require('@playwright/test');
 const { loginAsAdmin } = require('../helpers/auth');
-const { cleanDatabase, createUser, createGroup } = require('../helpers/db');
+const { cleanDatabase, createUser, createGroup, createHierarchy, createAssignment } = require('../helpers/db');
 
 test.describe('Admin', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +11,8 @@ test.describe('Admin', () => {
   });
 
   test.describe('User management', () => {
-    test('can create a new user via the UI', async ({ page }) => {
+    test('can create a new user via the UI (subject is required for the user role)', async ({ page }) => {
+      await createHierarchy({ subjectName: 'AdminSubject', assignmentName: 'A1' });
       await page.goto('/users');
       await page.getByRole('button', { name: /create user/i }).click();
 
@@ -21,10 +22,31 @@ test.describe('Admin', () => {
       await page.getByPlaceholder('Enter first name').fill('New');
       await page.getByPlaceholder('Enter last name').fill('User');
 
+      // Subject is mandatory for the user role (cascading select)
+      await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'AdminSubject' });
+
       await page.getByRole('button', { name: /^create$/i }).click();
 
-      // Newly created user should appear in the list
-      await expect(page.getByText('newuser', { exact: true })).toBeVisible();
+      await expect(page.getByText('User created successfully')).toBeVisible({ timeout: 5000 });
+      // Newly created user should appear in the list, enrolled in the subject
+      const row = page.locator('table tbody tr').filter({ hasText: 'newuser' });
+      await expect(row).toBeVisible();
+      await expect(row.getByText('AdminSubject')).toBeVisible();
+    });
+
+    test('creating a user without choosing a subject shows a validation error', async ({ page }) => {
+      await createHierarchy({ subjectName: 'AdminSubject', assignmentName: 'A1' });
+      await page.goto('/users');
+      await page.getByRole('button', { name: /create user/i }).click();
+
+      await page.getByPlaceholder('Enter username').fill('nosubject');
+      await page.getByPlaceholder('Enter email').fill('nosubject@test.com');
+      await page.getByPlaceholder('Enter first name').fill('No');
+      await page.getByPlaceholder('Enter last name').fill('Subject');
+
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.locator('.bg-red-50')).toContainText('Subject is required');
     });
 
     test('can edit a user profile', async ({ page }) => {
@@ -53,6 +75,7 @@ test.describe('Admin', () => {
 
   test.describe('Create User — error paths', () => {
     test('shows error when creating a user with a duplicate username', async ({ page }) => {
+      await createHierarchy({ subjectName: 'DupSubject', assignmentName: 'A1' });
       await createUser({ username: 'dupeuser', email: 'dupeuser@test.com' });
       await page.goto('/users');
       await page.getByRole('button', { name: /create user/i }).click();
@@ -61,6 +84,7 @@ test.describe('Admin', () => {
       await page.getByPlaceholder('Enter email').fill('unique@test.com');
       await page.getByPlaceholder('Enter first name').fill('Test');
       await page.getByPlaceholder('Enter last name').fill('User');
+      await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'DupSubject' });
 
       await page.getByRole('button', { name: /^create$/i }).click();
 
@@ -68,6 +92,7 @@ test.describe('Admin', () => {
     });
 
     test('shows error when creating a user with a duplicate email', async ({ page }) => {
+      await createHierarchy({ subjectName: 'DupSubject', assignmentName: 'A1' });
       await createUser({ username: 'uniqueuser', email: 'dupe@test.com' });
       await page.goto('/users');
       await page.getByRole('button', { name: /create user/i }).click();
@@ -76,6 +101,7 @@ test.describe('Admin', () => {
       await page.getByPlaceholder('Enter email').fill('dupe@test.com');
       await page.getByPlaceholder('Enter first name').fill('Test');
       await page.getByPlaceholder('Enter last name').fill('User');
+      await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'DupSubject' });
 
       await page.getByRole('button', { name: /^create$/i }).click();
 
@@ -84,9 +110,10 @@ test.describe('Admin', () => {
   });
 
   test.describe('Group management', () => {
-    test('can create a new group', async ({ page }) => {
-      await page.goto('/groups');
-      await page.getByRole('button', { name: /create group/i }).click();
+    test('can create a new group under an assignment', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({ subjectName: 'GroupSubject', assignmentName: 'GA1' });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
+      await page.getByRole('button', { name: '+ Create Group' }).click();
 
       // Create Group form uses placeholders — labels don't have htmlFor
       await page.getByPlaceholder('Enter group name').fill('Test Group Alpha');
@@ -95,10 +122,11 @@ test.describe('Admin', () => {
       await expect(page.getByText('Test Group Alpha')).toBeVisible();
     });
 
-    test('shows error when creating a group with a duplicate name', async ({ page }) => {
-      await createGroup({ name: 'DupGroup' });
-      await page.goto('/groups');
-      await page.getByRole('button', { name: /create group/i }).click();
+    test('shows error when creating a group with a duplicate name in the assignment', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({ subjectName: 'GroupSubject', assignmentName: 'GA1' });
+      await createGroup({ assignmentId: assignment.id, name: 'DupGroup' });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
+      await page.getByRole('button', { name: '+ Create Group' }).click();
 
       await page.getByPlaceholder('Enter group name').fill('DupGroup');
       await page.getByRole('button', { name: /^create$/i }).click();
@@ -107,9 +135,34 @@ test.describe('Admin', () => {
       await expect(page.getByText('Group name already exists')).toBeVisible();
     });
 
+    test('can create a group with the same name in a different assignment', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'GroupSubject',
+        assignmentName: 'GA1',
+        groups: [{ name: 'SharedName' }],
+      });
+      const other = await createAssignment({ subjectId: subject.id, name: 'GA2' });
+
+      await page.goto(`/subjects/${subject.id}/assignments/${other.id}`);
+      await page.getByRole('button', { name: '+ Create Group' }).click();
+      await page.getByPlaceholder('Enter group name').fill('SharedName');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('Group created successfully')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('SharedName')).toBeVisible();
+
+      // The original assignment still has its own group of the same name
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
+      await expect(page.getByText('SharedName')).toBeVisible();
+    });
+
     test('can edit a group name', async ({ page }) => {
-      await createGroup({ name: 'OldGroupName' });
-      await page.goto('/groups');
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'GroupSubject',
+        assignmentName: 'GA1',
+        groups: [{ name: 'OldGroupName' }],
+      });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
 
       // Use aria-label selector — <tr role="button"> also appears in getByRole('button') results
       await page.locator('button[aria-label="Edit Group"]').first().click();
@@ -121,8 +174,12 @@ test.describe('Admin', () => {
     });
 
     test('can delete a group', async ({ page }) => {
-      await createGroup({ name: 'GroupToDelete' });
-      await page.goto('/groups');
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'GroupSubject',
+        assignmentName: 'GA1',
+        groups: [{ name: 'GroupToDelete' }],
+      });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
 
       // Use aria-label selector — <tr role="button"> also appears in getByRole('button') results
       await page.locator('button[aria-label="Delete Group"]').first().click();

--- a/tests/e2e/am-scoping.spec.js
+++ b/tests/e2e/am-scoping.spec.js
@@ -36,9 +36,14 @@ test.describe('Assignment manager scoping', () => {
     await expect(page.getByText('Scoped S2')).not.toBeVisible();
   });
 
-  test('sees S1 members but not S2-only members on /users', async ({ page }) => {
+  test('cannot open /users — redirected to dashboard (admin-only)', async ({ page }) => {
     await page.goto('/users');
-    await expect(page.getByText('Manage Users')).toBeVisible();
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+
+  test('managed subject Members section lists S1 members but not S2-only members', async ({ page }) => {
+    await page.goto(`/subjects/${managed.subject.id}`);
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('scopeduser1', { exact: true })).toBeVisible();
     await expect(page.getByText('scopeduser2', { exact: true })).not.toBeVisible();
   });

--- a/tests/e2e/am-scoping.spec.js
+++ b/tests/e2e/am-scoping.spec.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs } = require('../helpers/auth');
+const {
+  cleanDatabase,
+  createUser,
+  createGroup,
+  createHierarchy,
+  addUserToSubject,
+  assignManager,
+} = require('../helpers/db');
+
+test.describe('Assignment manager scoping', () => {
+  let managed; // { subject: S1, assignment: A1 }
+  let unmanaged; // { subject: S2, assignment: A2 }
+
+  test.beforeEach(async ({ page }) => {
+    await cleanDatabase();
+    const am = await createUser({ username: 'scopeam', email: 'scopeam@test.com', role: 'assignment_manager' });
+    managed = await createHierarchy({ subjectName: 'Scoped S1', assignmentName: 'Scoped A1' });
+    unmanaged = await createHierarchy({ subjectName: 'Scoped S2', assignmentName: 'Scoped A2' });
+    await assignManager(am.id, managed.assignment.id);
+
+    const user1 = await createUser({ username: 'scopeduser1', email: 'scopeduser1@test.com' });
+    await addUserToSubject(user1.id, managed.subject.id);
+    const user2 = await createUser({ username: 'scopeduser2', email: 'scopeduser2@test.com' });
+    await addUserToSubject(user2.id, unmanaged.subject.id);
+
+    await loginAs(page, 'scopeam');
+  });
+
+  test('sees only the managed subject on /subjects', async ({ page }) => {
+    await page.goto('/subjects');
+    await expect(page.getByText('Scoped S1')).toBeVisible();
+    await expect(page.getByText('Scoped S2')).not.toBeVisible();
+  });
+
+  test('sees S1 members but not S2-only members on /users', async ({ page }) => {
+    await page.goto('/users');
+    await expect(page.getByText('Manage Users')).toBeVisible();
+    await expect(page.getByText('scopeduser1', { exact: true })).toBeVisible();
+    await expect(page.getByText('scopeduser2', { exact: true })).not.toBeVisible();
+  });
+
+  test('can create and delete a group in the managed assignment via the UI', async ({ page }) => {
+    await page.goto(`/subjects/${managed.subject.id}/assignments/${managed.assignment.id}`);
+
+    // Create
+    await page.getByRole('button', { name: '+ Create Group' }).click();
+    await page.getByPlaceholder('Enter group name').fill('AM Created Group');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByText('Group created successfully')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('AM Created Group')).toBeVisible();
+
+    // Delete
+    await page.locator('button[aria-label="Delete Group"]').click();
+    await page.getByRole('button', { name: /^Delete \d+ group/i }).click();
+    await expect(page.getByText('Group deleted successfully')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('AM Created Group')).not.toBeVisible();
+  });
+
+  test('managed assignment shows management controls; groups are manageable', async ({ page }) => {
+    await createGroup({ assignmentId: managed.assignment.id, name: 'Managed Group' });
+    await page.goto(`/subjects/${managed.subject.id}/assignments/${managed.assignment.id}`);
+
+    await expect(page.getByText('Managed Group')).toBeVisible();
+    await expect(page.getByRole('button', { name: '+ Create Group' })).toBeVisible();
+    const row = page.locator('table tbody tr').filter({ hasText: 'Managed Group' });
+    await expect(row.locator('button[aria-label="Edit Group"]')).toBeVisible();
+    await expect(row.locator('button[aria-label="Delete Group"]')).toBeVisible();
+  });
+
+  test('direct navigation to the unmanaged assignment offers no management controls', async ({ page }) => {
+    await createGroup({ assignmentId: unmanaged.assignment.id, name: 'Unmanaged Group' });
+    await page.goto(`/subjects/${unmanaged.subject.id}/assignments/${unmanaged.assignment.id}`);
+
+    // The backend refuses the data (403) — nothing manageable is rendered
+    await expect(page.getByText('Failed to load groups')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: '+ Create Group' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Bulk Create' })).not.toBeVisible();
+    await expect(page.locator('button[aria-label="Delete Group"]')).toHaveCount(0);
+    await expect(page.getByText('Unmanaged Group')).not.toBeVisible();
+  });
+
+  test('cannot open the unmanaged subject detail page', async ({ page }) => {
+    await page.goto(`/subjects/${unmanaged.subject.id}`);
+    await expect(page.getByText('Failed to load subject')).toBeVisible({ timeout: 10000 });
+    // No assignments of the unmanaged subject are leaked
+    await expect(page.getByText('Scoped A2')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/assignment-manager.spec.js
+++ b/tests/e2e/assignment-manager.spec.js
@@ -9,9 +9,12 @@ const {
   createHierarchy,
   addUserToSubject,
   assignManager,
-  assignUserToGroup,
 } = require('../helpers/db');
 
+/**
+ * Assignment manager user management happens on the subject detail page
+ * (Members section) — /users is admin-only and redirects AMs to the dashboard.
+ */
 test.describe('Assignment Manager', () => {
   let am;
   let subject;
@@ -25,25 +28,15 @@ test.describe('Assignment Manager', () => {
     await loginAs(page, 'am1');
   });
 
-  test('can navigate to /users page', async ({ page }) => {
+  test('cannot open /users — redirected to dashboard', async ({ page }) => {
     await page.goto('/users');
-    await expect(page).toHaveURL(/\/users/);
-    await expect(page.getByText('Manage Users')).toBeVisible();
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page.getByRole('heading', { name: 'Manage Users' })).not.toBeVisible();
   });
 
-  test('cannot see the Create User button', async ({ page }) => {
-    await page.goto('/users');
-    await expect(page.getByText('Manage Users')).toBeVisible();
-    await expect(page.getByRole('button', { name: /create user/i })).not.toBeVisible();
-  });
-
-  test('cannot see the Delete User button', async ({ page }) => {
-    const target = await createUser({ username: 'targetuser', email: 'target@test.com' });
-    await addUserToSubject(target.id, subject.id);
-    await page.goto('/users');
-    // The user in the managed subject is visible, but has no delete control
-    await expect(page.getByText('targetuser', { exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Delete User' })).not.toBeVisible();
+  test('cannot open /users/import — redirected to dashboard', async ({ page }) => {
+    await page.goto('/users/import');
+    await expect(page).toHaveURL(/\/dashboard/);
   });
 
   test('/groups redirects to /subjects for an assignment manager', async ({ page }) => {
@@ -51,49 +44,70 @@ test.describe('Assignment Manager', () => {
     await expect(page).toHaveURL(/\/subjects/);
   });
 
-  test('edit-user modal hides the Role select (no role escalation) but allows editing other fields', async ({
-    page,
-  }) => {
-    const target = await createUser({ username: 'edittarget', email: 'edittarget@test.com', role: 'user' });
+  test('sees the Members section on a managed subject page', async ({ page }) => {
+    const target = await createUser({ username: 'targetuser', email: 'target@test.com' });
     await addUserToSubject(target.id, subject.id);
-    await page.goto('/users');
 
-    // Scope to the target user's row.
-    const row = page.locator('table tbody tr').filter({ hasText: 'edittarget' });
-    await row.getByRole('button', { name: 'Edit User Profile' }).click();
+    await page.goto(`/subjects/${subject.id}`);
 
-    // Modal opens.
-    await expect(page.getByRole('heading', { name: 'Edit User' })).toBeVisible();
-
-    // The Role <select> is admin-only — it must not be present for an assignment manager.
-    const editForm = page.locator('form').filter({ has: page.getByPlaceholder('Enter first name') });
-    await expect(editForm.getByRole('combobox')).toHaveCount(0);
-
-    // The AM can still update an allowed field (first name).
-    await page.getByPlaceholder('Enter first name').fill('AmEdited');
-    await page.getByRole('button', { name: /save/i }).click();
-    await expect(page.getByText('User updated successfully')).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('AmEdited')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Users enrolled in this subject')).toBeVisible();
+    const row = page.locator('table tbody tr').filter({ hasText: 'targetuser' });
+    await expect(row).toBeVisible();
+    // "+ Add Existing User" is admin-only — not offered to an AM
+    await expect(page.getByRole('button', { name: '+ Add Existing User' })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: '+ Create User' })).toBeVisible();
   });
 
-  test('built-in admin is not listed for an assignment manager (subject-scoped view)', async ({ page }) => {
-    await page.goto('/users');
-    await expect(page.getByText('Manage Users')).toBeVisible();
-    // AMs only see users enrolled in subjects they manage; the admin account is
-    // not enrolled anywhere, so its row (and any edit control on it) is absent.
-    const adminRow = page.locator('table tbody tr').filter({ hasText: 'admin@gap.local' });
-    await expect(adminRow).toHaveCount(0);
+  test('can suspend and re-enable a member from the subject page', async ({ page }) => {
+    const target = await createUser({ username: 'suspendable', email: 'suspendable@test.com' });
+    await addUserToSubject(target.id, subject.id);
+
+    await page.goto(`/subjects/${subject.id}`);
+    const row = page.locator('table tbody tr').filter({ hasText: 'suspendable' });
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // Suspend via the confirmation modal
+    await row.locator('button[aria-label="Suspend Member"]').click();
+    await expect(page.getByRole('heading', { name: 'Suspend suspendable?' })).toBeVisible();
+    await page.getByRole('button', { name: 'Suspend', exact: true }).click();
+    await expect(page.getByText('Member suspended')).toBeVisible({ timeout: 5000 });
+    await expect(row.getByText('Suspended', { exact: true })).toBeVisible();
+
+    // Re-enable
+    await row.locator('button[aria-label="Enable Member"]').click();
+    await expect(page.getByText('Member enabled')).toBeVisible({ timeout: 5000 });
+    await expect(row.getByText('Suspended', { exact: true })).not.toBeVisible();
   });
 
-  test('can assign a user to a group via the Assign Group modal', async ({ page }) => {
+  test('can create a user in the managed subject via the Members section', async ({ page }) => {
+    await page.goto(`/subjects/${subject.id}`);
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: '+ Create User' }).click();
+    await page.getByPlaceholder('Enter username').fill('amcreated');
+    await page.getByPlaceholder('Enter email').fill('amcreated@test.com');
+    await page.getByPlaceholder('Enter first name').fill('Am');
+    await page.getByPlaceholder('Enter last name').fill('Created');
+    await page.getByRole('button', { name: /^create$/i }).click();
+
+    await expect(page.getByText('User created successfully')).toBeVisible({ timeout: 5000 });
+    const row = page.locator('table tbody tr').filter({ hasText: 'amcreated' });
+    await expect(row).toBeVisible();
+    // Created without a password — the account awaits email setup
+    await expect(row.getByText('Pending', { exact: true })).toBeVisible();
+  });
+
+  test('can assign a member to a group via the Members section Assign Group modal', async ({ page }) => {
     const assignee = await createUser({ username: 'assignee', email: 'assignee@test.com', role: 'user' });
     await addUserToSubject(assignee.id, subject.id);
     await createGroup({ assignmentId: assignment.id, name: 'AssignGroup' });
 
-    await page.goto('/users');
-
+    await page.goto(`/subjects/${subject.id}`);
     const row = page.locator('table tbody tr').filter({ hasText: 'assignee' });
-    await row.getByRole('button', { name: 'Assign Group' }).click();
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    await row.locator('button[aria-label="Assign Group"]').click();
 
     // Cascade: Subject → Assignment → Group
     await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'AM Subject' });
@@ -102,28 +116,5 @@ test.describe('Assignment Manager', () => {
     await page.getByRole('button', { name: 'Assign', exact: true }).click();
 
     await expect(page.getByText('User group updated successfully')).toBeVisible({ timeout: 10000 });
-    // Membership is summarised in the Subjects cell title: "Subject › Assignment › Group"
-    await expect(row.locator('[title*="AssignGroup"]')).toBeVisible();
-  });
-
-  test('can unassign a user from a group via the Assign Group modal', async ({ page }) => {
-    const group = await createGroup({ assignmentId: assignment.id, name: 'UnassignGroup' });
-    await createUser({ username: 'assigned', email: 'assigned@test.com', role: 'user' });
-    await assignUserToGroup('assigned', group.id);
-
-    await page.goto('/users');
-
-    const row = page.locator('table tbody tr').filter({ hasText: 'assigned' });
-    await expect(row.locator('[title*="UnassignGroup"]')).toBeVisible({ timeout: 10000 });
-
-    await row.getByRole('button', { name: 'Assign Group' }).click();
-
-    // Selecting the assignment with an existing membership reveals the remove action
-    await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'AM Subject' });
-    await page.getByLabel('Assignment', { exact: true }).selectOption({ label: 'AM Assignment' });
-    await page.getByRole('button', { name: 'Remove from group' }).click();
-
-    await expect(page.getByText('User group updated successfully')).toBeVisible({ timeout: 10000 });
-    await expect(row.locator('[title*="UnassignGroup"]')).toHaveCount(0);
   });
 });

--- a/tests/e2e/assignment-manager.spec.js
+++ b/tests/e2e/assignment-manager.spec.js
@@ -2,12 +2,26 @@
 
 const { test, expect } = require('@playwright/test');
 const { loginAs } = require('../helpers/auth');
-const { cleanDatabase, createUser, createGroup, assignUserToGroup } = require('../helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createGroup,
+  createHierarchy,
+  addUserToSubject,
+  assignManager,
+  assignUserToGroup,
+} = require('../helpers/db');
 
 test.describe('Assignment Manager', () => {
+  let am;
+  let subject;
+  let assignment;
+
   test.beforeEach(async ({ page }) => {
     await cleanDatabase();
-    await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+    am = await createUser({ username: 'am1', email: 'am1@test.com', role: 'assignment_manager' });
+    ({ subject, assignment } = await createHierarchy({ subjectName: 'AM Subject', assignmentName: 'AM Assignment' }));
+    await assignManager(am.id, assignment.id);
     await loginAs(page, 'am1');
   });
 
@@ -19,27 +33,32 @@ test.describe('Assignment Manager', () => {
 
   test('cannot see the Create User button', async ({ page }) => {
     await page.goto('/users');
+    await expect(page.getByText('Manage Users')).toBeVisible();
     await expect(page.getByRole('button', { name: /create user/i })).not.toBeVisible();
   });
 
   test('cannot see the Delete User button', async ({ page }) => {
-    await createUser({ username: 'targetuser', email: 'target@test.com' });
+    const target = await createUser({ username: 'targetuser', email: 'target@test.com' });
+    await addUserToSubject(target.id, subject.id);
     await page.goto('/users');
+    // The user in the managed subject is visible, but has no delete control
+    await expect(page.getByText('targetuser', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Delete User' })).not.toBeVisible();
   });
 
-  test('cannot access /groups — redirected to dashboard', async ({ page }) => {
+  test('/groups redirects to /subjects for an assignment manager', async ({ page }) => {
     await page.goto('/groups');
-    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page).toHaveURL(/\/subjects/);
   });
 
   test('edit-user modal hides the Role select (no role escalation) but allows editing other fields', async ({
     page,
   }) => {
-    await createUser({ username: 'edittarget', email: 'edittarget@test.com', role: 'user' });
+    const target = await createUser({ username: 'edittarget', email: 'edittarget@test.com', role: 'user' });
+    await addUserToSubject(target.id, subject.id);
     await page.goto('/users');
 
-    // Scope to the target user's row — the AM also has an Edit button on its own row.
+    // Scope to the target user's row.
     const row = page.locator('table tbody tr').filter({ hasText: 'edittarget' });
     await row.getByRole('button', { name: 'Edit User Profile' }).click();
 
@@ -47,7 +66,6 @@ test.describe('Assignment Manager', () => {
     await expect(page.getByRole('heading', { name: 'Edit User' })).toBeVisible();
 
     // The Role <select> is admin-only — it must not be present for an assignment manager.
-    // Scope to the edit form; in edit state there is no assign-group combobox active either.
     const editForm = page.locator('form').filter({ has: page.getByPlaceholder('Enter first name') });
     await expect(editForm.getByRole('combobox')).toHaveCount(0);
 
@@ -58,49 +76,54 @@ test.describe('Assignment Manager', () => {
     await expect(page.getByText('AmEdited')).toBeVisible();
   });
 
-  test('built-in admin row offers no Edit User Profile control to an assignment manager', async ({ page }) => {
+  test('built-in admin is not listed for an assignment manager (subject-scoped view)', async ({ page }) => {
     await page.goto('/users');
-    const adminRow = page.locator('table tbody tr').filter({ hasText: 'admin' });
-    await expect(adminRow).toHaveCount(1);
-    await expect(adminRow.getByRole('button', { name: 'Edit User Profile' })).toHaveCount(0);
+    await expect(page.getByText('Manage Users')).toBeVisible();
+    // AMs only see users enrolled in subjects they manage; the admin account is
+    // not enrolled anywhere, so its row (and any edit control on it) is absent.
+    const adminRow = page.locator('table tbody tr').filter({ hasText: 'admin@gap.local' });
+    await expect(adminRow).toHaveCount(0);
   });
 
-  test('can assign a user to a group', async ({ page }) => {
-    await createUser({ username: 'assignee', email: 'assignee@test.com', role: 'user' });
-    await createGroup({ name: 'AssignGroup' });
+  test('can assign a user to a group via the Assign Group modal', async ({ page }) => {
+    const assignee = await createUser({ username: 'assignee', email: 'assignee@test.com', role: 'user' });
+    await addUserToSubject(assignee.id, subject.id);
+    await createGroup({ assignmentId: assignment.id, name: 'AssignGroup' });
 
     await page.goto('/users');
 
-    // Click the Assign Group button for the user
-    await page.getByRole('button', { name: 'Assign Group' }).first().click();
+    const row = page.locator('table tbody tr').filter({ hasText: 'assignee' });
+    await row.getByRole('button', { name: 'Assign Group' }).click();
 
-    // Select the group from the dropdown
-    await page.getByRole('combobox', { name: /assign to group/i }).selectOption({ label: 'AssignGroup' });
-    await page.getByRole('button', { name: 'Save' }).click();
+    // Cascade: Subject → Assignment → Group
+    await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'AM Subject' });
+    await page.getByLabel('Assignment', { exact: true }).selectOption({ label: 'AM Assignment' });
+    await page.getByLabel('Group', { exact: true }).selectOption({ label: 'AssignGroup' });
+    await page.getByRole('button', { name: 'Assign', exact: true }).click();
 
-    // Group name appears in the user row's group cell (title attribute is unique)
-    await expect(page.locator('[title="AssignGroup"]')).toBeVisible();
+    await expect(page.getByText('User group updated successfully')).toBeVisible({ timeout: 10000 });
+    // Membership is summarised in the Subjects cell title: "Subject › Assignment › Group"
+    await expect(row.locator('[title*="AssignGroup"]')).toBeVisible();
   });
 
-  test('can unassign a user from a group', async ({ page }) => {
-    const group = await createGroup({ name: 'UnassignGroup' });
+  test('can unassign a user from a group via the Assign Group modal', async ({ page }) => {
+    const group = await createGroup({ assignmentId: assignment.id, name: 'UnassignGroup' });
     await createUser({ username: 'assigned', email: 'assigned@test.com', role: 'user' });
     await assignUserToGroup('assigned', group.id);
 
     await page.goto('/users');
 
-    // Verify the user is currently in the group
     const row = page.locator('table tbody tr').filter({ hasText: 'assigned' });
-    await expect(row.locator('[title="UnassignGroup"]')).toBeVisible({ timeout: 10000 });
+    await expect(row.locator('[title*="UnassignGroup"]')).toBeVisible({ timeout: 10000 });
 
-    // Click the Assign Group button for the user
     await row.getByRole('button', { name: 'Assign Group' }).click();
 
-    // Select "No Group" to unassign
-    await page.getByRole('combobox', { name: /assign to group/i }).selectOption({ value: '' });
-    await page.getByRole('button', { name: 'Save' }).click();
+    // Selecting the assignment with an existing membership reveals the remove action
+    await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'AM Subject' });
+    await page.getByLabel('Assignment', { exact: true }).selectOption({ label: 'AM Assignment' });
+    await page.getByRole('button', { name: 'Remove from group' }).click();
 
-    // Group column should now show "Not assigned"
-    await expect(row.locator('[title="Not assigned"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('User group updated successfully')).toBeVisible({ timeout: 10000 });
+    await expect(row.locator('[title*="UnassignGroup"]')).toHaveCount(0);
   });
 });

--- a/tests/e2e/assignments.spec.js
+++ b/tests/e2e/assignments.spec.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs, loginAsAdmin } = require('../helpers/auth');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  createHierarchy,
+  assignManager,
+} = require('../helpers/db');
+
+test.describe('Assignments', () => {
+  test.beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  test.describe('Admin', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginAsAdmin(page);
+    });
+
+    test('drilling into a subject shows its assignments', async ({ page }) => {
+      const { subject } = await createHierarchy({ subjectName: 'Drill Subject', assignmentName: 'Existing A1' });
+      await page.goto('/subjects');
+      await page.locator('table tbody tr').filter({ hasText: 'Drill Subject' }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/subjects/${subject.id}`));
+      await expect(page.getByText('Existing A1')).toBeVisible();
+      await expect(page.getByText('Assignments in this subject')).toBeVisible();
+    });
+
+    test('shows the empty state for a subject with no assignments', async ({ page }) => {
+      const subject = await createSubject({ name: 'Empty Subject' });
+      await page.goto(`/subjects/${subject.id}`);
+      await expect(page.getByText('No assignments yet')).toBeVisible();
+    });
+
+    test('can create an assignment in a subject', async ({ page }) => {
+      const subject = await createSubject({ name: 'Create Subject' });
+      await page.goto(`/subjects/${subject.id}`);
+
+      await page.getByRole('button', { name: '+ Create Assignment' }).click();
+      await expect(page.getByRole('heading', { name: 'Create New Assignment' })).toBeVisible();
+      await page.getByPlaceholder('Enter assignment name').fill('Assignment One');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('Assignment created successfully')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Assignment One')).toBeVisible();
+    });
+
+    test('shows an error when creating a duplicate assignment name in the same subject', async ({ page }) => {
+      const { subject } = await createHierarchy({ subjectName: 'Dup Subject', assignmentName: 'Dup Assignment' });
+      await page.goto(`/subjects/${subject.id}`);
+
+      await page.getByRole('button', { name: '+ Create Assignment' }).click();
+      await page.getByPlaceholder('Enter assignment name').fill('Dup Assignment');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('An assignment with this name already exists in this subject')).toBeVisible();
+    });
+
+    test('the same assignment name is allowed in a different subject', async ({ page }) => {
+      await createHierarchy({ subjectName: 'First Subject', assignmentName: 'Shared Assignment' });
+      const other = await createSubject({ name: 'Second Subject' });
+
+      await page.goto(`/subjects/${other.id}`);
+      await page.getByRole('button', { name: '+ Create Assignment' }).click();
+      await page.getByPlaceholder('Enter assignment name').fill('Shared Assignment');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('Assignment created successfully')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Shared Assignment')).toBeVisible();
+    });
+
+    test('clicking an assignment row opens the groups view with a breadcrumb', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'Crumb Subject',
+        assignmentName: 'Crumb Assignment',
+        groups: [{ name: 'Crumb Group' }],
+      });
+      await page.goto(`/subjects/${subject.id}`);
+      await page.locator('table tbody tr').filter({ hasText: 'Crumb Assignment' }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/subjects/${subject.id}/assignments/${assignment.id}`));
+      const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' });
+      await expect(breadcrumb).toContainText('Subjects');
+      await expect(breadcrumb).toContainText('Crumb Subject');
+      await expect(breadcrumb).toContainText('Crumb Assignment');
+      await expect(page.getByText('Crumb Group')).toBeVisible();
+    });
+
+    test('breadcrumb links navigate back up the hierarchy', async ({ page }) => {
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'Back Subject',
+        assignmentName: 'Back Assignment',
+      });
+      await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
+
+      const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' });
+      await breadcrumb.getByRole('link', { name: 'Back Subject' }).click();
+      await expect(page).toHaveURL(new RegExp(`/subjects/${subject.id}$`));
+
+      await page.getByRole('navigation', { name: 'Breadcrumb' }).getByRole('link', { name: 'Subjects' }).click();
+      await expect(page).toHaveURL(/\/subjects$/);
+    });
+  });
+
+  test.describe('Assignment manager', () => {
+    test('cannot create or delete assignments in a managed subject', async ({ page }) => {
+      const am = await createUser({ username: 'am-assign', email: 'am-assign@test.com', role: 'assignment_manager' });
+      const { subject, assignment } = await createHierarchy({
+        subjectName: 'AM Subject',
+        assignmentName: 'AM Assignment',
+      });
+      await createAssignment({ subjectId: subject.id, name: 'Other Assignment' });
+      await assignManager(am.id, assignment.id);
+
+      await loginAs(page, 'am-assign');
+      await page.goto(`/subjects/${subject.id}`);
+
+      // The AM can view the subject's assignments…
+      await expect(page.getByText('AM Assignment')).toBeVisible();
+      // …but has no create or delete controls (admin only)
+      await expect(page.getByRole('button', { name: '+ Create Assignment' })).not.toBeVisible();
+      await expect(page.locator('button[aria-label="Delete Assignment"]')).toHaveCount(0);
+    });
+  });
+});

--- a/tests/e2e/bulk-operations.spec.js
+++ b/tests/e2e/bulk-operations.spec.js
@@ -2,7 +2,7 @@
 
 const { test, expect } = require('@playwright/test');
 const { loginAsAdmin } = require('../helpers/auth');
-const { cleanDatabase, createUser, createGroup } = require('../helpers/db');
+const { cleanDatabase, createUser, createHierarchy } = require('../helpers/db');
 
 test.describe('Bulk Operations — Users', () => {
   test.beforeEach(async () => {
@@ -39,6 +39,7 @@ test.describe('Bulk Operations — Users', () => {
   });
 
   test('admin can send setup emails to pending users', async ({ page }) => {
+    await createHierarchy({ subjectName: 'BulkSubject', assignmentName: 'BA1' });
     await loginAsAdmin(page);
     await page.goto('/users');
 
@@ -48,6 +49,8 @@ test.describe('Bulk Operations — Users', () => {
     await page.getByPlaceholder('Enter email').fill('pendinguser1@test.com');
     await page.getByPlaceholder('Enter first name').fill('Pending');
     await page.getByPlaceholder('Enter last name').fill('User');
+    // Subject is required for the user role
+    await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'BulkSubject' });
 
     // Ensure the checkbox is unchecked so the user is created as pending
     const sendEmailCheckbox = page.locator('#sendSetupEmail');
@@ -76,10 +79,13 @@ test.describe('Bulk Operations — Groups', () => {
   });
 
   test('admin can bulk delete multiple groups', async ({ page }) => {
-    await createGroup({ name: 'BulkDeleteGroup1' });
-    await createGroup({ name: 'BulkDeleteGroup2' });
+    const { subject, assignment } = await createHierarchy({
+      subjectName: 'BulkGroupSubject',
+      assignmentName: 'BGA1',
+      groups: [{ name: 'BulkDeleteGroup1' }, { name: 'BulkDeleteGroup2' }],
+    });
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(`/subjects/${subject.id}/assignments/${assignment.id}`);
 
     await page.locator('input[aria-label="Select BulkDeleteGroup1"]').check();
     await page.locator('input[aria-label="Select BulkDeleteGroup2"]').check();

--- a/tests/e2e/dashboard-advanced.spec.js
+++ b/tests/e2e/dashboard-advanced.spec.js
@@ -1,45 +1,60 @@
 'use strict';
 
 const { test, expect } = require('@playwright/test');
-const { cleanDatabase, createUser, createGroup, assignUserToGroup } = require('../helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createGroup,
+  createHierarchy,
+  addUserToSubject,
+  assignUserToGroup,
+} = require('../helpers/db');
 const { loginAs, logout, enableGroupJoinLock } = require('../helpers/auth');
 
 test.describe('Dashboard — Feeling Lucky & Group Join Lock', () => {
+  let subject;
+  let assignment;
+
   test.beforeEach(async () => {
     await cleanDatabase();
+    ({ subject, assignment } = await createHierarchy({ subjectName: 'Dash Subject', assignmentName: 'Dash A1' }));
   });
 
   test('user sees "Feeling Lucky" button when groups are available', async ({ page }) => {
-    await createUser({ username: 'luckyuser', email: 'luckyuser@test.com' });
-    await createGroup({ name: 'LuckyGroup' });
+    const user = await createUser({ username: 'luckyuser', email: 'luckyuser@test.com' });
+    await addUserToSubject(user.id, subject.id);
+    await createGroup({ assignmentId: assignment.id, name: 'LuckyGroup' });
     await loginAs(page, 'luckyuser', 'TestPass123!');
     await expect(page.getByRole('button', { name: /feeling lucky/i })).toBeVisible();
     await expect(page.getByText('LuckyGroup')).toBeVisible();
   });
 
-  test('clicking "Feeling Lucky" assigns user to a group', async ({ page }) => {
-    await createUser({ username: 'luckyuser2', email: 'luckyuser2@test.com' });
-    await createGroup({ name: 'LuckyGroupA' });
-    await createGroup({ name: 'LuckyGroupB' });
+  test('clicking "Feeling Lucky" assigns user to a group in the assignment', async ({ page }) => {
+    const user = await createUser({ username: 'luckyuser2', email: 'luckyuser2@test.com' });
+    await addUserToSubject(user.id, subject.id);
+    await createGroup({ assignmentId: assignment.id, name: 'LuckyGroupA' });
+    await createGroup({ assignmentId: assignment.id, name: 'LuckyGroupB' });
     await loginAs(page, 'luckyuser2', 'TestPass123!');
     await page.getByRole('button', { name: /feeling lucky/i }).click();
-    await expect(page.getByText(/you are in:/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/your group:/i)).toBeVisible({ timeout: 10000 });
   });
 
   test('user can join a specific group from the list', async ({ page }) => {
-    await createUser({ username: 'joinuser', email: 'joinuser@test.com' });
-    await createGroup({ name: 'JoinTarget' });
+    const user = await createUser({ username: 'joinuser', email: 'joinuser@test.com' });
+    await addUserToSubject(user.id, subject.id);
+    await createGroup({ assignmentId: assignment.id, name: 'JoinTarget' });
     await loginAs(page, 'joinuser', 'TestPass123!');
     // exact: true avoids matching "joinuser" in the header button accessible name
     await page.getByRole('button', { name: 'Join', exact: true }).click();
     await expect(page.getByText(/successfully joined/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText(/you are in:/i)).toBeVisible();
+    await expect(page.getByText(/your group:/i)).toBeVisible();
   });
 
   test('when group join lock is enabled, user sees locked message instead of groups', async ({ page }) => {
     await enableGroupJoinLock(page);
-    await createGroup({ name: 'LockedGroup' });
-    await createUser({ username: 'lockeduser', email: 'lockeduser@test.com' });
+    await createGroup({ assignmentId: assignment.id, name: 'LockedGroup' });
+    const user = await createUser({ username: 'lockeduser', email: 'lockeduser@test.com' });
+    await addUserToSubject(user.id, subject.id);
     // PublicRoute redirects authenticated users from /login, so logout first
     await logout(page);
     await loginAs(page, 'lockeduser', 'TestPass123!');
@@ -50,13 +65,14 @@ test.describe('Dashboard — Feeling Lucky & Group Join Lock', () => {
 
   test('locked user in a group sees locked message and no Leave Group button', async ({ page }) => {
     await enableGroupJoinLock(page);
-    const group = await createGroup({ name: 'LockedGroup2' });
+    const group = await createGroup({ assignmentId: assignment.id, name: 'LockedGroup2' });
     const user = await createUser({ username: 'ingroup', email: 'ingroup@test.com' });
     await assignUserToGroup(user.username, group.id);
     // PublicRoute redirects authenticated users from /login, so logout first
     await logout(page);
     await loginAs(page, 'ingroup', 'TestPass123!');
     await expect(page.getByText('Group joining is locked')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/your group:/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /leave group/i })).not.toBeVisible();
   });
 });

--- a/tests/e2e/groups-advanced.spec.js
+++ b/tests/e2e/groups-advanced.spec.js
@@ -4,19 +4,32 @@ const { test, expect } = require('@playwright/test');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
-const { cleanDatabase, createGroup, createUser, assignUserToGroup } = require('../helpers/db');
+const {
+  cleanDatabase,
+  createGroup,
+  createUser,
+  createHierarchy,
+  addUserToSubject,
+  assignUserToGroup,
+} = require('../helpers/db');
 const { loginAsAdmin } = require('../helpers/auth');
 
 test.describe('Groups — Advanced Admin Features', () => {
+  let subject;
+  let assignment;
+
   test.beforeEach(async () => {
     await cleanDatabase();
+    ({ subject, assignment } = await createHierarchy({ subjectName: 'Adv Subject', assignmentName: 'Adv Assignment' }));
   });
+
+  const groupsUrl = () => `/subjects/${subject.id}/assignments/${assignment.id}`;
 
   // ── Bulk Create ────────────────────────────────────────────────────────────
 
   test('bulk create groups with prefix and count', async ({ page }) => {
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     await page.getByRole('button', { name: 'Bulk Create' }).click();
     await expect(page.getByText('Bulk Create Groups')).toBeVisible();
 
@@ -35,7 +48,7 @@ test.describe('Groups — Advanced Admin Features', () => {
 
   test('bulk create with member limit sets max_members on all groups', async ({ page }) => {
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     await page.getByRole('button', { name: 'Bulk Create' }).click();
     await page.getByPlaceholder('e.g. Team').fill('LimitedGroup');
     await page.getByPlaceholder('e.g. 10').fill('2');
@@ -51,9 +64,9 @@ test.describe('Groups — Advanced Admin Features', () => {
   // ── Enable / Disable toggle ────────────────────────────────────────────────
 
   test('admin can disable an enabled group', async ({ page }) => {
-    await createGroup({ name: 'ActiveGroup', enabled: true });
+    await createGroup({ assignmentId: assignment.id, name: 'ActiveGroup', enabled: true });
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     const row = page.locator('table tbody tr').filter({ hasText: 'ActiveGroup' });
     await row.locator('button[aria-label="Disable Group"]').click();
     await expect(page.getByText('Group disabled successfully')).toBeVisible({ timeout: 5000 });
@@ -61,9 +74,9 @@ test.describe('Groups — Advanced Admin Features', () => {
   });
 
   test('admin can re-enable a disabled group', async ({ page }) => {
-    await createGroup({ name: 'DisabledGroup', enabled: false });
+    await createGroup({ assignmentId: assignment.id, name: 'DisabledGroup', enabled: false });
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     const row = page.locator('table tbody tr').filter({ hasText: 'DisabledGroup' });
     await row.locator('button[aria-label="Enable Group"]').click();
     await expect(page.getByText('Group enabled successfully')).toBeVisible({ timeout: 5000 });
@@ -73,9 +86,9 @@ test.describe('Groups — Advanced Admin Features', () => {
   // ── Set Member Limit ───────────────────────────────────────────────────────
 
   test('admin can set a member limit on a group', async ({ page }) => {
-    await createGroup({ name: 'LimitGroup' });
+    await createGroup({ assignmentId: assignment.id, name: 'LimitGroup' });
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     const row = page.locator('table tbody tr').filter({ hasText: 'LimitGroup' });
     await row.locator('button[aria-label="Set Member Limit"]').click();
     // Use heading role to avoid strict mode violation with tooltip spans
@@ -87,9 +100,9 @@ test.describe('Groups — Advanced Admin Features', () => {
   });
 
   test('admin can remove a member limit (set to unlimited)', async ({ page }) => {
-    await createGroup({ name: 'LimitedGroup2', maxMembers: 5 });
+    await createGroup({ assignmentId: assignment.id, name: 'LimitedGroup2', maxMembers: 5 });
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
     const row = page.locator('table tbody tr').filter({ hasText: 'LimitedGroup2' });
     await row.locator('button[aria-label="Set Member Limit"]').click();
     await page.getByPlaceholder('Unlimited').clear();
@@ -101,11 +114,11 @@ test.describe('Groups — Advanced Admin Features', () => {
   // ── Export Mappings ────────────────────────────────────────────────────────
 
   test('export mappings button triggers a CSV download', async ({ page }) => {
-    const group = await createGroup({ name: 'ExportGroup' });
+    const group = await createGroup({ assignmentId: assignment.id, name: 'ExportGroup' });
     await createUser({ username: 'exportuser', email: 'exportuser@test.com' });
     await assignUserToGroup('exportuser', group.id);
     await loginAsAdmin(page);
-    await page.goto('/groups');
+    await page.goto(groupsUrl());
 
     const [download] = await Promise.all([
       page.waitForEvent('download'),
@@ -117,8 +130,10 @@ test.describe('Groups — Advanced Admin Features', () => {
   // ── Import Group Mappings (CSV wizard) ────────────────────────────────────
 
   test('import group mappings wizard: upload CSV, preview, and import', async ({ page }) => {
-    await createGroup({ name: 'ImportTarget' });
-    await createUser({ username: 'importtarget', email: 'importtarget@test.com' });
+    await createGroup({ assignmentId: assignment.id, name: 'ImportTarget' });
+    const importUser = await createUser({ username: 'importtarget', email: 'importtarget@test.com' });
+    // The universal placement rule requires the user to be a subject member
+    await addUserToSubject(importUser.id, subject.id);
 
     const csvContent = `email,group\nimporttarget@test.com,ImportTarget\n`;
     const tmpFile = path.join(os.tmpdir(), 'test-mappings.csv');
@@ -126,7 +141,8 @@ test.describe('Groups — Advanced Admin Features', () => {
 
     try {
       await loginAsAdmin(page);
-      await page.goto('/groups/import');
+      // Query params preselect the Subject → Assignment cascade
+      await page.goto(`/groups/import?subjectId=${subject.id}&assignmentId=${assignment.id}`);
 
       // Hidden file input — use setInputFiles to bypass browser file picker
       await page.locator('input[aria-label="Upload CSV file"]').setInputFiles(tmpFile);
@@ -149,15 +165,24 @@ test.describe('Groups — Advanced Admin Features', () => {
     }
   });
 
+  test('import group mappings wizard requires choosing an assignment first', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/groups/import');
+    await expect(page.getByText('Select a subject and assignment to continue.')).toBeVisible();
+    // The upload dropzone is gated behind the cascade selection
+    await expect(page.locator('input[aria-label="Upload CSV file"]')).toHaveCount(0);
+  });
+
   test('import group mappings shows "Group not found" for unknown groups', async ({ page }) => {
-    await createUser({ username: 'missinggroup', email: 'missinggroup@test.com' });
+    const missingUser = await createUser({ username: 'missinggroup', email: 'missinggroup@test.com' });
+    await addUserToSubject(missingUser.id, subject.id);
     const csvContent = `email,group\nmissinggroup@test.com,NoSuchGroup\n`;
     const tmpFile = path.join(os.tmpdir(), 'test-missing.csv');
     fs.writeFileSync(tmpFile, csvContent);
 
     try {
       await loginAsAdmin(page);
-      await page.goto('/groups/import');
+      await page.goto(`/groups/import?subjectId=${subject.id}&assignmentId=${assignment.id}`);
       await page.locator('input[aria-label="Upload CSV file"]').setInputFiles(tmpFile);
       await expect(page.getByRole('heading', { name: 'Preview' })).toBeVisible({ timeout: 10000 });
       await expect(page.getByText('Group not found')).toBeVisible();

--- a/tests/e2e/hierarchy-workflow.spec.js
+++ b/tests/e2e/hierarchy-workflow.spec.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs, loginAsAdmin, logout } = require('../helpers/auth');
+const { cleanDatabase, createUser, assignUserToGroup, query } = require('../helpers/db');
+
+/**
+ * End-to-end admin → user workflow across the full Subject → Assignment →
+ * Group hierarchy, exercised through the UI wherever possible.
+ */
+test.describe('Hierarchy workflow', () => {
+  test.beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  test('admin builds the hierarchy, places a user, and the user joins/leaves groups', async ({ page }) => {
+    test.setTimeout(120000);
+    await createUser({ username: 'flowuser', email: 'flowuser@test.com', role: 'user' });
+
+    await loginAsAdmin(page);
+
+    // ── 1. Create the subject ────────────────────────────────────────────
+    await page.goto('/subjects');
+    await page.getByRole('button', { name: '+ Create Subject' }).click();
+    await page.getByPlaceholder('Enter subject name').fill('Flow Subject');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByText('Subject created successfully')).toBeVisible({ timeout: 5000 });
+
+    // ── 2. Drill in and create the assignment ────────────────────────────
+    await page.locator('table tbody tr').filter({ hasText: 'Flow Subject' }).click();
+    await page.getByRole('button', { name: '+ Create Assignment' }).click();
+    await page.getByPlaceholder('Enter assignment name').fill('Flow Assignment');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByText('Assignment created successfully')).toBeVisible({ timeout: 5000 });
+
+    // ── 3. Drill in and create two groups ────────────────────────────────
+    await page.locator('table tbody tr').filter({ hasText: 'Flow Assignment' }).click();
+    await expect(page.getByRole('navigation', { name: 'Breadcrumb' })).toContainText('Flow Assignment');
+
+    await page.getByRole('button', { name: '+ Create Group' }).click();
+    await page.getByPlaceholder('Enter group name').fill('Flow Group A');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByText('Group created successfully')).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: '+ Create Group' }).click();
+    await page.getByPlaceholder('Enter group name').fill('Flow Group B');
+    await page.getByRole('button', { name: /^create$/i }).click();
+    await expect(page.getByText('Flow Group B')).toBeVisible({ timeout: 5000 });
+
+    // ── 4. Enrol the user in the subject via Manage Subjects ─────────────
+    await page.goto('/users');
+    const userRow = page.locator('table tbody tr').filter({ hasText: 'flowuser' });
+    await userRow.getByRole('button', { name: 'Manage Subjects' }).click();
+    await expect(page.getByRole('heading', { name: /Manage Subjects — flowuser/ })).toBeVisible();
+    await page.locator('label').filter({ hasText: 'Flow Subject' }).locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByText('Subjects updated successfully')).toBeVisible({ timeout: 5000 });
+    await expect(userRow.getByText('Flow Subject')).toBeVisible();
+
+    // ── 5. Place the user in Flow Group A via the Assign Group modal ─────
+    await userRow.getByRole('button', { name: 'Assign Group' }).click();
+    await page.getByLabel('Subject', { exact: true }).selectOption({ label: 'Flow Subject' });
+    await page.getByLabel('Assignment', { exact: true }).selectOption({ label: 'Flow Assignment' });
+    await page.getByLabel('Group', { exact: true }).selectOption({ label: 'Flow Group A' });
+    await page.getByRole('button', { name: 'Assign', exact: true }).click();
+    await expect(page.getByText('User group updated successfully')).toBeVisible({ timeout: 10000 });
+    await expect(userRow.locator('[title*="Flow Group A"]')).toBeVisible();
+
+    // ── 6. The user sees their placement on the dashboard ────────────────
+    await logout(page);
+    await loginAs(page, 'flowuser');
+    await expect(page.getByRole('heading', { name: 'Flow Subject' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Flow Assignment')).toBeVisible();
+    await expect(page.getByText(/your group:/i)).toBeVisible();
+    await expect(page.getByText('Flow Group A')).toBeVisible();
+
+    // ── 7. Leave, then join the other group ──────────────────────────────
+    await page.getByRole('button', { name: /leave group/i }).click();
+    await expect(page.getByText(/successfully left group/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Join', exact: true }).first()).toBeVisible();
+
+    await page
+      .locator('li')
+      .filter({ hasText: 'Flow Group B' })
+      .getByRole('button', { name: 'Join', exact: true })
+      .click();
+    await expect(page.getByText(/successfully joined/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/your group:/i)).toBeVisible();
+    await expect(page.getByText('Flow Group B')).toBeVisible();
+
+    // ── 8. A second join for the same assignment is rejected with 409 ────
+    await page.getByRole('button', { name: /leave group/i }).click();
+    await expect(page.getByText(/successfully left group/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Join', exact: true }).first()).toBeVisible();
+
+    // Re-create a membership behind the UI's back so the visible Join button
+    // targets an assignment the user already belongs to.
+    const groupARows = await query("SELECT id FROM groups WHERE name = 'Flow Group A'");
+    await assignUserToGroup('flowuser', groupARows[0].id);
+
+    await page
+      .locator('li')
+      .filter({ hasText: 'Flow Group B' })
+      .getByRole('button', { name: 'Join', exact: true })
+      .click();
+    await expect(page.getByText('User is already in a group for this assignment')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/e2e/import-users.spec.js
+++ b/tests/e2e/import-users.spec.js
@@ -4,15 +4,16 @@ const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { cleanDatabase, createUser } = require('../helpers/db');
+const { cleanDatabase, createUser, createHierarchy } = require('../helpers/db');
 const { loginAsAdmin } = require('../helpers/auth');
 
 test.describe('Import Users', () => {
   test.beforeEach(async () => {
     await cleanDatabase();
+    await createHierarchy({ subjectName: 'Import Subject', assignmentName: 'Import A1' });
   });
 
-  test('upload CSV and import new users successfully', async ({ page }) => {
+  test('upload CSV and import new users into the target subject', async ({ page }) => {
     const csvContent = 'username,email,firstName,lastName\nnewimport,newimport@test.com,Import,Test\n';
     const tmpPath = path.join(os.tmpdir(), `import-new-${Date.now()}.csv`);
 
@@ -27,14 +28,45 @@ test.describe('Import Users', () => {
       await expect(page.getByRole('button', { name: /preview import/i })).toBeVisible({ timeout: 10000 });
       await page.getByRole('button', { name: /preview import/i }).click();
 
-      // Step 3: Preview — row should appear as "New"
+      // Step 3: Preview — row should appear as "New"; the target subject is required
       await expect(page.getByText('New', { exact: true })).toBeVisible({ timeout: 10000 });
       await expect(page.getByRole('cell', { name: 'newimport', exact: true })).toBeVisible();
+      await page.getByLabel(/target subject/i).selectOption({ label: 'Import Subject' });
       await page.getByRole('button', { name: /^import$/i }).click();
 
       // Step 4: Result
       await expect(page.getByText('Import Complete')).toBeVisible({ timeout: 10000 });
       await expect(page.getByText(/1 imported/)).toBeVisible();
+
+      // Imported user is enrolled in the target subject (Subjects column on /users)
+      await page.goto('/users');
+      const row = page.locator('table tbody tr').filter({ hasText: 'newimport' });
+      await expect(row.getByText('Import Subject')).toBeVisible({ timeout: 10000 });
+    } finally {
+      fs.rmSync(tmpPath, { force: true });
+    }
+  });
+
+  test('import without choosing a target subject shows an error', async ({ page }) => {
+    const csvContent = 'username,email,firstName,lastName\nnosubjimport,nosubjimport@test.com,No,Subject\n';
+    const tmpPath = path.join(os.tmpdir(), `import-nosubj-${Date.now()}.csv`);
+
+    try {
+      fs.writeFileSync(tmpPath, csvContent, 'utf8');
+      await loginAsAdmin(page);
+      await page.goto('/users/import');
+
+      await page.locator('input[aria-label="Upload CSV file"]').setInputFiles(tmpPath);
+      await expect(page.getByRole('button', { name: /preview import/i })).toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: /preview import/i }).click();
+
+      await expect(page.getByText('New', { exact: true })).toBeVisible({ timeout: 10000 });
+      // Leave the Target subject select empty
+      await page.getByRole('button', { name: /^import$/i }).click();
+
+      await expect(page.getByText('Subject is required')).toBeVisible();
+      // Still on the preview step — nothing was imported
+      await expect(page.getByText('Import Complete')).not.toBeVisible();
     } finally {
       fs.rmSync(tmpPath, { force: true });
     }
@@ -89,6 +121,7 @@ test.describe('Import Users', () => {
       await page.locator('input[type="radio"][value="overwrite"]').check();
       await expect(page.getByText('Existing – overwrite')).toBeVisible({ timeout: 10000 });
 
+      await page.getByLabel(/target subject/i).selectOption({ label: 'Import Subject' });
       await page.getByRole('button', { name: /^import$/i }).click();
 
       // Step 4: Result

--- a/tests/e2e/join-constraints.spec.js
+++ b/tests/e2e/join-constraints.spec.js
@@ -1,23 +1,39 @@
 'use strict';
 
 const { test, expect } = require('@playwright/test');
-const { cleanDatabase, createUser, createGroup, assignUserToGroup } = require('../helpers/db');
+const {
+  cleanDatabase,
+  createUser,
+  createGroup,
+  createHierarchy,
+  addUserToSubject,
+  assignUserToGroup,
+} = require('../helpers/db');
 const { loginAs } = require('../helpers/auth');
 
 test.describe('Join Group Constraints', () => {
+  let subject;
+  let assignment;
+
   test.beforeEach(async () => {
     await cleanDatabase();
+    ({ subject, assignment } = await createHierarchy({ subjectName: 'Join Subject', assignmentName: 'Join A1' }));
   });
 
   test('user cannot see a full group in the join list', async ({ page }) => {
     // The UI filters full groups client-side before rendering, so a full group
     // never appears with a Join button — this tests that filtering behaviour.
-    const fullGroup = await createGroup({ name: 'FullGroup', maxMembers: 1 });
+    const fullGroup = await createGroup({ assignmentId: assignment.id, name: 'FullGroup', maxMembers: 1 });
     const occupant = await createUser({ username: 'occupant', email: 'occupant@test.com' });
     await assignUserToGroup(occupant.username, fullGroup.id);
 
     const testUser = await createUser({ username: 'testjoin', email: 'testjoin@test.com' });
+    await addUserToSubject(testUser.id, subject.id);
     await loginAs(page, testUser.username);
+
+    // The subject card renders the assignment section
+    await expect(page.getByRole('heading', { name: 'Join Subject' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Join A1')).toBeVisible();
 
     // Full group must not appear in the available-groups list
     await expect(page.getByText('FullGroup')).not.toBeVisible();
@@ -27,32 +43,43 @@ test.describe('Join Group Constraints', () => {
   });
 
   test('user already in a group sees Leave button and no Join buttons', async ({ page }) => {
-    const groupA = await createGroup({ name: 'GroupA' });
-    await createGroup({ name: 'GroupB' });
+    const groupA = await createGroup({ assignmentId: assignment.id, name: 'GroupA' });
+    await createGroup({ assignmentId: assignment.id, name: 'GroupB' });
     const testUser = await createUser({ username: 'ingrpuser', email: 'ingrpuser@test.com' });
     await assignUserToGroup(testUser.username, groupA.id);
 
     await loginAs(page, testUser.username);
 
-    // When user has a group, the available-groups list is not shown at all;
-    // instead the current-group panel with Leave Group is rendered.
-    await expect(page.getByText(/you are in:/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('definition').filter({ hasText: 'GroupA' })).toBeVisible();
+    // The assignment section shows the current group instead of the join list
+    await expect(page.getByText(/your group:/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('GroupA')).toBeVisible();
     await expect(page.getByRole('button', { name: /leave group/i })).toBeVisible();
 
-    // Join buttons are not present when the user is already in a group
+    // Join buttons (and other groups of the assignment) are not offered
     await expect(page.getByRole('button', { name: 'Join', exact: true })).not.toBeVisible();
+    await expect(page.getByText('GroupB')).not.toBeVisible();
   });
 
   test('Feeling Lucky shows error when no groups are available', async ({ page }) => {
-    // No groups in DB — available list is empty, button click triggers inline error
+    // No groups under the assignment — available list is empty, button click triggers inline error
     const testUser = await createUser({ username: 'luckynone', email: 'luckynone@test.com' });
+    await addUserToSubject(testUser.id, subject.id);
     await loginAs(page, testUser.username);
 
     await expect(page.getByText('No available groups to join')).toBeVisible({ timeout: 10000 });
 
-    // The Feeling Lucky button is always rendered for a group-less user regardless of list size
+    // The Feeling Lucky button is always rendered for a group-less assignment regardless of list size
     await page.getByRole('button', { name: /feeling lucky/i }).click();
     await expect(page.getByText('No available group to join')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('disabled groups are not offered in the join list', async ({ page }) => {
+    await createGroup({ assignmentId: assignment.id, name: 'DisabledJoinGroup', enabled: false });
+    const testUser = await createUser({ username: 'nodisabled', email: 'nodisabled@test.com' });
+    await addUserToSubject(testUser.id, subject.id);
+    await loginAs(page, testUser.username);
+
+    await expect(page.getByText('No available groups to join')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('DisabledJoinGroup')).not.toBeVisible();
   });
 });

--- a/tests/e2e/settings.spec.js
+++ b/tests/e2e/settings.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { test, expect } = require('@playwright/test');
-const { cleanDatabase, createUser } = require('../helpers/db');
+const { cleanDatabase, createUser, createHierarchy, addUserToSubject } = require('../helpers/db');
 const { loginAsAdmin, loginAs, logout, enableGroupJoinLock } = require('../helpers/auth');
 
 test.describe('Settings — Group Join Lock', () => {
@@ -42,7 +42,10 @@ test.describe('Settings — Group Join Lock', () => {
 
   test('when group join lock is enabled, user dashboard shows locked message', async ({ page }) => {
     await enableGroupJoinLock(page);
-    await createUser({ username: 'locktest', email: 'locktest@test.com' });
+    // The locked message renders per assignment inside the user's subject cards
+    const { subject } = await createHierarchy({ subjectName: 'Lock Subject', assignmentName: 'Lock A1' });
+    const user = await createUser({ username: 'locktest', email: 'locktest@test.com' });
+    await addUserToSubject(user.id, subject.id);
     // PublicRoute redirects authenticated users from /login, so logout first
     await logout(page);
     await loginAs(page, 'locktest', 'TestPass123!');

--- a/tests/e2e/subject-landing.spec.js
+++ b/tests/e2e/subject-landing.spec.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs } = require('../helpers/auth');
+const { cleanDatabase, createUser, createHierarchy, addUserToSubject } = require('../helpers/db');
+
+/**
+ * Subject-first landing for students: multi-subject users pick a subject on
+ * the dashboard (persisted in sessionStorage), single-subject users land
+ * straight on their subject card.
+ */
+test.describe('Subject-first landing', () => {
+  let alpha;
+  let beta;
+
+  test.beforeEach(async () => {
+    await cleanDatabase();
+    alpha = await createHierarchy({ subjectName: 'Landing Alpha', assignmentName: 'Landing A1' });
+    beta = await createHierarchy({ subjectName: 'Landing Beta', assignmentName: 'Landing B1' });
+  });
+
+  test.describe('multi-subject student', () => {
+    test.beforeEach(async ({ page }) => {
+      const student = await createUser({ username: 'multisub', email: 'multisub@test.com', role: 'user' });
+      await addUserToSubject(student.id, alpha.subject.id);
+      await addUserToSubject(student.id, beta.subject.id);
+      await loginAs(page, 'multisub');
+    });
+
+    test('sees the picker with both subjects', async ({ page }) => {
+      await expect(page.getByText('Select your subject')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByRole('button', { name: /Landing Alpha/ })).toBeVisible();
+      await expect(page.getByRole('button', { name: /Landing Beta/ })).toBeVisible();
+      // No subject card is shown until one is picked
+      await expect(page.getByRole('heading', { name: 'Landing Alpha' })).not.toBeVisible();
+      await expect(page.getByRole('heading', { name: 'Landing Beta' })).not.toBeVisible();
+    });
+
+    test('picking a subject shows a single card with a Switch subject button', async ({ page }) => {
+      await page.getByRole('button', { name: /Landing Alpha/ }).click();
+
+      await expect(page.getByRole('heading', { name: 'Landing Alpha' })).toBeVisible();
+      await expect(page.getByText('Landing A1')).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Switch subject' })).toBeVisible();
+      // Only the selected subject's card renders
+      await expect(page.getByRole('heading', { name: 'Landing Beta' })).not.toBeVisible();
+      await expect(page.getByText('Select your subject')).not.toBeVisible();
+    });
+
+    test('selection is remembered across a reload', async ({ page }) => {
+      await page.getByRole('button', { name: /Landing Beta/ }).click();
+      await expect(page.getByRole('heading', { name: 'Landing Beta' })).toBeVisible();
+
+      await page.reload();
+
+      await expect(page.getByRole('heading', { name: 'Landing Beta' })).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText('Select your subject')).not.toBeVisible();
+      // The selection is persisted in sessionStorage
+      const stored = await page.evaluate(() => window.sessionStorage.getItem('gap.currentSubject'));
+      expect(stored).toBe(beta.subject.id);
+    });
+
+    test('Switch subject returns to the picker', async ({ page }) => {
+      await page.getByRole('button', { name: /Landing Alpha/ }).click();
+      await expect(page.getByRole('heading', { name: 'Landing Alpha' })).toBeVisible();
+
+      await page.getByRole('button', { name: 'Switch subject' }).click();
+
+      await expect(page.getByText('Select your subject')).toBeVisible();
+      await expect(page.getByRole('button', { name: /Landing Alpha/ })).toBeVisible();
+      await expect(page.getByRole('button', { name: /Landing Beta/ })).toBeVisible();
+
+      // Picking the other subject works from here
+      await page.getByRole('button', { name: /Landing Beta/ }).click();
+      await expect(page.getByRole('heading', { name: 'Landing Beta' })).toBeVisible();
+    });
+  });
+
+  test('single-subject student lands straight on the subject card without a picker', async ({ page }) => {
+    const student = await createUser({ username: 'singlesub', email: 'singlesub@test.com', role: 'user' });
+    await addUserToSubject(student.id, alpha.subject.id);
+    await loginAs(page, 'singlesub');
+
+    await expect(page.getByRole('heading', { name: 'Landing Alpha' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Select your subject')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Switch subject' })).not.toBeVisible();
+  });
+
+  test('student with no subject enrolment sees the not-enrolled empty state', async ({ page }) => {
+    await createUser({ username: 'zerosub', email: 'zerosub@test.com', role: 'user' });
+    await loginAs(page, 'zerosub');
+
+    await expect(page.getByText('You are not enrolled in any subject yet. Contact your administrator.')).toBeVisible();
+    await expect(page.getByText('Select your subject')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/subject-suspension.spec.js
+++ b/tests/e2e/subject-suspension.spec.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs, logout } = require('../helpers/auth');
+const {
+  cleanDatabase,
+  createUser,
+  createHierarchy,
+  addUserToSubject,
+  assignManager,
+  assignUserToGroup,
+  query,
+} = require('../helpers/db');
+
+const SUSPEND_WARNING =
+  'Suspending removes their group memberships in this subject. Re-enabling will NOT restore groups.';
+
+/**
+ * Per-subject suspension: an assignment manager suspends a student from a
+ * managed subject, which deletes the student's group memberships in that
+ * subject only; re-enabling restores subject access but not groups.
+ */
+test.describe('Subject member suspension', () => {
+  let s1; // { subject, assignment, groups } — managed by the AM
+  let s2; // second enrolment, untouched by suspension
+  let student;
+
+  test.beforeEach(async () => {
+    await cleanDatabase();
+    s1 = await createHierarchy({
+      subjectName: 'Susp S1',
+      assignmentName: 'Susp A1',
+      groups: [{ name: 'S1 Group' }],
+    });
+    s2 = await createHierarchy({
+      subjectName: 'Susp S2',
+      assignmentName: 'Susp A2',
+      groups: [{ name: 'S2 Group' }],
+    });
+
+    student = await createUser({ username: 'suspstudent', email: 'suspstudent@test.com', role: 'user' });
+    // Enrols the student in both subjects and places them in a group in each
+    await assignUserToGroup('suspstudent', s1.groups[0].id);
+    await assignUserToGroup('suspstudent', s2.groups[0].id);
+
+    const am = await createUser({ username: 'suspam', email: 'suspam@test.com', role: 'assignment_manager' });
+    await assignManager(am.id, s1.assignment.id);
+  });
+
+  test('AM suspends and re-enables a student; groups are removed in that subject only', async ({ page }) => {
+    test.setTimeout(120000);
+
+    // ── 1. AM opens the managed subject and sees the Members section ──────
+    await loginAs(page, 'suspam');
+    await page.goto(`/subjects/${s1.subject.id}`);
+    await expect(page.getByRole('heading', { name: 'Members' })).toBeVisible({ timeout: 10000 });
+
+    const row = page.locator('table tbody tr').filter({ hasText: 'suspstudent' });
+    await expect(row).toBeVisible();
+
+    // ── 2. Suspend — confirm modal warns about group membership removal ───
+    await row.locator('button[aria-label="Suspend Member"]').click();
+    await expect(page.getByRole('heading', { name: 'Suspend suspstudent?' })).toBeVisible();
+    await expect(page.getByText(SUSPEND_WARNING)).toBeVisible();
+    await page.getByRole('button', { name: 'Suspend', exact: true }).click();
+
+    await expect(page.getByText('Member suspended')).toBeVisible({ timeout: 5000 });
+    await expect(row.getByText('Suspended', { exact: true })).toBeVisible();
+
+    // ── 3. DB: S1 group membership deleted, S2 membership intact ──────────
+    const s1Groups = await query('SELECT * FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      student.id,
+      s1.assignment.id,
+    ]);
+    expect(s1Groups).toHaveLength(0);
+
+    const s2Groups = await query('SELECT * FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [
+      student.id,
+      s2.assignment.id,
+    ]);
+    expect(s2Groups).toHaveLength(1);
+
+    const s1Membership = await query('SELECT enabled FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
+      student.id,
+      s1.subject.id,
+    ]);
+    expect(s1Membership[0].enabled).toBe(false);
+    const s2Membership = await query('SELECT enabled FROM user_subjects WHERE user_id = $1 AND subject_id = $2', [
+      student.id,
+      s2.subject.id,
+    ]);
+    expect(s2Membership[0].enabled).toBe(true);
+
+    // ── 4. Student sees only S2 — single remaining subject auto-selected ──
+    await logout(page);
+    await loginAs(page, 'suspstudent');
+    await expect(page.getByRole('heading', { name: 'Susp S2' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Select your subject')).not.toBeVisible();
+    await expect(page.getByText('Susp S1')).not.toBeVisible();
+    // Their S2 group membership is untouched
+    await expect(page.getByText(/your group:/i)).toBeVisible();
+    await expect(page.getByText('S2 Group')).toBeVisible();
+
+    // ── 5. AM re-enables the student ───────────────────────────────────────
+    await logout(page);
+    await loginAs(page, 'suspam');
+    await page.goto(`/subjects/${s1.subject.id}`);
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.locator('button[aria-label="Enable Member"]').click();
+    await expect(page.getByText('Member enabled')).toBeVisible({ timeout: 5000 });
+    await expect(row.getByText('Suspended', { exact: true })).not.toBeVisible();
+
+    // ── 6. Student sees S1 again, but is no longer grouped there ──────────
+    await logout(page);
+    // Clear the persisted subject selection so the picker state is deterministic
+    await page.evaluate(() => window.sessionStorage.clear());
+    await loginAs(page, 'suspstudent');
+
+    // Two subjects again → picker offers both
+    await expect(page.getByText('Select your subject')).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: /Susp S1/ }).click();
+
+    await expect(page.getByRole('heading', { name: 'Susp S1' })).toBeVisible();
+    // Re-enabling does not restore groups — S1 Group is joinable again
+    await expect(page.getByText(/your group:/i)).not.toBeVisible();
+    await expect(page.getByText('S1 Group')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Join', exact: true })).toBeVisible();
+  });
+
+  test('AM who does not manage the subject sees no Members section', async ({ page }) => {
+    // Enrolled as a member of S1 but managing nothing in it — the page loads
+    // (member read access) without any member-management UI.
+    const otherAm = await createUser({ username: 'otheram', email: 'otheram@test.com', role: 'assignment_manager' });
+    await addUserToSubject(otherAm.id, s1.subject.id);
+
+    await loginAs(page, 'otheram');
+    await page.goto(`/subjects/${s1.subject.id}`);
+
+    await expect(page.getByRole('heading', { name: 'Susp S1' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Assignments in this subject')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Members' })).not.toBeVisible();
+    await expect(page.locator('button[aria-label="Suspend Member"]')).toHaveCount(0);
+  });
+
+  test('regular user is route-guarded away from the subject detail page', async ({ page }) => {
+    await loginAs(page, 'suspstudent');
+    await page.goto(`/subjects/${s1.subject.id}`);
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});

--- a/tests/e2e/subjects.spec.js
+++ b/tests/e2e/subjects.spec.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAs, loginAsAdmin } = require('../helpers/auth');
+const {
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createHierarchy,
+  assignManager,
+  addUserToSubject,
+} = require('../helpers/db');
+
+test.describe('Subjects', () => {
+  test.beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  test.describe('Admin', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginAsAdmin(page);
+    });
+
+    test('sees the empty state when no subjects exist', async ({ page }) => {
+      await page.goto('/subjects');
+      await expect(page.getByText('No subjects found')).toBeVisible();
+    });
+
+    test('can create a subject and it appears with zero counts', async ({ page }) => {
+      await page.goto('/subjects');
+      await page.getByRole('button', { name: '+ Create Subject' }).click();
+      await expect(page.getByRole('heading', { name: 'Create New Subject' })).toBeVisible();
+
+      await page.getByPlaceholder('Enter subject name').fill('COMP10001');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('Subject created successfully')).toBeVisible({ timeout: 5000 });
+      const row = page.locator('table tbody tr').filter({ hasText: 'COMP10001' });
+      await expect(row).toBeVisible();
+      // Assignment and member counts start at zero
+      await expect(row.locator('td').nth(1)).toHaveText('0');
+      await expect(row.locator('td').nth(2)).toHaveText('0');
+    });
+
+    test('shows the counts of assignments and members', async ({ page }) => {
+      const { subject } = await createHierarchy({ subjectName: 'Counted Subject', assignmentName: 'CA1' });
+      const member = await createUser({ username: 'countmember', email: 'countmember@test.com' });
+      await addUserToSubject(member.id, subject.id);
+
+      await page.goto('/subjects');
+      const row = page.locator('table tbody tr').filter({ hasText: 'Counted Subject' });
+      await expect(row.locator('td').nth(1)).toHaveText('1');
+      await expect(row.locator('td').nth(2)).toHaveText('1');
+    });
+
+    test('shows an error when creating a subject with a duplicate name', async ({ page }) => {
+      await createSubject({ name: 'DupSubject' });
+      await page.goto('/subjects');
+      await page.getByRole('button', { name: '+ Create Subject' }).click();
+
+      await page.getByPlaceholder('Enter subject name').fill('DupSubject');
+      await page.getByRole('button', { name: /^create$/i }).click();
+
+      await expect(page.getByText('A subject with this name already exists')).toBeVisible();
+    });
+
+    test('clicking a subject row opens the subject detail page', async ({ page }) => {
+      const subject = await createSubject({ name: 'Clickable Subject' });
+      await page.goto('/subjects');
+      await page.locator('table tbody tr').filter({ hasText: 'Clickable Subject' }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/subjects/${subject.id}`));
+      await expect(page.getByRole('heading', { name: 'Clickable Subject' })).toBeVisible();
+      // Breadcrumb links back to the subjects list
+      await expect(page.getByRole('navigation', { name: 'Breadcrumb' })).toContainText('Subjects');
+    });
+
+    test('can filter subjects with the search box', async ({ page }) => {
+      await createSubject({ name: 'Alpha Subject' });
+      await createSubject({ name: 'Beta Subject' });
+      await page.goto('/subjects');
+
+      await page.getByLabel('Search subjects').fill('Alpha');
+      await expect(page.getByText('Alpha Subject')).toBeVisible();
+      await expect(page.getByText('Beta Subject')).not.toBeVisible();
+    });
+  });
+
+  test.describe('Role scoping', () => {
+    test('regular user is redirected away from /subjects', async ({ page }) => {
+      const user = await createUser({ username: 'subjuser', email: 'subjuser@test.com', role: 'user' });
+      const { subject } = await createHierarchy({ subjectName: 'Scoped Subject', assignmentName: 'SA1' });
+      await addUserToSubject(user.id, subject.id);
+      await loginAs(page, 'subjuser');
+      await page.goto('/subjects');
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('assignment manager sees only subjects containing assignments they manage', async ({ page }) => {
+      const am = await createUser({ username: 'scopedam', email: 'scopedam@test.com', role: 'assignment_manager' });
+      const managed = await createHierarchy({ subjectName: 'Managed Subject', assignmentName: 'MA1' });
+      await createHierarchy({ subjectName: 'Unmanaged Subject', assignmentName: 'UA1' });
+      await assignManager(am.id, managed.assignment.id);
+
+      await loginAs(page, 'scopedam');
+      await page.goto('/subjects');
+
+      await expect(page.getByText('Managed Subject')).toBeVisible();
+      await expect(page.getByText('Unmanaged Subject')).not.toBeVisible();
+      // AMs cannot create or delete subjects
+      await expect(page.getByRole('button', { name: '+ Create Subject' })).not.toBeVisible();
+      await expect(page.locator('button[aria-label="Delete Subject"]')).toHaveCount(0);
+    });
+
+    test('assignment manager with no managed assignments sees the empty state', async ({ page }) => {
+      await createUser({ username: 'idleam', email: 'idleam@test.com', role: 'assignment_manager' });
+      await createHierarchy({ subjectName: 'Invisible Subject', assignmentName: 'IA1' });
+
+      await loginAs(page, 'idleam');
+      await page.goto('/subjects');
+
+      await expect(page.getByText('No subjects found')).toBeVisible();
+      await expect(page.getByText('Invisible Subject')).not.toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/typed-deletion.spec.js
+++ b/tests/e2e/typed-deletion.spec.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { loginAsAdmin } = require('../helpers/auth');
+const { cleanDatabase, createUser, createHierarchy, assignUserToGroup, query } = require('../helpers/db');
+
+/**
+ * Two-step typed confirmation for destructive deletes:
+ * step 1 requires the exact entity name, step 2 requires the word "delete".
+ */
+test.describe('Typed deletion confirmation', () => {
+  let subject;
+  let assignment;
+  let group;
+
+  test.beforeEach(async ({ page }) => {
+    await cleanDatabase();
+    const created = await createHierarchy({
+      subjectName: 'Doomed Subject',
+      assignmentName: 'Doomed Assignment',
+      groups: [{ name: 'Doomed Group' }],
+    });
+    subject = created.subject;
+    assignment = created.assignment;
+    group = created.groups[0];
+    await createUser({ username: 'survivor', email: 'survivor@test.com' });
+    await assignUserToGroup('survivor', group.id);
+    await loginAsAdmin(page);
+  });
+
+  const nameInput = (page) => page.getByLabel('Confirmation name');
+  const wordInput = (page) => page.getByLabel('Confirmation word');
+  const continueBtn = (page) => page.getByRole('button', { name: 'Continue' });
+  const deleteBtn = (page) => page.getByRole('button', { name: 'Delete', exact: true });
+
+  test.describe('Subject deletion', () => {
+    const openDeleteModal = async (page) => {
+      await page.goto('/subjects');
+      await page.locator('button[aria-label="Delete Subject"]').click();
+      await expect(page.getByRole('heading', { name: 'Delete subject' })).toBeVisible();
+    };
+
+    test('Continue stays disabled until the exact subject name is typed', async ({ page }) => {
+      await openDeleteModal(page);
+
+      // Disabled initially
+      await expect(continueBtn(page)).toBeDisabled();
+
+      // Wrong name keeps it disabled
+      await nameInput(page).fill('Wrong Subject');
+      await expect(continueBtn(page)).toBeDisabled();
+
+      // Case matters — a near miss keeps it disabled
+      await nameInput(page).fill('doomed subject');
+      await expect(continueBtn(page)).toBeDisabled();
+
+      // Exact name enables Continue
+      await nameInput(page).fill('Doomed Subject');
+      await expect(continueBtn(page)).toBeEnabled();
+    });
+
+    test('step 2 requires the word "delete" and cascades on confirm; users survive', async ({ page }) => {
+      await openDeleteModal(page);
+      await nameInput(page).fill('Doomed Subject');
+      await continueBtn(page).click();
+
+      // Step 2 — Delete disabled until the exact word 'delete'
+      await expect(wordInput(page)).toBeVisible();
+      await expect(deleteBtn(page)).toBeDisabled();
+      await wordInput(page).fill('remove');
+      await expect(deleteBtn(page)).toBeDisabled();
+      await wordInput(page).fill('delete');
+      await expect(deleteBtn(page)).toBeEnabled();
+      await deleteBtn(page).click();
+
+      await expect(page.getByText('Subject deleted successfully')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Doomed Subject')).not.toBeVisible();
+
+      // DB cascade: subject, assignments, groups and memberships are gone…
+      expect(await query('SELECT 1 FROM subjects WHERE id = $1', [subject.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM assignments WHERE id = $1', [assignment.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM groups WHERE id = $1', [group.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM user_groups WHERE group_id = $1', [group.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM user_subjects WHERE subject_id = $1', [subject.id])).toHaveLength(0);
+      // …but the user account survives
+      expect(await query("SELECT 1 FROM users WHERE username = 'survivor'")).toHaveLength(1);
+    });
+
+    test('Cancel at step 2 keeps the subject and resets the modal state', async ({ page }) => {
+      await openDeleteModal(page);
+      await nameInput(page).fill('Doomed Subject');
+      await continueBtn(page).click();
+      await expect(wordInput(page)).toBeVisible();
+      await wordInput(page).fill('delete');
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // Subject intact in UI and DB
+      await expect(page.getByText('Doomed Subject')).toBeVisible();
+      expect(await query('SELECT 1 FROM subjects WHERE id = $1', [subject.id])).toHaveLength(1);
+
+      // Reopening starts back at step 1 with an empty input
+      await page.locator('button[aria-label="Delete Subject"]').click();
+      await expect(nameInput(page)).toBeVisible();
+      await expect(nameInput(page)).toHaveValue('');
+      await expect(continueBtn(page)).toBeDisabled();
+    });
+  });
+
+  test.describe('Assignment deletion', () => {
+    const openDeleteModal = async (page) => {
+      await page.goto(`/subjects/${subject.id}`);
+      await page.locator('button[aria-label="Delete Assignment"]').click();
+      await expect(page.getByRole('heading', { name: 'Delete assignment' })).toBeVisible();
+    };
+
+    test('Continue stays disabled until the exact assignment name is typed', async ({ page }) => {
+      await openDeleteModal(page);
+
+      await expect(continueBtn(page)).toBeDisabled();
+      await nameInput(page).fill('Wrong Assignment');
+      await expect(continueBtn(page)).toBeDisabled();
+      await nameInput(page).fill('Doomed Assignment');
+      await expect(continueBtn(page)).toBeEnabled();
+    });
+
+    test('step 2 requires the word "delete" and cascades on confirm; subject and users survive', async ({ page }) => {
+      await openDeleteModal(page);
+      await nameInput(page).fill('Doomed Assignment');
+      await continueBtn(page).click();
+
+      await expect(wordInput(page)).toBeVisible();
+      await expect(deleteBtn(page)).toBeDisabled();
+      await wordInput(page).fill('remove');
+      await expect(deleteBtn(page)).toBeDisabled();
+      await wordInput(page).fill('delete');
+      await expect(deleteBtn(page)).toBeEnabled();
+      await deleteBtn(page).click();
+
+      await expect(page.getByText('Assignment deleted successfully')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText('Doomed Assignment')).not.toBeVisible();
+
+      // DB cascade: assignment, its groups and memberships are gone…
+      expect(await query('SELECT 1 FROM assignments WHERE id = $1', [assignment.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM groups WHERE id = $1', [group.id])).toHaveLength(0);
+      expect(await query('SELECT 1 FROM user_groups WHERE assignment_id = $1', [assignment.id])).toHaveLength(0);
+      // …but the subject, its enrolments and the user survive
+      expect(await query('SELECT 1 FROM subjects WHERE id = $1', [subject.id])).toHaveLength(1);
+      expect(await query('SELECT 1 FROM user_subjects WHERE subject_id = $1', [subject.id])).toHaveLength(1);
+      expect(await query("SELECT 1 FROM users WHERE username = 'survivor'")).toHaveLength(1);
+    });
+
+    test('Cancel at step 2 keeps the assignment and resets the modal state', async ({ page }) => {
+      await openDeleteModal(page);
+      await nameInput(page).fill('Doomed Assignment');
+      await continueBtn(page).click();
+      await expect(wordInput(page)).toBeVisible();
+      await wordInput(page).fill('delete');
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await expect(page.getByText('Doomed Assignment')).toBeVisible();
+      expect(await query('SELECT 1 FROM assignments WHERE id = $1', [assignment.id])).toHaveLength(1);
+
+      // Reopening starts back at step 1 with an empty input
+      await page.locator('button[aria-label="Delete Assignment"]').click();
+      await expect(nameInput(page)).toBeVisible();
+      await expect(nameInput(page)).toHaveValue('');
+      await expect(continueBtn(page)).toBeDisabled();
+    });
+  });
+});

--- a/tests/e2e/user.spec.js
+++ b/tests/e2e/user.spec.js
@@ -1,40 +1,57 @@
 'use strict';
 
 const { test, expect } = require('@playwright/test');
-const { loginAs } = require('../helpers/auth');
-const { cleanDatabase, createUser, createGroup, assignUserToGroup } = require('../helpers/db');
+const { loginAs, logout } = require('../helpers/auth');
+const {
+  cleanDatabase,
+  createUser,
+  createGroup,
+  createHierarchy,
+  addUserToSubject,
+  assignUserToGroup,
+} = require('../helpers/db');
 
 test.describe('Regular User', () => {
+  let subject;
+  let assignment;
+
   test.beforeEach(async ({ page }) => {
     await cleanDatabase();
-    await createUser({ username: 'normaluser', email: 'normal@test.com', role: 'user' });
+    ({ subject, assignment } = await createHierarchy({ subjectName: 'User Subject', assignmentName: 'User A1' }));
+    const user = await createUser({ username: 'normaluser', email: 'normal@test.com', role: 'user' });
+    await addUserToSubject(user.id, subject.id);
     await loginAs(page, 'normaluser');
   });
 
-  test('sees dashboard with profile information', async ({ page }) => {
+  test('sees dashboard with profile information including subjects', async ({ page }) => {
     await expect(page.getByText('Dashboard')).toBeVisible();
     // Username shown exactly once in the profile <dd> element
     await expect(page.getByText('normaluser', { exact: true })).toBeVisible();
     // Role displayed as "User" in the profile <dd> element
     await expect(page.getByText('User', { exact: true })).toBeVisible();
+    // Enrolled subject listed in the profile
+    await expect(page.getByText('User Subject').first()).toBeVisible();
   });
 
-  test('sees "My Group" section when not in a group', async ({ page }) => {
-    await expect(page.getByText('My Group')).toBeVisible();
-    // When no groups exist, the list shows this specific message
+  test('sees the subject card with the assignment and no-groups message', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'User Subject' })).toBeVisible();
+    await expect(page.getByText('User A1')).toBeVisible();
+    // When no groups exist under the assignment, the list shows this specific message
     await expect(page.getByText('No available groups to join')).toBeVisible();
   });
 
   test('can join a group from the dashboard', async ({ page }) => {
-    await createGroup({ name: 'JoinableGroup' });
+    await createGroup({ assignmentId: assignment.id, name: 'JoinableGroup' });
     await page.reload();
 
-    // Group appears in the available list
+    // Group appears in the available list of the assignment
     await expect(page.getByText('JoinableGroup')).toBeVisible();
-    await page.getByRole('button', { name: /^join$/i }).first().click();
+    await page.getByRole('button', { name: 'Join', exact: true }).first().click();
 
-    // After joining, the group name is shown in the profile (definition list)
-    await expect(page.getByRole('definition').filter({ hasText: 'JoinableGroup' })).toBeVisible();
+    // After joining, the assignment section shows the current-group panel
+    await expect(page.getByText(/successfully joined/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/your group:/i)).toBeVisible();
+    await expect(page.getByText('JoinableGroup')).toBeVisible();
   });
 
   test('cannot access /users — redirected to dashboard', async ({ page }) => {
@@ -48,7 +65,7 @@ test.describe('Regular User', () => {
   });
 
   test('can leave a group after joining', async ({ page }) => {
-    const group = await createGroup({ name: 'LeaveGroup' });
+    const group = await createGroup({ assignmentId: assignment.id, name: 'LeaveGroup' });
     await assignUserToGroup('normaluser', group.id);
 
     await page.reload();
@@ -56,7 +73,16 @@ test.describe('Regular User', () => {
     await expect(page.getByRole('button', { name: /leave group/i })).toBeVisible();
 
     await page.getByRole('button', { name: /leave group/i }).click();
-    // After leaving, the profile group field shows "Not assigned"
-    await expect(page.getByText('Not assigned', { exact: true })).toBeVisible();
+    await expect(page.getByText(/successfully left group/i)).toBeVisible({ timeout: 10000 });
+    // After leaving, the join list is offered again for the assignment
+    await expect(page.getByRole('button', { name: 'Join', exact: true })).toBeVisible();
+  });
+
+  test('user with no subject enrolment sees the not-enrolled message', async ({ page }) => {
+    await createUser({ username: 'nosubjectuser', email: 'nosubject@test.com', role: 'user' });
+    // PublicRoute redirects authenticated users away from /login, so log out first
+    await logout(page);
+    await loginAs(page, 'nosubjectuser');
+    await expect(page.getByText('You are not enrolled in any subject yet. Contact your administrator.')).toBeVisible();
   });
 });

--- a/tests/helpers/db.js
+++ b/tests/helpers/db.js
@@ -3,6 +3,9 @@
 /**
  * Direct database helpers for e2e test setup and cleanup.
  * Reads connection config from the state file written by global-setup.js.
+ *
+ * Hierarchy: subjects → assignments → groups. Users enrol in subjects
+ * (user_subjects); group membership is per assignment (user_groups).
  */
 
 const { Pool } = require('pg');
@@ -29,15 +32,30 @@ function getPool() {
 }
 
 /**
- * Truncates test data, preserving the seeded admin user.
+ * Run an arbitrary parameterised query against the e2e database.
+ * Used by specs that need to assert DB state directly (e.g. cascade deletes).
+ */
+async function query(text, params = []) {
+  const db = getPool();
+  const result = await db.query(text, params);
+  return result.rows;
+}
+
+/**
+ * Truncates test data in FK-safe order, preserving the seeded admin user.
  * Call in beforeEach to guarantee a clean slate between tests.
  */
 async function cleanDatabase() {
   const db = getPool();
   await db.query(`
     DELETE FROM password_reset_tokens WHERE TRUE;
+    DELETE FROM user_groups WHERE TRUE;
+    DELETE FROM assignment_managers WHERE TRUE;
+    DELETE FROM user_subjects WHERE TRUE;
     DELETE FROM users WHERE LOWER(username) != 'admin';
     DELETE FROM groups WHERE TRUE;
+    DELETE FROM assignments WHERE TRUE;
+    DELETE FROM subjects WHERE TRUE;
     DELETE FROM config WHERE TRUE;
   `);
 }
@@ -71,23 +89,119 @@ async function createUser({
 }
 
 /**
- * Create a group directly in the DB.
+ * Create a subject directly in the DB.
  */
-async function createGroup({ name, enabled = true, maxMembers = null }) {
+async function createSubject({ name }) {
+  const db = getPool();
+  const { rows } = await db.query('INSERT INTO subjects (name) VALUES ($1) RETURNING *', [name]);
+  return rows[0];
+}
+
+/**
+ * Create an assignment under a subject directly in the DB.
+ */
+async function createAssignment({ subjectId, name }) {
+  const db = getPool();
+  const { rows } = await db.query('INSERT INTO assignments (subject_id, name) VALUES ($1, $2) RETURNING *', [
+    subjectId,
+    name,
+  ]);
+  return rows[0];
+}
+
+/**
+ * Enrol a user in a subject (idempotent).
+ */
+async function addUserToSubject(userId, subjectId) {
   const db = getPool();
   const { rows } = await db.query(
-    'INSERT INTO groups (name, enabled, max_members) VALUES ($1, $2, $3) RETURNING *',
-    [name, enabled, maxMembers]
+    `INSERT INTO user_subjects (user_id, subject_id) VALUES ($1, $2)
+     ON CONFLICT (user_id, subject_id) DO NOTHING
+     RETURNING *`,
+    [userId, subjectId]
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Make a user a manager of an assignment (idempotent).
+ */
+async function assignManager(userId, assignmentId) {
+  const db = getPool();
+  const { rows } = await db.query(
+    `INSERT INTO assignment_managers (user_id, assignment_id) VALUES ($1, $2)
+     ON CONFLICT (user_id, assignment_id) DO NOTHING
+     RETURNING *`,
+    [userId, assignmentId]
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Create a group under an assignment directly in the DB.
+ */
+async function createGroup({ assignmentId, name, enabled = true, maxMembers = null }) {
+  const db = getPool();
+  const { rows } = await db.query(
+    'INSERT INTO groups (assignment_id, name, enabled, max_members) VALUES ($1, $2, $3, $4) RETURNING *',
+    [assignmentId, name, enabled, maxMembers]
   );
   return rows[0];
 }
 
 /**
- * Assign a user to a group directly in the DB.
+ * Composite fixture: one subject with one assignment and optional groups.
+ * `groups` is an array of group specs ({ name, enabled?, maxMembers? }).
+ * Returns { subject, assignment, groups }.
+ */
+async function createHierarchy({ subjectName = 'Subject 1', assignmentName = 'Assignment 1', groups = [] } = {}) {
+  const subject = await createSubject({ name: subjectName });
+  const assignment = await createAssignment({ subjectId: subject.id, name: assignmentName });
+  const createdGroups = [];
+  for (const groupSpec of groups) {
+    createdGroups.push(await createGroup({ assignmentId: assignment.id, ...groupSpec }));
+  }
+  return { subject, assignment, groups: createdGroups };
+}
+
+/**
+ * Assign a user (by username, case-insensitive) to a group directly in the DB.
+ * Replaces any existing membership for the group's assignment and enrols the
+ * user in the parent subject so the fixture satisfies the universal
+ * subject-membership rule enforced by the backend.
  */
 async function assignUserToGroup(username, groupId) {
   const db = getPool();
-  await db.query('UPDATE users SET group_id = $1 WHERE LOWER(username) = LOWER($2)', [groupId, username]);
+
+  const userResult = await db.query('SELECT id FROM users WHERE LOWER(username) = LOWER($1)', [username]);
+  const user = userResult.rows[0];
+  if (!user) {
+    throw new Error(`assignUserToGroup: no user found for username ${username}`);
+  }
+
+  const groupResult = await db.query(
+    `SELECT g.id, g.assignment_id, a.subject_id
+     FROM groups g
+     JOIN assignments a ON a.id = g.assignment_id
+     WHERE g.id = $1`,
+    [groupId]
+  );
+  const group = groupResult.rows[0];
+  if (!group) {
+    throw new Error(`assignUserToGroup: no group found for id ${groupId}`);
+  }
+
+  await db.query(
+    `INSERT INTO user_subjects (user_id, subject_id) VALUES ($1, $2)
+     ON CONFLICT (user_id, subject_id) DO NOTHING`,
+    [user.id, group.subject_id]
+  );
+  await db.query('DELETE FROM user_groups WHERE user_id = $1 AND assignment_id = $2', [user.id, group.assignment_id]);
+  await db.query('INSERT INTO user_groups (user_id, assignment_id, group_id) VALUES ($1, $2, $3)', [
+    user.id,
+    group.assignment_id,
+    group.id,
+  ]);
 }
 
 /**
@@ -121,4 +235,17 @@ async function closePool() {
   }
 }
 
-module.exports = { cleanDatabase, createUser, createGroup, assignUserToGroup, createPasswordResetToken, closePool };
+module.exports = {
+  query,
+  cleanDatabase,
+  createUser,
+  createSubject,
+  createAssignment,
+  addUserToSubject,
+  assignManager,
+  createGroup,
+  createHierarchy,
+  assignUserToGroup,
+  createPasswordResetToken,
+  closePool,
+};

--- a/tests/helpers/db.js
+++ b/tests/helpers/db.js
@@ -111,16 +111,36 @@ async function createAssignment({ subjectId, name }) {
 
 /**
  * Enrol a user in a subject (idempotent).
+ * `enabled` seeds the per-subject suspension flag (false = suspended).
  */
-async function addUserToSubject(userId, subjectId) {
+async function addUserToSubject(userId, subjectId, enabled = true) {
   const db = getPool();
   const { rows } = await db.query(
-    `INSERT INTO user_subjects (user_id, subject_id) VALUES ($1, $2)
+    `INSERT INTO user_subjects (user_id, subject_id, enabled) VALUES ($1, $2, $3)
      ON CONFLICT (user_id, subject_id) DO NOTHING
      RETURNING *`,
-    [userId, subjectId]
+    [userId, subjectId, enabled]
   );
   return rows[0] || null;
+}
+
+/**
+ * Set the enabled flag on an existing subject membership directly in the DB.
+ * Unlike the API, this does NOT touch group memberships — use it to seed
+ * suspended states without side effects.
+ */
+async function setMembershipEnabled(userId, subjectId, enabled) {
+  const db = getPool();
+  const { rows } = await db.query(
+    `UPDATE user_subjects SET enabled = $3
+     WHERE user_id = $1 AND subject_id = $2
+     RETURNING *`,
+    [userId, subjectId, enabled]
+  );
+  if (!rows[0]) {
+    throw new Error(`setMembershipEnabled: no membership for user ${userId} in subject ${subjectId}`);
+  }
+  return rows[0];
 }
 
 /**
@@ -242,6 +262,7 @@ module.exports = {
   createSubject,
   createAssignment,
   addUserToSubject,
+  setMembershipEnabled,
   assignManager,
   createGroup,
   createHierarchy,


### PR DESCRIPTION
## Summary

Introduces a three-level **Subject → Assignment → Group** hierarchy replacing the flat group structure, modelling real coursework: users enrol in subjects, subjects contain assignments, assignments contain groups, and a user is in **at most one group per assignment**.

### Data model
- New tables: `subjects`, `assignments` (unique name per subject), `user_subjects` (m2m enrolment), `user_groups` (PK `(user_id, assignment_id)` enforces one-group-per-assignment; composite FK pins each membership's group to its assignment), `assignment_managers` (AM scoping m2m)
- `groups` gains `assignment_id` (name now unique per assignment); `users.group_id` removed
- **⚠️ Destructive migration (013):** legacy databases converge by dropping the flat `groups` table and `users.group_id` — user accounts are preserved, group data is not. Recommended deployment: `pnpm --filter gap-backend migrate:reset`. Verified on fresh, idempotent-rerun, and legacy upgrade paths.

### Backend
- New models `Subject`/`Assignment`/`UserGroup`; `Group`/`User` reworked; new `/api/subjects` and `/api/assignments` route trees; groups/users/auth reworked
- New RBAC decorator `assertManagesAssignment`: admins pass; AMs only for assignments they manage
- **Universal placement rule:** a user can only be placed in a group of a subject they belong to — enforced inside the row-locked `UserGroup.assignUserToGroup` transaction for **all** callers, admins included
- Self-join rejects a second group in the same assignment (409, must leave first); admin/AM reassignment replaces atomically; global group-join lock unchanged
- JWT claims reduced to `{id, username, email, role}`; `/auth/me` + login return `subjects`, `memberships`, `managedAssignments`
- AMs see only users of subjects containing their managed assignments on `GET /users`; user rows enriched with `subjects[]`/`memberships[]` via two batch queries

### Security fixes (found by test agents during the work)
- Restored the DB re-check on join/leave so a **disabled account with a still-valid JWT** gets 403 (was dropped in the rework)
- `POST /users` now enforces the same AM subject-scope rule as `POST /users/import` (AM could previously enrol users into any subject)
- `ImportGroupMappings` conflict detection updated off the removed `users.group_id` (conflicts could never trigger)

### Frontend
- Drill-down navigation: `/subjects` → `/subjects/:subjectId` → `/subjects/:subjectId/assignments/:assignmentId` (repurposed Groups view); `/groups` redirects to `/subjects`
- **Two-step typed deletion** for subjects/assignments: type the exact name, then type `delete` (cascade warning shown; user accounts never deleted)
- `CascadingAssignmentSelect` (Subject → Assignment → Group, children reset on parent change) used by create-user (subject required for role user, AM creation scoped by assignment) and `AssignGroupModal`
- Users page: subject-based sections, Subjects column with membership tooltips, admin Manage Subjects modal, per-row Assign Group modal
- Dashboard: per-subject cards with per-assignment join/leave + per-assignment "I'm Feeling Lucky"
- Imports: user import requires a target subject; mappings import/export are per-assignment

### Docs
README (with upgrade warning), `docs/api-reference.md`, `docs/user-guide.md`, and `CLAUDE.md` updated.

## Test plan
- [x] Backend unit: **921 passed** (20 suites), coverage thresholds met
- [x] Backend integration (Testcontainers): **260 passed** (6 suites), incl. cascade-delete assertions, RBAC negative matrix (401/403/400/404/409 per endpoint), cross-subject placement 403s for admin/AM/self-join, disabled-account 403s
- [x] Frontend unit: **731 passed** (31 suites), coverage thresholds met
- [x] E2E (Playwright): **146 passed**, incl. new `subjects`, `assignments`, `typed-deletion`, `hierarchy-workflow` (full create→enrol→assign→join/leave flow), `am-scoping` specs
- [x] Lint (`--max-warnings 0`) and Prettier clean repo-wide
- [x] Migration verified: fresh reset, idempotent re-run, legacy DB convergence (accounts preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)